### PR TITLE
handle case where additionalRef is a ref (fixes #345)

### DIFF
--- a/src/types/OpenAPI2.ts
+++ b/src/types/OpenAPI2.ts
@@ -32,6 +32,12 @@ export type OpenAPI2Type =
 
 export type OpenAPI2Reference = { $ref: string };
 
+export function isOpenAPI2Reference(
+  additionalProperties: OpenAPI2SchemaObject | OpenAPI2Reference | boolean
+): additionalProperties is OpenAPI2Reference {
+  return (additionalProperties as OpenAPI2Reference).$ref !== undefined;
+}
+
 export interface OpenAPI2SchemaObject {
   additionalProperties?: OpenAPI2SchemaObject | OpenAPI2Reference | boolean;
   allOf?: OpenAPI2SchemaObject[];

--- a/src/types/OpenAPI2.ts
+++ b/src/types/OpenAPI2.ts
@@ -32,12 +32,6 @@ export type OpenAPI2Type =
 
 export type OpenAPI2Reference = { $ref: string };
 
-export function isOpenAPI2Reference(
-  additionalProperties: OpenAPI2SchemaObject | OpenAPI2Reference | boolean
-): additionalProperties is OpenAPI2Reference {
-  return (additionalProperties as OpenAPI2Reference).$ref !== undefined;
-}
-
 export interface OpenAPI2SchemaObject {
   additionalProperties?: OpenAPI2SchemaObject | OpenAPI2Reference | boolean;
   allOf?: OpenAPI2SchemaObject[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { OpenAPI2, OpenAPI3 } from "./types";
+import { OpenAPI2, OpenAPI2Reference, OpenAPI2SchemaObject, OpenAPI3 } from "./types";
 
 export function comment(text: string): string {
   return `/**
@@ -120,4 +120,10 @@ export function tsUnionOf(types: string[]): string {
 export function unrefComponent(components: any, ref: string): any {
   const [type, object] = ref.match(/(?<=\[")([^"]+)/g) as string[];
   return components[type][object];
+}
+
+export function isOpenAPI2Reference(
+  additionalProperties: OpenAPI2SchemaObject | OpenAPI2Reference | boolean
+): additionalProperties is OpenAPI2Reference {
+  return (additionalProperties as OpenAPI2Reference).$ref !== undefined;
 }

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -1,13 +1,6 @@
 import propertyMapper from "./property-mapper";
-import {
-  OpenAPI2,
-  OpenAPI2Reference,
-  OpenAPI2SchemaObject,
-  OpenAPI2Schemas,
-  SwaggerToTSOptions,
-  isOpenAPI2Reference,
-} from "./types";
-import { comment, nodeType, transformRef, tsArrayOf, tsIntersectionOf, tsUnionOf } from "./utils";
+import { OpenAPI2, OpenAPI2Reference, OpenAPI2SchemaObject, OpenAPI2Schemas, SwaggerToTSOptions } from "./types";
+import { comment, nodeType, transformRef, tsArrayOf, tsIntersectionOf, tsUnionOf, isOpenAPI2Reference } from "./utils";
 
 export const PRIMITIVES: { [key: string]: "boolean" | "string" | "number" } = {
   // boolean types

--- a/tests/v2/index.test.ts
+++ b/tests/v2/index.test.ts
@@ -255,6 +255,38 @@ describe("transformation", () => {
       );
     });
 
+    it("additionalProperties 2 (issue #345)", () => {
+      const schema: OpenAPI2 = {
+        swagger: "2.0",
+        definitions: {
+          Messages: {
+            type: "object",
+            additionalProperties: {
+              $ref: "#/definitions/Message",
+            },
+          },
+          Message: {
+            type: "object",
+            properties: {
+              code: {
+                type: "integer",
+              },
+              text: {
+                type: "string",
+              },
+            },
+          },
+        },
+      };
+      expect(swaggerToTS(schema)).toBe(
+        format(`
+        export interface definitions {
+          Messages: { [key: string]: definitions["Message"] }
+          Message: { code?: number; text?: string }
+        }`)
+      );
+    });
+
     it("allOf", () => {
       const schema: OpenAPI2 = {
         swagger: "2.0",


### PR DESCRIPTION
Fixes #345 

As stated in the comment, the functionality in getAdditionalPropertiesType could perhaps be added in nodeType, but then I had to pass in the rawDefinition there, and risk messing up things.

This seems to work, added a new tests based on the inut in #345, both this and all old tests pass