### PR TITLE
fix: default path/query types to string

### DIFF
--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -1014,4 +1014,52 @@ describe("OpenAPI3 features", () => {
       export interface components {}`)
     );
   });
+  it("missing schema in parameteres (#377)", () => {
+    const schema: OpenAPI3 = {
+      openapi: "3.0.1",
+      paths: {
+        "/test/{test_id}": {
+          get: {
+            summary: "some summary",
+            description: "some description",
+            parameters: [
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              {
+                name: "id",
+                in: "path",
+                required: true,
+              },
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              {
+                name: "page",
+                in: "query",
+                required: false,
+              },
+            ],
+            responses: {},
+          },
+        },
+      },
+    };
+
+    expect(swaggerToTS(schema)).toBe(
+      format(`
+      export interface paths {
+        '/test/{test_id}': {
+         /**
+          * some description
+          */
+         get: {
+            responses: { }
+          }
+        };
+      }
+
+      export interface operations {}
+
+      export interface components {}`)
+    );
+  });
 });


### PR DESCRIPTION
This PR adds failing test for #377 
I faced this issue with a real-world openapi schema (discourse.org)

I'm not sure anymore if this even should be fixed but having a better error message for bad schemas would be neat.

fixes #377