### PR TITLE
refactor: rename internal `responses` variable to `operation`

### DIFF
--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -10,11 +10,11 @@ export interface OpenAPI3Schemas {
 
 export interface OpenAPI3Paths {
   [path: string]: {
-    [method: string]: OpenAPI3Response;
+    [method: string]: OpenAPI3Operation;
   };
 }
 
-export interface OpenAPI3Response {
+export interface OpenAPI3Operation {
   description?: string;
   parameters?: OpenAPI3Parameter[];
   responses: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ export function comment(text: string): string {
 }
 
 /** shim for Object.fromEntries() for Node < 13 */
-export function fromEntries(entries: [string, any][]): object {
+export function fromEntries(entries: [string, any][]): Record<string, unknown> {
   return entries.reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
 }
 

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -157,18 +157,18 @@ export default function generateTypesV3(
     let output = "";
     Object.entries(paths).forEach(([path, methods]) => {
       output += `"${path}": {\n`;
-      Object.entries(methods).forEach(([method, responses]) => {
-        if (responses.description) output += comment(responses.description);
+      Object.entries(methods).forEach(([method, operation]) => {
+        if (operation.description) output += comment(operation.description);
         output += `"${method}": {\n`;
 
         // handle parameters
-        if (responses.parameters) {
+        if (operation.parameters) {
           output += `parameters: {\n`;
           const allParameters: Record<
             string,
             Record<string, OpenAPI3Parameter>
           > = {};
-          responses.parameters.forEach((p) => {
+          operation.parameters.forEach((p) => {
             if (!allParameters[p.in]) allParameters[p.in] = {};
             // TODO: handle $ref parameters
             if (p.name) {
@@ -192,7 +192,7 @@ export default function generateTypesV3(
 
         // handle responses
         output += `responses: {\n`;
-        Object.entries(responses.responses).forEach(
+        Object.entries(operation.responses).forEach(
           ([statusCode, response]) => {
             if (response.description) output += comment(response.description);
             if (!response.content || !Object.keys(response.content).length) {


### PR DESCRIPTION
cause that is what it is: https://swagger.io/docs/specification/paths-and-operations/