### PR TITLE
Set index type to all possible values

### DIFF
--- a/src/v3.ts
+++ b/src/v3.ts
@@ -92,18 +92,21 @@ export default function generateTypesV3(
 
         let properties = createKeys(node.properties || {}, node.required);
 
-        // if additional properties, add to end of properties
-        if (node.additionalProperties) {
-          properties += `[key: string]: ${
-            node.additionalProperties === true
-              ? "any"
-              : transform(node.additionalProperties) || "any"
-          };\n`;
-        }
+        // if additional properties, add an intersection with a generic map type
+        const additionalProperties = node.additionalProperties
+          ? [
+              `{ [key: string]: ${
+                node.additionalProperties === true
+                  ? "any"
+                  : transform(node.additionalProperties) || "any"
+              };}\n`,
+            ]
+          : [];
 
         return tsIntersectionOf([
           ...(node.allOf ? (node.allOf as any[]).map(transform) : []), // append allOf first
-          ...(properties ? [`{ ${properties} }`] : []), // then properties + additionalProperties
+          ...(properties ? [`{ ${properties} }`] : []), // then properties
+          ...additionalProperties, // then additional properties
         ]);
       }
       case "array": {

--- a/tests/v3/expected/github.ts
+++ b/tests/v3/expected/github.ts
@@ -86,13 +86,13 @@ export interface paths {
          * response
          */
         "201": {
-          "application/json": components["schemas"]["integration"] & {
-            client_id: string;
-            client_secret: string;
-            webhook_secret: string;
-            pem: string;
-            [key: string]: any;
-          };
+          "application/json": components["schemas"]["integration"] &
+            ({
+              client_id: string;
+              client_secret: string;
+              webhook_secret: string;
+              pem: string;
+            } & { [key: string]: any });
         };
         "404": unknown;
         "422": unknown;
@@ -20980,8 +20980,7 @@ export interface components {
         metadata?: string;
         contents?: string;
         deployments?: string;
-        [key: string]: string;
-      };
+      } & { [key: string]: string };
       /**
        * The list of events for the GitHub app
        */
@@ -20994,8 +20993,7 @@ export interface components {
       client_secret?: string;
       webhook_secret?: string;
       pem?: string;
-      [key: string]: any;
-    };
+    } & { [key: string]: any };
     /**
      * Basic Error
      */

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -291,8 +291,8 @@ describe("OpenAPI3 features", () => {
       format(`
       export interface components {
         schemas: {
-          additional_properties: { number?: number; [key: string]: any };
-          additional_properties_string: { string?: string; [key: string]: string };
+          additional_properties: { number?: number; } & { [key: string]: any };
+          additional_properties_string: { string?: string } & { [key: string]: string };
         }
       }`)
     );


### PR DESCRIPTION
Here is a minimal test case to reproduce the problem: [TypeScript Playground](
https://www.typescriptlang.org/play?#code/C4TwDgpgBAKhDOwoF4oG8BQVtQJb3gFcEB+ALikQCdcA7AcwG4scBjACwlYGt5zLgNBsxxQAthGABDACZTp-anSYtsrAPa1gELXwpLhqqDIhgANupATdiwcpE4A2twgh9dhgF13QlQF8gA)

This feels like a potential TypeScript bug to me, what do you think? But basically this comes down to:

- If a schema is of type `object`
- and it has `additionalProperties`
- then instead of adding `[key: string]: string;` to the object, we should create an intersection with a separate `{ [key: string]: string; }` object

Result: [TypeScript Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAKhDOwoF4oG8BQVtQJb3gFcEB+ALikQCdcA7AcwG4scBjACwlYGt5zLgNBsxxQAthGABDACZTp-anSYtsrAPa1gELXwpLhqqDIhgANupATdiwcuYBfKADJ0UANrcIIfXYYBdXyEmKAcgA)