### PR TITLE
Fix external $refs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,6 +96,10 @@ export function swaggerVersion(definition: OpenAPI2 | OpenAPI3): 2 | 3 {
 
 /** Convert $ref to TS ref */
 export function transformRef(ref: string, root = ""): string {
+  // TODO: load external file
+  const isExternalRef = !ref.startsWith("#"); // if # isn’t first character, we can assume this is a remote schema
+  if (isExternalRef) return "any";
+
   const parts = ref.replace(/^#\//, root).split("/");
   return `${parts[0]}["${parts.slice(1).join('"]["')}"]`;
 }

--- a/tests/v2/index.test.ts
+++ b/tests/v2/index.test.ts
@@ -316,6 +316,24 @@ describe("transformation", () => {
         }`)
       );
     });
+
+    // TODO: allow import later
+    it("external $ref", () => {
+      const schema: OpenAPI2 = {
+        swagger: "2.0",
+        definitions: {
+          externalRef: {
+            $ref: "./external.yaml",
+          },
+        },
+      };
+      expect(swaggerToTS(schema)).toBe(
+        format(`
+        export interface definitions {
+          externalRef: any;
+        }`)
+      );
+    });
   });
 
   describe("propertyMapper", () => {

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -266,6 +266,28 @@ describe("types", () => {
       }`)
     );
   });
+
+  // TODO: allow import later
+  it("external $ref", () => {
+    const schema: OpenAPI3 = {
+      openapi: "3.0",
+      components: {
+        schemas: {
+          externalRef: {
+            $ref: "./external.yaml",
+          },
+        },
+      },
+    };
+    expect(swaggerToTS(schema)).toBe(
+      format(`
+      export interface components {
+        schemas: {
+          externalRef: any;
+        }
+      }`)
+    );
+  });
 });
 
 describe("OpenAPI3 features", () => {


### PR DESCRIPTION
Partial workaround for #321. Converts `$ref: 'foo.yaml#bar'` to `any` for now.