### PR TITLE
fix: check if path item is method operation

### DIFF
--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -12,20 +12,20 @@ export interface OpenAPI3Paths {
   [path: string]: Partial<OpenAPI3PathItem>;
 }
 
-export type OpenAPI3PathItem= {
-  $ref: string
-  summary: string
-  description: string
-  get: OpenAPI3Operation
-  put: OpenAPI3Operation
-  post: OpenAPI3Operation
-  delete: OpenAPI3Operation
-  options: OpenAPI3Operation
-  head: OpenAPI3Operation
-  patch: OpenAPI3Operation
-  trace: OpenAPI3Operation
-  parameters: Parameter[]
-}
+export type OpenAPI3PathItem = {
+  $ref: string;
+  summary: string;
+  description: string;
+  get: OpenAPI3Operation;
+  put: OpenAPI3Operation;
+  post: OpenAPI3Operation;
+  delete: OpenAPI3Operation;
+  options: OpenAPI3Operation;
+  head: OpenAPI3Operation;
+  patch: OpenAPI3Operation;
+  trace: OpenAPI3Operation;
+  parameters: Parameter[];
+};
 
 export interface OpenAPI3Operation {
   operationId?: string;

--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -24,7 +24,6 @@ export type OpenAPI3PathItem= {
   head: OpenAPI3Operation
   patch: OpenAPI3Operation
   trace: OpenAPI3Operation
-  servers: any
   parameters: Parameter[]
 }
 

--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -9,13 +9,28 @@ export interface OpenAPI3Schemas {
 }
 
 export interface OpenAPI3Paths {
-  [path: string]: {
-    [method: string]: OpenAPI3Operation | Parameter[];
-  };
+  [path: string]: Partial<OpenAPI3PathItem>;
+}
+
+export type OpenAPI3PathItem= {
+  $ref: string
+  summary: string
+  description: string
+  get: OpenAPI3Operation
+  put: OpenAPI3Operation
+  post: OpenAPI3Operation
+  delete: OpenAPI3Operation
+  options: OpenAPI3Operation
+  head: OpenAPI3Operation
+  patch: OpenAPI3Operation
+  trace: OpenAPI3Operation
+  servers: any
+  parameters: Parameter[]
 }
 
 export interface OpenAPI3Operation {
   operationId?: string;
+  summary?: string;
   description?: string;
   parameters?: Parameter[];
   requestBody?: OpenAPI3RequestBody;

--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -9,22 +9,22 @@ export interface OpenAPI3Schemas {
 }
 
 export interface OpenAPI3Paths {
-  [path: string]: Partial<OpenAPI3PathItem>;
+  [path: string]: OpenAPI3PathItemObject;
 }
 
-export type OpenAPI3PathItem = {
-  $ref: string;
-  summary: string;
-  description: string;
-  get: OpenAPI3Operation;
-  put: OpenAPI3Operation;
-  post: OpenAPI3Operation;
-  delete: OpenAPI3Operation;
-  options: OpenAPI3Operation;
-  head: OpenAPI3Operation;
-  patch: OpenAPI3Operation;
-  trace: OpenAPI3Operation;
-  parameters: Parameter[];
+export type OpenAPI3PathItemObject = {
+  $ref?: string;
+  summary?: string;
+  description?: string;
+  get?: OpenAPI3Operation;
+  put?: OpenAPI3Operation;
+  post?: OpenAPI3Operation;
+  delete?: OpenAPI3Operation;
+  options?: OpenAPI3Operation;
+  head?: OpenAPI3Operation;
+  patch?: OpenAPI3Operation;
+  trace?: OpenAPI3Operation;
+  parameters?: Parameter[];
 };
 
 export interface OpenAPI3Operation {

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -261,29 +261,40 @@ export default function generateTypesV3(
 
   function transformPaths(paths: OpenAPI3Paths): string {
     let output = "";
-    Object.entries(paths).forEach(([path, methods]) => {
+    Object.entries(paths).forEach(([path, pathItem]) => {
       output += `"${path}": {\n`;
 
-      Object.entries(methods).forEach(([method, operation]) => {
+      Object.entries(pathItem).forEach(([field, operation]) => {
         // skip the parameters "method" for shared parameters - we'll handle it later
-        if (method !== "parameters") {
+        const isMethod = [
+          "get",
+          "put",
+          "post",
+          "delete",
+          "options",
+          "head",
+          "patch",
+          "trace",
+        ].includes(field);
+
+        if (isMethod) {
           operation = operation as OpenAPI3Operation;
 
           if (operation.operationId) {
-            output += `"${method}": operations["${operation.operationId}"];\n`;
+            output += `"${field}": operations["${operation.operationId}"];\n`;
             operations[operation.operationId] = operation;
           } else {
             if (operation.description) output += comment(operation.description);
-            output += `"${method}": ${transformOperation(
+            output += `"${field}": ${transformOperation(
               operation as OpenAPI3Operation
             )}`;
           }
         }
       });
 
-      if (methods.parameters) {
+      if (pathItem.parameters) {
         // Handle shared parameters
-        output += transformParameters(methods.parameters as Parameter[]);
+        output += transformParameters(pathItem.parameters as Parameter[]);
       }
       output += `}\n`;
     });

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -998,6 +998,7 @@ describe("OpenAPI3 features", () => {
           description: "root description",
           get: {
             summary: "get summary",
+            description: "get description",
             responses: {
               "200": {
                 content: {
@@ -1052,6 +1053,9 @@ describe("OpenAPI3 features", () => {
       format(`
       export interface paths {
         '/': {
+         /**
+          * get description
+          */
          get: {
             responses: {
               '200': {

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -994,9 +994,10 @@ describe("OpenAPI3 features", () => {
       openapi: "3.0.1",
       paths: {
         "/": {
-          summary: "Root",
-          description: "Lorem ipsum sic dolor amet",
+          summary: "root summary",
+          description: "root description",
           get: {
+            summary: "get summary",
             responses: {
               "200": {
                 content: {
@@ -1009,49 +1010,6 @@ describe("OpenAPI3 features", () => {
                       },
                       required: ["title", "body"],
                     },
-                  },
-                },
-              },
-            },
-          },
-        },
-        "/search": {
-          post: {
-            parameters: [
-              {
-                name: "q",
-                in: "query",
-                required: true,
-                schema: { type: "string" },
-              },
-              {
-                name: "p",
-                in: "query",
-                schema: { type: "integer" },
-              },
-            ],
-            responses: {
-              "200": {
-                content: {
-                  "application/json": {
-                    schema: {
-                      type: "object",
-                      properties: {
-                        results: {
-                          type: "array",
-                          items: { $ref: "#/components/schemas/SearchResult" },
-                        },
-                        total: { type: "integer" },
-                      },
-                      required: ["total"],
-                    },
-                  },
-                },
-              },
-              "404": {
-                content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
                   },
                 },
               },
@@ -1094,7 +1052,7 @@ describe("OpenAPI3 features", () => {
       format(`
       export interface paths {
         '/': {
-          get: {
+         get: {
             responses: {
               '200': {
                 'application/json': { title: string; body: string }
@@ -1102,27 +1060,6 @@ describe("OpenAPI3 features", () => {
             }
           }
         };
-        '/search': {
-          post: {
-            parameters: {
-              query: {
-                q: string;
-                p?: number;
-              }
-            };
-            responses: {
-              '200': {
-                'application/json': {
-                  results?: components['schemas']['SearchResult'][];
-                  total: number;
-                }
-              }
-              '404': {
-                'application/json': components['schemas']['ErrorResponse']
-              }
-            }
-          }
-        }
       }
 
       export interface operations {}

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -999,54 +999,10 @@ describe("OpenAPI3 features", () => {
           get: {
             summary: "get summary",
             description: "get description",
-            responses: {
-              "200": {
-                content: {
-                  "application/json": {
-                    schema: {
-                      type: "object",
-                      properties: {
-                        title: { type: "string" },
-                        body: { type: "string" },
-                      },
-                      required: ["title", "body"],
-                    },
-                  },
-                },
-              },
-            },
+            responses: { },
           },
         },
-      },
-      components: {
-        schemas: {
-          ErrorResponse: {
-            type: "object",
-            properties: {
-              error: { type: "string" },
-              message: { type: "string" },
-            },
-            required: ["error", "message"],
-          },
-          SearchResponse: {
-            type: "object",
-            properties: {
-              title: { type: "string" },
-              date: { type: "string" },
-            },
-            required: ["title", "date"],
-          },
-        },
-        responses: {
-          NotFound: {
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/ErrorResponse" },
-              },
-            },
-          },
-        },
-      },
+      }
     };
 
     expect(swaggerToTS(schema)).toBe(
@@ -1057,26 +1013,14 @@ describe("OpenAPI3 features", () => {
           * get description
           */
          get: {
-            responses: {
-              '200': {
-                'application/json': { title: string; body: string }
-              }
-            }
+            responses: { }
           }
         };
       }
 
       export interface operations {}
         
-      export interface components {
-        schemas: {
-          ErrorResponse: { error: string; message: string };
-          SearchResponse: { title: string; date: string }
-        }
-        responses: {
-          NotFound: { [key: string]: any }
-        }
-      }`)
+      export interface components {}`)
     );
   });
 });


### PR DESCRIPTION
Fixes issue #360

* Adds a check `isMethod` in `transformPaths` in [./src/v3.ts](./src/v3.ts)
* Adds a new `OpenAPI3PathItemObject` type in [./src/types/OpenAPI3.ts](./src/types/OpenAPI3.ts)
* This added type `OpenAPI3PathItemObject` is per "PathItemObject" spec <https://swagger.io/specification/#path-item-object>
* Replaces the key-value pair in `OpenAPI3Paths`
* `OpenAPI3PathItemObject` *is* missing the `servers` field from the specs
* Variable name bikeshedding - changed `method` to `field` since it *might not* be a method

*Edit*: updated type to `OpenAPI3PathItemObject` from `OpenAPI3PathItem`


