### PR TITLE
Fixing 'content' being expected to be present.

### DIFF
--- a/src/types/OpenAPI3.ts
+++ b/src/types/OpenAPI3.ts
@@ -43,7 +43,7 @@ export interface OpenAPI3ResponseObject {
 
 export interface OpenAPI3RequestBody {
   description?: string;
-  content: {
+  content?: {
     [contentType: string]: { schema: OpenAPI3SchemaObject | { $ref: string } };
   };
 }

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -225,7 +225,7 @@ export default function generateTypesV3(
     // handle requestBody
     if (operation.requestBody) {
       output += `requestBody: {\n`;
-      Object.entries(operation.requestBody.content).forEach(
+      Object.entries(operation.requestBody.content || {}).forEach(
         ([contentType, { schema }]) => {
           output += `"${contentType}": ${transform(schema)};\n`;
         }


### PR DESCRIPTION
I spotted that this caused failures for our OpenAPI files being generated.

In general, I think that `OpenAPI3.ts` should be replaced with something like https://www.npmjs.com/package/atlassian-openapi so that the types are more reliable and thus the logic is more correct. 