### PR TITLE
Fix single-line comments

### DIFF
--- a/examples/stripe-openapi2.ts
+++ b/examples/stripe-openapi2.ts
@@ -245,7 +245,8 @@ export interface definitions {
     user_agent?: string;
   };
   address: {
-    /** City, district, suburb, town, or village. */ city?: string;
+    /** City, district, suburb, town, or village. */
+    city?: string;
     /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
     country?: string;
     /** Address line 1 (e.g., street, PO Box, or company name). */
@@ -284,7 +285,8 @@ export interface definitions {
     username: string;
   };
   api_errors: {
-    /** For card errors, the ID of the failed charge. */ charge?: string;
+    /** For card errors, the ID of the failed charge. */
+    charge?: string;
     /** For some errors that could be handled programmatically, a short string indicating the [error code](https://stripe.com/docs/error-codes) reported. */
     code?: string;
     /** For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://stripe.com/docs/declines#issuer-declines) if they provide one. */
@@ -321,14 +323,16 @@ export interface definitions {
     object: "apple_pay_domain";
   };
   application: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** The name of the application. */
     name?: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "application";
   };
   application_fee: {
-    /** ID of the Stripe account this fee was taken from. */ account: string;
+    /** ID of the Stripe account this fee was taken from. */
+    account: string;
     /** Amount earned, in %s. */
     amount: number;
     /** Amount in %s refunded (can be less than the amount attribute on the fee if a partial refund was issued) */
@@ -355,7 +359,8 @@ export interface definitions {
     refunded: boolean;
     /** A list of refunds that have been applied to the fee. */
     refunds: {
-      /** Details about each object. */ data: definitions["fee_refund"][];
+      /** Details about each object. */
+      data: definitions["fee_refund"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -390,13 +395,15 @@ export interface definitions {
     pending: definitions["balance_amount"][];
   };
   balance_amount: {
-    /** Balance amount. */ amount: number;
+    /** Balance amount. */
+    amount: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
     currency: string;
     source_types?: definitions["balance_amount_by_source_type"];
   };
   balance_amount_by_source_type: {
-    /** Amount for bank account. */ bank_account?: number;
+    /** Amount for bank account. */
+    bank_account?: number;
     /** Amount for card. */
     card?: number;
     /** Amount for FPX. */
@@ -409,7 +416,8 @@ export interface definitions {
    * Related guide: [Balance Transaction Types](https://stripe.com/docs/reports/balance-transaction-types).
    */
   balance_transaction: {
-    /** Gross amount of the transaction, in %s. */ amount: number;
+    /** Gross amount of the transaction, in %s. */
+    amount: number;
     /** The date the transaction's net funds will become available in the Stripe balance. */
     available_on: number;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -775,7 +783,8 @@ export interface definitions {
     refunded: boolean;
     /** A list of refunds that have been applied to the charge. */
     refunds: {
-      /** Details about each object. */ data: definitions["refund"][];
+      /** Details about each object. */
+      data: definitions["refund"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -934,14 +943,16 @@ export interface definitions {
     success_url: string;
   };
   checkout_session_custom_display_item_description: {
-    /** The description of the line item. */ description?: string;
+    /** The description of the line item. */
+    description?: string;
     /** The images of the line item. */
     images?: string[];
     /** The name of the line item. */
     name: string;
   };
   checkout_session_display_item: {
-    /** Amount for the display item. */ amount?: number;
+    /** Amount for the display item. */
+    amount?: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
     currency?: string;
     custom?: definitions["checkout_session_custom_display_item_description"];
@@ -953,7 +964,8 @@ export interface definitions {
     type?: string;
   };
   connect_collection_transfer: {
-    /** Amount transferred, in %s. */ amount: number;
+    /** Amount transferred, in %s. */
+    amount: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
     currency: string;
     /** ID of the account that funds are being collected for. */
@@ -1134,7 +1146,8 @@ export interface definitions {
     unit_amount_decimal?: string;
   };
   credit_note_tax_amount: {
-    /** The amount, in %s, of the tax. */ amount: number;
+    /** The amount, in %s, of the tax. */
+    amount: number;
     /** Whether this tax amount is inclusive or exclusive. */
     inclusive: boolean;
     /** The tax rate that was applied to get this tax amount. */
@@ -1191,7 +1204,8 @@ export interface definitions {
     shipping?: definitions["shipping"];
     /** The customer's payment sources, if any. */
     sources: {
-      /** Details about each object. */ data: definitions["alipay_account"][];
+      /** Details about each object. */
+      data: definitions["alipay_account"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -1201,7 +1215,8 @@ export interface definitions {
     };
     /** The customer's current subscriptions, if any. */
     subscriptions?: {
-      /** Details about each object. */ data: definitions["subscription"][];
+      /** Details about each object. */
+      data: definitions["subscription"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -1213,7 +1228,8 @@ export interface definitions {
     tax_exempt?: "exempt" | "none" | "reverse";
     /** The customer's tax IDs. */
     tax_ids?: {
-      /** Details about each object. */ data: definitions["tax_id"][];
+      /** Details about each object. */
+      data: definitions["tax_id"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -1276,21 +1292,24 @@ export interface definitions {
       | "unspent_receiver_credit";
   };
   deleted_account: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "account";
   };
   deleted_alipay_account: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "alipay_account";
   };
   deleted_apple_pay_domain: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -1307,7 +1326,8 @@ export interface definitions {
     object: "bank_account";
   };
   deleted_bitcoin_receiver: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -1324,21 +1344,24 @@ export interface definitions {
     object: "card";
   };
   deleted_coupon: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "coupon";
   };
   deleted_customer: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "customer";
   };
   deleted_discount: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "discount";
   };
@@ -1353,105 +1376,120 @@ export interface definitions {
     object: "bank_account";
   };
   deleted_invoice: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "invoice";
   };
   deleted_invoiceitem: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "invoiceitem";
   };
   deleted_payment_source: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "alipay_account";
   };
   deleted_person: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "person";
   };
   deleted_plan: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "plan";
   };
   deleted_product: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "product";
   };
   "deleted_radar.value_list": {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "radar.value_list";
   };
   "deleted_radar.value_list_item": {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "radar.value_list_item";
   };
   deleted_recipient: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "recipient";
   };
   deleted_sku: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "sku";
   };
   deleted_subscription_item: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "subscription_item";
   };
   deleted_tax_id: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "tax_id";
   };
   "deleted_terminal.location": {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "terminal.location";
   };
   "deleted_terminal.reader": {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "terminal.reader";
   };
   deleted_webhook_endpoint: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -1615,7 +1653,9 @@ export interface definitions {
     secret?: string;
   };
   /** An error response from the Stripe API */
-  error: { error: definitions["api_errors"] };
+  error: {
+    error: definitions["api_errors"];
+  };
   /**
    * Events are our way of letting you know when something interesting happens in
    * your account. When an interesting event occurs, we create a new `Event`
@@ -1648,7 +1688,8 @@ export interface definitions {
    * guaranteed only for 30 days.
    */
   event: {
-    /** The connected account that originated the event. */ account?: string;
+    /** The connected account that originated the event. */
+    account?: string;
     /** The Stripe API version used to render `data`. *Note: This property is populated only for events on or after October 31, 2014*. */
     api_version?: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -1710,7 +1751,8 @@ export interface definitions {
     object: "bank_account";
   };
   fee: {
-    /** Amount of the fee, in cents. */ amount: number;
+    /** Amount of the fee, in cents. */
+    amount: number;
     /** ID of the Connect application that earned the fee. */
     application?: string;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -1728,7 +1770,8 @@ export interface definitions {
    * Related guide: [Refunding Application Fees](https://stripe.com/docs/connect/destination-charges#refunding-app-fee).
    */
   fee_refund: {
-    /** Amount, in %s. */ amount: number;
+    /** Amount, in %s. */
+    amount: number;
     /** Balance transaction that describes the impact on your account balance. */
     balance_transaction?: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -1762,7 +1805,8 @@ export interface definitions {
     id: string;
     /** A list of [file links](https://stripe.com/docs/api#file_links) that point at this file. */
     links?: {
-      /** Details about each object. */ data: definitions["file_link"][];
+      /** Details about each object. */
+      data: definitions["file_link"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -1944,7 +1988,8 @@ export interface definitions {
     invoice_pdf?: string;
     /** The individual line items that make up the invoice. `lines` is sorted as follows: invoice items in reverse chronological order, followed by the subscription, if any. */
     lines: {
-      /** Details about each object. */ data: definitions["line_item"][];
+      /** Details about each object. */
+      data: definitions["line_item"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -2008,12 +2053,14 @@ export interface definitions {
     usage_gte: number;
   };
   invoice_line_item_period: {
-    /** End of the line item's billing period */ end: number;
+    /** End of the line item's billing period */
+    end: number;
     /** Start of the line item's billing period */
     start: number;
   };
   invoice_setting_custom_field: {
-    /** The name of the custom field. */ name: string;
+    /** The name of the custom field. */
+    name: string;
     /** The value of the custom field. */
     value: string;
   };
@@ -2030,7 +2077,8 @@ export interface definitions {
     days_until_due?: number;
   };
   invoice_tax_amount: {
-    /** The amount, in %s, of the tax. */ amount: number;
+    /** The amount, in %s, of the tax. */
+    amount: number;
     /** Whether this tax amount is inclusive or exclusive. */
     inclusive: boolean;
     /** The tax rate that was applied to get this tax amount. */
@@ -2122,7 +2170,8 @@ export interface definitions {
     value?: string;
   };
   invoices_status_transitions: {
-    /** The time that the invoice draft was finalized. */ finalized_at?: number;
+    /** The time that the invoice draft was finalized. */
+    finalized_at?: number;
     /** The time that the invoice was marked uncollectible. */
     marked_uncollectible_at?: number;
     /** The time that the invoice was paid. */
@@ -2209,7 +2258,8 @@ export interface definitions {
   };
   /** You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders. */
   "issuing.card": {
-    /** The brand of the card. */ brand: string;
+    /** The brand of the card. */
+    brand: string;
     /** The reason why the card was canceled. */
     cancellation_reason?: "lost" | "stolen";
     cardholder: definitions["issuing.cardholder"];
@@ -2286,7 +2336,8 @@ export interface definitions {
    * Related guide: [Disputing Transactions](https://stripe.com/docs/issuing/purchases/disputes)
    */
   "issuing.dispute": {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -3046,7 +3097,8 @@ export interface definitions {
     type: "bulk" | "individual";
   };
   issuing_card_spending_limit: {
-    /** Maximum amount allowed to spend per time interval. */ amount: number;
+    /** Maximum amount allowed to spend per time interval. */
+    amount: number;
     /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges. */
     categories?: (
       | "ac_refrigeration_repair"
@@ -3347,7 +3399,9 @@ export interface definitions {
       | "weekly"
       | "yearly";
   };
-  issuing_cardholder_address: { address: definitions["address"] };
+  issuing_cardholder_address: {
+    address: definitions["address"];
+  };
   issuing_cardholder_authorization_controls: {
     /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this cardholder's cards. */
     allowed_categories?: (
@@ -3955,7 +4009,8 @@ export interface definitions {
     verification?: definitions["issuing_cardholder_verification"];
   };
   issuing_cardholder_individual_dob: {
-    /** The day of birth, between 1 and 31. */ day?: number;
+    /** The day of birth, between 1 and 31. */
+    day?: number;
     /** The month of birth, between 1 and 12. */
     month?: number;
     /** The four-digit year of birth. */
@@ -3976,7 +4031,8 @@ export interface definitions {
     )[];
   };
   issuing_cardholder_spending_limit: {
-    /** Maximum amount allowed to spend per time interval. */ amount: number;
+    /** Maximum amount allowed to spend per time interval. */
+    amount: number;
     /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges. */
     categories?: (
       | "ac_refrigeration_repair"
@@ -4337,14 +4393,16 @@ export interface definitions {
     front?: string;
   };
   legal_entity_dob: {
-    /** The day of birth, between 1 and 31. */ day?: number;
+    /** The day of birth, between 1 and 31. */
+    day?: number;
     /** The month of birth, between 1 and 12. */
     month?: number;
     /** The four-digit year of birth. */
     year?: number;
   };
   legal_entity_japan_address: {
-    /** City/Ward. */ city?: string;
+    /** City/Ward. */
+    city?: string;
     /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
     country?: string;
     /** Block/Building number. */
@@ -4380,7 +4438,8 @@ export interface definitions {
   };
   light_account_logout: { [key: string]: any };
   line_item: {
-    /** The amount, in %s. */ amount: number;
+    /** The amount, in %s. */
+    amount: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
     currency: string;
     /** An arbitrary string attached to the object. Often useful for displaying to users. */
@@ -4454,12 +4513,14 @@ export interface definitions {
     type: string;
   };
   mandate_sepa_debit: {
-    /** The unique reference of the mandate. */ reference: string;
+    /** The unique reference of the mandate. */
+    reference: string;
     /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
     url: string;
   };
   mandate_single_use: {
-    /** On a single use mandate, the amount of the payment. */ amount: number;
+    /** On a single use mandate, the amount of the payment. */
+    amount: number;
     /** On a single use mandate, the currency of the payment. */
     currency: string;
   };
@@ -4522,7 +4583,8 @@ export interface definitions {
     object: "order";
     /** A list of returns that have taken place for this order. */
     returns?: {
-      /** Details about each object. */ data: definitions["order_return"][];
+      /** Details about each object. */
+      data: definitions["order_return"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -4592,7 +4654,8 @@ export interface definitions {
     refund?: string;
   };
   package_dimensions: {
-    /** Height, in inches. */ height: number;
+    /** Height, in inches. */
+    height: number;
     /** Length, in inches. */
     length: number;
     /** Weight, in ounces. */
@@ -4808,7 +4871,8 @@ export interface definitions {
     cvc_check?: string;
   };
   payment_method_card_generated_card: {
-    /** The charge that created this object. */ charge?: string;
+    /** The charge that created this object. */
+    charge?: string;
     payment_method_details?: definitions["payment_method_details"];
   };
   payment_method_card_present: { [key: string]: any };
@@ -4877,7 +4941,8 @@ export interface definitions {
     wechat?: definitions["payment_method_details_wechat"];
   };
   payment_method_details_ach_credit_transfer: {
-    /** Account number to transfer funds to. */ account_number?: string;
+    /** Account number to transfer funds to. */
+    account_number?: string;
     /** Name of the bank associated with the routing number. */
     bank_name?: string;
     /** Routing transit number for the bank account to transfer funds to. */
@@ -4901,7 +4966,8 @@ export interface definitions {
   };
   payment_method_details_alipay: { [key: string]: any };
   payment_method_details_au_becs_debit: {
-    /** Bank-State-Branch number of the bank account. */ bsb_number?: string;
+    /** Bank-State-Branch number of the bank account. */
+    bsb_number?: string;
     /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
     fingerprint?: string;
     /** Last four digits of the bank account number. */
@@ -5149,7 +5215,8 @@ export interface definitions {
     reference?: string;
   };
   payment_method_details_p24: {
-    /** Unique reference for this Przelewy24 payment. */ reference?: string;
+    /** Unique reference for this Przelewy24 payment. */
+    reference?: string;
     /**
      * Owner's verified full name. Values are verified or provided by Przelewy24 directly
      * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
@@ -5508,7 +5575,8 @@ export interface definitions {
     )[];
   };
   payment_source: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
     metadata?: { [key: string]: any };
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -5642,7 +5710,8 @@ export interface definitions {
    * Related guides: [Set up a subscription](https://stripe.com/docs/billing/subscriptions/set-up-subscription) and more about [products and plans](https://stripe.com/docs/billing/subscriptions/products-and-plans).
    */
   plan: {
-    /** Whether the plan can be used for new purchases. */ active: boolean;
+    /** Whether the plan can be used for new purchases. */
+    active: boolean;
     /** Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`. */
     aggregate_usage?: "last_during_period" | "last_ever" | "max" | "sum";
     /** The amount in %s to be charged on the interval specified. */
@@ -5682,7 +5751,8 @@ export interface definitions {
     usage_type: "licensed" | "metered";
   };
   plan_tier: {
-    /** Price for the entire tier. */ flat_amount?: number;
+    /** Price for the entire tier. */
+    flat_amount?: number;
     /** Same as `flat_amount`, but contains a decimal value with at most 12 decimal places. */
     flat_amount_decimal?: string;
     /** Per unit price for units relevant to the tier. */
@@ -5693,7 +5763,8 @@ export interface definitions {
     up_to?: number;
   };
   platform_tax_fee: {
-    /** The Connected account that incurred this charge. */ account: string;
+    /** The Connected account that incurred this charge. */
+    account: string;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -5780,7 +5851,8 @@ export interface definitions {
    * Related guide: [Default Stripe Lists](https://stripe.com/docs/radar/lists#managing-list-items).
    */
   "radar.value_list": {
-    /** The name of the value list for use in rules. */ alias: string;
+    /** The name of the value list for use in rules. */
+    alias: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
     created: number;
     /** The name or email address of the user who created this value list. */
@@ -5838,7 +5910,8 @@ export interface definitions {
     value_list: string;
   };
   radar_review_resource_location: {
-    /** The city where the payment originated. */ city?: string;
+    /** The city where the payment originated. */
+    city?: string;
     /** Two-letter ISO code representing the country where the payment originated. */
     country?: string;
     /** The geographic latitude where the payment originated. */
@@ -5913,7 +5986,8 @@ export interface definitions {
    * Related guide: [Refunds](https://stripe.com/docs/refunds).
    */
   refund: {
-    /** Amount, in %s. */ amount: number;
+    /** Amount, in %s. */
+    amount: number;
     /** Balance transaction that describes the impact on your account balance. */
     balance_transaction?: string;
     /** ID of the charge that was refunded. */
@@ -6063,7 +6137,8 @@ export interface definitions {
     session?: definitions["radar_review_resource_session"];
   };
   rule: {
-    /** The action taken on the payment. */ action: string;
+    /** The action taken on the payment. */
+    action: string;
     /** Unique identifier for the object. */
     id: string;
     /** The predicate to evaluate the payment against. */
@@ -6221,7 +6296,8 @@ export interface definitions {
     id: string;
   };
   sigma_scheduled_query_run_error: {
-    /** Information about the run failure. */ message: string;
+    /** Information about the run failure. */
+    message: string;
   };
   /**
    * Stores representations of [stock keeping units](http://en.wikipedia.org/wiki/Stock_keeping_unit).
@@ -6234,7 +6310,8 @@ export interface definitions {
    * Related guide: [Tax, Shipping, and Inventory](https://stripe.com/docs/orders).
    */
   sku: {
-    /** Whether the SKU is available for purchase. */ active: boolean;
+    /** Whether the SKU is available for purchase. */
+    active: boolean;
     /** A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`. */
     attributes: { [key: string]: any };
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -6374,7 +6451,8 @@ export interface definitions {
     last4?: string;
   };
   source_mandate_notification_sepa_debit_data: {
-    /** SEPA creditor ID. */ creditor_identifier?: string;
+    /** SEPA creditor ID. */
+    creditor_identifier?: string;
     /** Last 4 digits of the account number associated with the debit. */
     last4?: string;
     /** Mandate reference associated with the debit. */
@@ -6392,7 +6470,8 @@ export interface definitions {
     shipping?: definitions["shipping"];
   };
   source_order_item: {
-    /** The amount (price) for this order item. */ amount?: number;
+    /** The amount (price) for this order item. */
+    amount?: number;
     /** This currency of this order item. Required when `amount` is present. */
     currency?: string;
     /** Human-readable description for this order item. */
@@ -6490,7 +6569,8 @@ export interface definitions {
       | "wechat";
   };
   source_transaction_ach_credit_transfer_data: {
-    /** Customer data associated with the transfer. */ customer_data?: string;
+    /** Customer data associated with the transfer. */
+    customer_data?: string;
     /** Bank account fingerprint associated with the transfer. */
     fingerprint?: string;
     /** Last 4 digits of the account number associated with the transfer. */
@@ -6499,7 +6579,8 @@ export interface definitions {
     routing_number?: string;
   };
   source_transaction_chf_credit_transfer_data: {
-    /** Reference associated with the transfer. */ reference?: string;
+    /** Reference associated with the transfer. */
+    reference?: string;
     /** Sender's country address. */
     sender_address_country?: string;
     /** Sender's line 1 address. */
@@ -6532,7 +6613,8 @@ export interface definitions {
     invoices?: string;
   };
   source_transaction_sepa_credit_transfer_data: {
-    /** Reference associated with the transfer. */ reference?: string;
+    /** Reference associated with the transfer. */
+    reference?: string;
     /** Sender's bank account IBAN. */
     sender_iban?: string;
     /** Sender's name. */
@@ -6615,7 +6697,10 @@ export interface definitions {
     terminal_verification_results?: string;
     transaction_status_information?: string;
   };
-  source_type_eps: { reference?: string; statement_descriptor?: string };
+  source_type_eps: {
+    reference?: string;
+    statement_descriptor?: string;
+  };
   source_type_giropay: {
     bank_code?: string;
     bank_name?: string;
@@ -6667,7 +6752,9 @@ export interface definitions {
     refund_account_holder_name?: string;
     refund_iban?: string;
   };
-  source_type_p24: { reference?: string };
+  source_type_p24: {
+    reference?: string;
+  };
   source_type_sepa_debit: {
     bank_code?: string;
     branch_code?: string;
@@ -6711,7 +6798,8 @@ export interface definitions {
     statement_descriptor?: string;
   };
   status_transitions: {
-    /** The time that the order was canceled. */ canceled?: number;
+    /** The time that the order was canceled. */
+    canceled?: number;
     /** The time that the order was fulfilled. */
     fulfiled?: number;
     /** The time that the order was paid. */
@@ -6904,7 +6992,8 @@ export interface definitions {
     tax_rates?: definitions["tax_rate"][];
   };
   subscription_schedule_current_phase: {
-    /** The end of this phase of the subscription schedule. */ end_date: number;
+    /** The end of this phase of the subscription schedule. */
+    end_date: number;
     /** The start of this phase of the subscription schedule. */
     start_date: number;
   };
@@ -6970,7 +7059,8 @@ export interface definitions {
     trial_from_plan?: boolean;
   };
   tax_deducted_at_source: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "tax_deducted_at_source";
     /** The end of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period. */
@@ -7161,7 +7251,8 @@ export interface definitions {
     version: string;
   };
   three_d_secure_usage: {
-    /** Whether 3D Secure is supported on this card. */ supported: boolean;
+    /** Whether 3D Secure is supported on this card. */
+    supported: boolean;
   };
   /**
    * Tokenization is the process Stripe uses to collect sensitive card or bank
@@ -7213,7 +7304,8 @@ export interface definitions {
    * Related guide: [Topping Up your Platform Account](https://stripe.com/docs/connect/top-ups).
    */
   topup: {
-    /** Amount transferred. */ amount: number;
+    /** Amount transferred. */
+    amount: number;
     /** ID of the balance transaction that describes the impact of this top-up on your account balance. May not be specified depending on status of top-up. */
     balance_transaction?: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -7257,7 +7349,8 @@ export interface definitions {
    * Related guide: [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers).
    */
   transfer: {
-    /** Amount in %s to be transferred. */ amount: number;
+    /** Amount in %s to be transferred. */
+    amount: number;
     /** Amount in %s reversed (can be less than the amount attribute on the transfer if a partial reversal was issued). */
     amount_reversed: number;
     /** Balance transaction that describes the impact of this transfer on your account balance. */
@@ -7326,7 +7419,8 @@ export interface definitions {
    * Related guide: [Reversing Transfers](https://stripe.com/docs/connect/charges-transfers#reversing-transfers).
    */
   transfer_reversal: {
-    /** Amount, in %s. */ amount: number;
+    /** Amount, in %s. */
+    amount: number;
     /** Balance transaction that describes the impact on your account balance. */
     balance_transaction?: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -7357,7 +7451,8 @@ export interface definitions {
     weekly_anchor?: string;
   };
   transform_usage: {
-    /** Divide usage by this number. */ divide_by: number;
+    /** Divide usage by this number. */
+    divide_by: number;
     /** After division, either round the result `up` or `down`. */
     round: "down" | "up";
   };
@@ -7368,7 +7463,8 @@ export interface definitions {
    * Related guide: [Metered Billing](https://stripe.com/docs/billing/subscriptions/metered-billing).
    */
   usage_record: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -7381,7 +7477,8 @@ export interface definitions {
     timestamp: number;
   };
   usage_record_summary: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** The invoice in which this usage period has been billed for. */
     invoice?: string;
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */

--- a/examples/stripe-openapi3.ts
+++ b/examples/stripe-openapi3.ts
@@ -840,7 +840,9 @@ export interface operations {
    */
   DeleteAccount: {
     requestBody: {
-      "application/x-www-form-urlencoded": { account?: string };
+      "application/x-www-form-urlencoded": {
+        account?: string;
+      };
     };
     responses: {
       /** Successful response. */
@@ -967,7 +969,12 @@ export interface operations {
           tax_id?: string;
           tax_id_registrar?: string;
           vat_id?: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts). */
         default_currency?: string;
@@ -1005,7 +1012,11 @@ export interface operations {
             state?: string;
             town?: string;
           };
-          dob?: Partial<{ day: number; month: number; year: number }> &
+          dob?: Partial<{
+            day: number;
+            month: number;
+            year: number;
+          }> &
             Partial<"">;
           email?: string;
           first_name?: string;
@@ -1021,8 +1032,14 @@ export interface operations {
           phone?: string;
           ssn_last_4?: string;
           verification?: {
-            additional_document?: { back?: string; front?: string };
-            document?: { back?: string; front?: string };
+            additional_document?: {
+              back?: string;
+              front?: string;
+            };
+            document?: {
+              back?: string;
+              front?: string;
+            };
           };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -1046,7 +1063,10 @@ export interface operations {
             secondary_color?: string;
           };
           card_payments?: {
-            decline_on?: { avs_failure?: boolean; cvc_failure?: boolean };
+            decline_on?: {
+              avs_failure?: boolean;
+              cvc_failure?: boolean;
+            };
             statement_descriptor_prefix?: string;
           };
           payments?: {
@@ -1073,7 +1093,11 @@ export interface operations {
           };
         };
         /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
-        tos_acceptance?: { date?: number; ip?: string; user_agent?: string };
+        tos_acceptance?: {
+          date?: number;
+          ip?: string;
+          user_agent?: string;
+        };
       };
     };
     responses: {
@@ -1604,7 +1628,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -1647,8 +1675,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -1749,7 +1783,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -1792,8 +1830,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -1886,7 +1930,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -1929,8 +1977,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -2031,7 +2085,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -2074,8 +2132,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -2256,7 +2320,12 @@ export interface operations {
           tax_id?: string;
           tax_id_registrar?: string;
           vat_id?: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** The country in which the account holder resides, or in which the business is legally established. This should be an ISO 3166-1 alpha-2 country code. For example, if you are in the United States and the business for which you're creating an account is legally represented in Canada, you would use `CA` as the country for the account being created. */
         country?: string;
@@ -2296,7 +2365,11 @@ export interface operations {
             state?: string;
             town?: string;
           };
-          dob?: Partial<{ day: number; month: number; year: number }> &
+          dob?: Partial<{
+            day: number;
+            month: number;
+            year: number;
+          }> &
             Partial<"">;
           email?: string;
           first_name?: string;
@@ -2312,8 +2385,14 @@ export interface operations {
           phone?: string;
           ssn_last_4?: string;
           verification?: {
-            additional_document?: { back?: string; front?: string };
-            document?: { back?: string; front?: string };
+            additional_document?: {
+              back?: string;
+              front?: string;
+            };
+            document?: {
+              back?: string;
+              front?: string;
+            };
           };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -2337,7 +2416,10 @@ export interface operations {
             secondary_color?: string;
           };
           card_payments?: {
-            decline_on?: { avs_failure?: boolean; cvc_failure?: boolean };
+            decline_on?: {
+              avs_failure?: boolean;
+              cvc_failure?: boolean;
+            };
             statement_descriptor_prefix?: string;
           };
           payments?: {
@@ -2364,7 +2446,11 @@ export interface operations {
           };
         };
         /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
-        tos_acceptance?: { date?: number; ip?: string; user_agent?: string };
+        tos_acceptance?: {
+          date?: number;
+          ip?: string;
+          user_agent?: string;
+        };
         /** The type of Stripe account to create. Currently must be `custom`, as only [Custom accounts](https://stripe.com/docs/connect/custom-accounts) may be created via the API. */
         type?: "custom" | "express" | "standard";
       };
@@ -2529,7 +2615,12 @@ export interface operations {
           tax_id?: string;
           tax_id_registrar?: string;
           vat_id?: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts). */
         default_currency?: string;
@@ -2567,7 +2658,11 @@ export interface operations {
             state?: string;
             town?: string;
           };
-          dob?: Partial<{ day: number; month: number; year: number }> &
+          dob?: Partial<{
+            day: number;
+            month: number;
+            year: number;
+          }> &
             Partial<"">;
           email?: string;
           first_name?: string;
@@ -2583,8 +2678,14 @@ export interface operations {
           phone?: string;
           ssn_last_4?: string;
           verification?: {
-            additional_document?: { back?: string; front?: string };
-            document?: { back?: string; front?: string };
+            additional_document?: {
+              back?: string;
+              front?: string;
+            };
+            document?: {
+              back?: string;
+              front?: string;
+            };
           };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -2608,7 +2709,10 @@ export interface operations {
             secondary_color?: string;
           };
           card_payments?: {
-            decline_on?: { avs_failure?: boolean; cvc_failure?: boolean };
+            decline_on?: {
+              avs_failure?: boolean;
+              cvc_failure?: boolean;
+            };
             statement_descriptor_prefix?: string;
           };
           payments?: {
@@ -2635,7 +2739,11 @@ export interface operations {
           };
         };
         /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
-        tos_acceptance?: { date?: number; ip?: string; user_agent?: string };
+        tos_acceptance?: {
+          date?: number;
+          ip?: string;
+          user_agent?: string;
+        };
       };
     };
     responses: {
@@ -3205,7 +3313,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -3248,8 +3360,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -3352,7 +3470,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -3395,8 +3517,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -3496,7 +3624,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -3539,8 +3671,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -3643,7 +3781,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -3686,8 +3828,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -4276,7 +4424,8 @@ export interface operations {
   PostBillingPortalSessions: {
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The ID of an existing customer. */ customer: string;
+        /** The ID of an existing customer. */
+        customer: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** The URL to which Stripe should send customers when they click on the link to return to your website. This field is required if a default return URL has not been configured for the portal. */
@@ -4526,7 +4675,10 @@ export interface operations {
         customer?: string;
         /** An arbitrary string which you can attach to a `Charge` object. It is displayed when in the web interface alongside the charge. Note that if you use Stripe to send automatic email receipts to your customers, your receipt emails will include the `description` of the charge(s) that they are describing. */
         description?: string;
-        destination?: Partial<{ account: string; amount?: number }> &
+        destination?: Partial<{
+          account: string;
+          amount?: number;
+        }> &
           Partial<string>;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
@@ -4558,7 +4710,10 @@ export interface operations {
         /** Provides information about the charge that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
         statement_descriptor_suffix?: string;
         /** An optional dictionary including the account to automatically transfer to as part of a destination charge. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details. */
-        transfer_data?: { amount?: number; destination: string };
+        transfer_data?: {
+          amount?: number;
+          destination: string;
+        };
         /** A string that identifies this transaction as part of a group. For details, see [Grouping transactions](https://stripe.com/docs/connect/charges-transfers#transfer-options). */
         transfer_group?: string;
       };
@@ -4615,7 +4770,9 @@ export interface operations {
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** A set of key-value pairs you can attach to a charge giving information about its riskiness. If you believe a charge is fraudulent, include a `user_report` key with a value of `fraudulent`. If you believe a charge is safe, include a `user_report` key with a value of `safe`. Stripe will use the information you send to improve our fraud detection algorithms. */
-        fraud_details?: { user_report: "" | "fraudulent" | "safe" };
+        fraud_details?: {
+          user_report: "" | "fraudulent" | "safe";
+        };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: Partial<{ [key: string]: string }> & Partial<"">;
         /** This is the email address that the receipt for this charge will be sent to. If this field is updated, then a new email receipt will be sent to the updated address. */
@@ -4678,7 +4835,9 @@ export interface operations {
         /** Provides information about the charge that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
         statement_descriptor_suffix?: string;
         /** An optional dictionary including the account to automatically transfer to as part of a destination charge. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details. */
-        transfer_data?: { amount?: number };
+        transfer_data?: {
+          amount?: number;
+        };
         /** A string that identifies this transaction as part of a group. `transfer_group` may only be provided if it has not been set. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details. */
         transfer_group?: string;
       };
@@ -5101,7 +5260,10 @@ export interface operations {
           };
           statement_descriptor?: string;
           statement_descriptor_suffix?: string;
-          transfer_data?: { amount?: number; destination: string };
+          transfer_data?: {
+            amount?: number;
+            destination: string;
+          };
         };
         /** A list of the types of payment methods (e.g., card) this Checkout session can accept. */
         payment_method_types: ("card" | "fpx" | "ideal")[];
@@ -5364,7 +5526,11 @@ export interface operations {
         subscription_data?: {
           application_fee_percent?: number;
           default_tax_rates?: string[];
-          items?: { plan: string; quantity?: number; tax_rates?: string[] }[];
+          items?: {
+            plan: string;
+            quantity?: number;
+            tax_rates?: string[];
+          }[];
           metadata?: { [key: string]: string };
           trial_end?: number;
           trial_from_plan?: boolean;
@@ -6059,7 +6225,12 @@ export interface operations {
         invoice_prefix?: string;
         /** Default invoice settings for this customer. */
         invoice_settings?: {
-          custom_fields?: Partial<{ name: string; value: string }[]> &
+          custom_fields?: Partial<
+            {
+              name: string;
+              value: string;
+            }[]
+          > &
             Partial<"">;
           default_payment_method?: string;
           footer?: string;
@@ -6258,7 +6429,12 @@ export interface operations {
         invoice_prefix?: string;
         /** Default invoice settings for this customer. */
         invoice_settings?: {
-          custom_fields?: Partial<{ name: string; value: string }[]> &
+          custom_fields?: Partial<
+            {
+              name: string;
+              value: string;
+            }[]
+          > &
             Partial<"">;
           default_payment_method?: string;
           footer?: string;
@@ -7281,7 +7457,10 @@ export interface operations {
         expand?: string[];
         /** A list of up to 20 subscription items, each with an attached plan. */
         items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           metadata?: { [key: string]: string };
           plan?: string;
           quantity?: number;
@@ -7438,7 +7617,10 @@ export interface operations {
         expand?: string[];
         /** List of subscription items, each with an attached plan. */
         items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
@@ -8351,7 +8533,10 @@ export interface operations {
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: Partial<{ [key: string]: string }> & Partial<"">;
         /** The period associated with this invoice item. */
-        period?: { end: number; start: number };
+        period?: {
+          end: number;
+          start: number;
+        };
         /** Non-negative integer. The quantity of units for the invoice item. */
         quantity?: number;
         /** The ID of a subscription to add this invoice item to. When left blank, the invoice item will be be added to the next upcoming scheduled invoice. When set, scheduled invoices for subscriptions other than the specified subscription will ignore the invoice item. Use this when you want to express that an invoice item has been accrued within the context of a particular subscription. */
@@ -8441,7 +8626,10 @@ export interface operations {
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: Partial<{ [key: string]: string }> & Partial<"">;
         /** The period associated with this invoice item. */
-        period?: { end: number; start: number };
+        period?: {
+          end: number;
+          start: number;
+        };
         /** Non-negative integer. The quantity of units for the invoice item. */
         quantity?: number;
         /** The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the invoice do not apply to this invoice item. Pass an empty string to remove previously-defined tax rates. */
@@ -8532,7 +8720,12 @@ export interface operations {
         /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions. Defaults to `charge_automatically`. */
         collection_method?: "charge_automatically" | "send_invoice";
         /** A list of up to 4 custom fields to be displayed on the invoice. */
-        custom_fields?: Partial<{ name: string; value: string }[]> &
+        custom_fields?: Partial<
+          {
+            name: string;
+            value: string;
+          }[]
+        > &
           Partial<"">;
         /** The ID of the customer who will be billed. */
         customer: string;
@@ -8597,7 +8790,10 @@ export interface operations {
           discountable?: boolean;
           invoiceitem?: string;
           metadata?: Partial<{ [key: string]: string }> & Partial<"">;
-          period?: { end: number; start: number };
+          period?: {
+            end: number;
+            start: number;
+          };
           quantity?: number;
           tax_rates?: Partial<string[]> & Partial<"">;
           unit_amount?: number;
@@ -8620,7 +8816,10 @@ export interface operations {
         subscription_default_tax_rates?: Partial<string[]> & Partial<"">;
         /** List of subscription items, each with an attached plan. */
         subscription_items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
@@ -8688,7 +8887,10 @@ export interface operations {
           discountable?: boolean;
           invoiceitem?: string;
           metadata?: Partial<{ [key: string]: string }> & Partial<"">;
-          period?: { end: number; start: number };
+          period?: {
+            end: number;
+            start: number;
+          };
           quantity?: number;
           tax_rates?: Partial<string[]> & Partial<"">;
           unit_amount?: number;
@@ -8715,7 +8917,10 @@ export interface operations {
         subscription_default_tax_rates?: Partial<string[]> & Partial<"">;
         /** List of subscription items, each with an attached plan. */
         subscription_items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
@@ -8841,7 +9046,12 @@ export interface operations {
         /** Either `charge_automatically` or `send_invoice`. This field can be updated only on `draft` invoices. */
         collection_method?: "charge_automatically" | "send_invoice";
         /** A list of up to 4 custom fields to be displayed on the invoice. If a value for `custom_fields` is specified, the list specified will replace the existing custom field list on this invoice. Pass an empty string to remove previously-defined fields. */
-        custom_fields?: Partial<{ name: string; value: string }[]> &
+        custom_fields?: Partial<
+          {
+            name: string;
+            value: string;
+          }[]
+        > &
           Partial<"">;
         /** The number of days from which the invoice is created until it is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices. */
         days_until_due?: number;
@@ -9348,17 +9558,28 @@ export interface operations {
           };
         };
         /** Additional information about a `company` cardholder. */
-        company?: { tax_id?: string };
+        company?: {
+          tax_id?: string;
+        };
         /** The cardholder's email address. */
         email?: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Additional information about an `individual` cardholder. */
         individual?: {
-          dob?: { day: number; month: number; year: number };
+          dob?: {
+            day: number;
+            month: number;
+            year: number;
+          };
           first_name: string;
           last_name: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: { [key: string]: string };
@@ -10313,17 +10534,28 @@ export interface operations {
           };
         };
         /** Additional information about a `company` cardholder. */
-        company?: { tax_id?: string };
+        company?: {
+          tax_id?: string;
+        };
         /** The cardholder's email address. */
         email?: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Additional information about an `individual` cardholder. */
         individual?: {
-          dob?: { day: number; month: number; year: number };
+          dob?: {
+            day: number;
+            month: number;
+            year: number;
+          };
           first_name: string;
           last_name: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: { [key: string]: string };
@@ -13727,7 +13959,10 @@ export interface operations {
         /** The shipping method to select for fulfilling this order. If specified, must be one of the `id`s of a shipping method in the `shipping_methods` array. If specified, will overwrite the existing selected shipping method, updating `items` as necessary. */
         selected_shipping_method?: string;
         /** Tracking information once the order has been fulfilled. */
-        shipping?: { carrier: string; tracking_number: string };
+        shipping?: {
+          carrier: string;
+          tracking_number: string;
+        };
         /** Current order status. One of `created`, `paid`, `canceled`, `fulfilled`, or `returned`. More detail in the [Orders Guide](https://stripe.com/docs/orders/guide#understanding-order-statuses). */
         status?: "canceled" | "created" | "fulfilled" | "paid" | "returned";
       };
@@ -13909,7 +14144,10 @@ export interface operations {
           customer_acceptance: {
             accepted_at?: number;
             offline?: { [key: string]: any };
-            online?: { ip_address: string; user_agent: string };
+            online?: {
+              ip_address: string;
+              user_agent: string;
+            };
             type: "offline" | "online";
           };
         };
@@ -13978,7 +14216,10 @@ export interface operations {
          * The parameters used to automatically create a Transfer when the payment succeeds.
          * For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
          */
-        transfer_data?: { amount?: number; destination: string };
+        transfer_data?: {
+          amount?: number;
+          destination: string;
+        };
         /** A string that identifies the resulting payment as part of a group. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
         transfer_group?: string;
         /** Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle additional authentication steps. */
@@ -14119,7 +14360,9 @@ export interface operations {
         /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
         statement_descriptor_suffix?: string;
         /** The parameters used to automatically create a Transfer when the payment succeeds. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts). */
-        transfer_data?: { amount?: number };
+        transfer_data?: {
+          amount?: number;
+        };
         /** A string that identifies the resulting payment as part of a group. `transfer_group` may only be provided if it has not been set. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
         transfer_group?: string;
       };
@@ -14202,7 +14445,9 @@ export interface operations {
          * The parameters used to automatically create a Transfer when the payment
          * is captured. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
          */
-        transfer_data?: { amount?: number };
+        transfer_data?: {
+          amount?: number;
+        };
       };
     };
     responses: {
@@ -14251,7 +14496,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The client secret of the PaymentIntent. */ client_secret?: string;
+        /** The client secret of the PaymentIntent. */
+        client_secret?: string;
         /** Set to `true` to fail the payment attempt if the PaymentIntent transitions into `requires_action`. This parameter is intended for simpler integrations that do not handle customer actions, like [saving cards without authentication](https://stripe.com/docs/payments/save-card-without-authentication). */
         error_on_requires_action?: boolean;
         /** Specifies which fields in the response should be expanded. */
@@ -14263,13 +14509,19 @@ export interface operations {
           customer_acceptance: {
             accepted_at?: number;
             offline?: { [key: string]: any };
-            online?: { ip_address: string; user_agent: string };
+            online?: {
+              ip_address: string;
+              user_agent: string;
+            };
             type: "offline" | "online";
           };
         }> &
           Partial<{
             customer_acceptance: {
-              online: { ip_address?: string; user_agent?: string };
+              online: {
+                ip_address?: string;
+                user_agent?: string;
+              };
               type: "online";
             };
           }>;
@@ -14395,7 +14647,10 @@ export interface operations {
     requestBody: {
       "application/x-www-form-urlencoded": {
         /** If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account. */
-        au_becs_debit?: { account_number: string; bsb_number: string };
+        au_becs_debit?: {
+          account_number: string;
+          bsb_number: string;
+        };
         /** Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods. */
         billing_details?: {
           address?: {
@@ -14417,7 +14672,9 @@ export interface operations {
           exp_year: number;
           number: string;
         }> &
-          Partial<{ token: string }>;
+          Partial<{
+            token: string;
+          }>;
         /** The `Customer` to whom the original PaymentMethod is attached. */
         customer?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -14467,7 +14724,9 @@ export interface operations {
         /** The PaymentMethod to share. */
         payment_method?: string;
         /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
-        sepa_debit?: { iban: string };
+        sepa_debit?: {
+          iban: string;
+        };
         /** The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type. Required unless `payment_method` is specified (see the [Cloning PaymentMethods](https://stripe.com/docs/payments/payment-methods/connect#cloning-payment-methods) guide) */
         type?: "au_becs_debit" | "card" | "fpx" | "ideal" | "sepa_debit";
       };
@@ -14532,7 +14791,10 @@ export interface operations {
           phone?: string;
         };
         /** If this is a `card` PaymentMethod, this hash contains the user's card details. */
-        card?: { exp_month?: number; exp_year?: number };
+        card?: {
+          exp_month?: number;
+          exp_year?: number;
+        };
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -14880,7 +15142,10 @@ export interface operations {
         /** Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows. */
         tiers_mode?: "graduated" | "volume";
         /** Apply a transformation to the reported usage or set quantity before computing the billed price. Cannot be combined with `tiers`. */
-        transform_usage?: { divide_by: number; round: "down" | "up" };
+        transform_usage?: {
+          divide_by: number;
+          round: "down" | "up";
+        };
         /** Default number of trial days when subscribing a customer to this plan using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan). */
         trial_period_days?: number;
         /** Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`. */
@@ -15146,7 +15411,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** Whether the product is available for purchase. */ active?: boolean;
+        /** Whether the product is available for purchase. */
+        active?: boolean;
         /** A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g., `["color", "size"]`). If a value for `attributes` is specified, the list specified will replace the existing attributes list on this product. Any attributes not present after the update will be deleted from the SKUs for this product. */
         attributes?: Partial<string[]> & Partial<"">;
         /** A short one-line description of the product, meant to be displayable to the customer. May only be set if `type=good`. */
@@ -15431,7 +15697,8 @@ export interface operations {
   PostRadarValueLists: {
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The name of the value list for use in rules. */ alias: string;
+        /** The name of the value list for use in rules. */
+        alias: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Type of the items in the value list. One of `card_fingerprint`, `card_bin`, `email`, `ip_address`, `country`, `string`, or `case_sensitive_string`. Use `string` if the item type is unknown or mixed. */
@@ -15515,7 +15782,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The name of the value list for use in rules. */ alias?: string;
+        /** The name of the value list for use in rules. */
+        alias?: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -16787,7 +17055,10 @@ export interface operations {
           customer_acceptance: {
             accepted_at?: number;
             offline?: { [key: string]: any };
-            online?: { ip_address: string; user_agent: string };
+            online?: {
+              ip_address: string;
+              user_agent: string;
+            };
             type: "offline" | "online";
           };
         };
@@ -16799,14 +17070,19 @@ export interface operations {
         payment_method?: string;
         /** Payment-method-specific configuration for this SetupIntent. */
         payment_method_options?: {
-          card?: { request_three_d_secure?: "any" | "automatic" };
+          card?: {
+            request_three_d_secure?: "any" | "automatic";
+          };
         };
         /** The list of payment method types (e.g. card) that this SetupIntent is allowed to use. If this is not provided, defaults to ["card"]. */
         payment_method_types?: string[];
         /** The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site. If you'd prefer to redirect to a mobile application, you can alternatively supply an application URI scheme. This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm). */
         return_url?: string;
         /** If this hash is populated, this SetupIntent will generate a single_use Mandate on success. */
-        single_use?: { amount: number; currency: string };
+        single_use?: {
+          amount: number;
+          currency: string;
+        };
         /** Indicates how the payment method is intended to be used in the future. If not provided, this value defaults to `off_session`. */
         usage?: "off_session" | "on_session";
       };
@@ -16880,7 +17156,9 @@ export interface operations {
         payment_method?: string;
         /** Payment-method-specific configuration for this SetupIntent. */
         payment_method_options?: {
-          card?: { request_three_d_secure?: "any" | "automatic" };
+          card?: {
+            request_three_d_secure?: "any" | "automatic";
+          };
         };
         /** The list of payment method types (e.g. card) that this SetupIntent is allowed to set up. If this is not provided, defaults to ["card"]. */
         payment_method_types?: string[];
@@ -16953,7 +17231,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The client secret of the SetupIntent. */ client_secret?: string;
+        /** The client secret of the SetupIntent. */
+        client_secret?: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** This hash contains details about the Mandate to create */
@@ -16961,13 +17240,19 @@ export interface operations {
           customer_acceptance: {
             accepted_at?: number;
             offline?: { [key: string]: any };
-            online?: { ip_address: string; user_agent: string };
+            online?: {
+              ip_address: string;
+              user_agent: string;
+            };
             type: "offline" | "online";
           };
         }> &
           Partial<{
             customer_acceptance: {
-              online: { ip_address?: string; user_agent?: string };
+              online: {
+                ip_address?: string;
+                user_agent?: string;
+              };
               type: "online";
             };
           }>;
@@ -16975,7 +17260,9 @@ export interface operations {
         payment_method?: string;
         /** Payment-method-specific configuration for this SetupIntent. */
         payment_method_options?: {
-          card?: { request_three_d_secure?: "any" | "automatic" };
+          card?: {
+            request_three_d_secure?: "any" | "automatic";
+          };
         };
         /**
          * The URL to redirect your customer back to after they authenticate on the payment method's app or site.
@@ -17211,7 +17498,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** Whether this SKU is available for purchase. */ active?: boolean;
+        /** Whether this SKU is available for purchase. */
+        active?: boolean;
         /** A dictionary of attributes and values for the attributes defined by the product. When specified, `attributes` will partially update the existing attributes dictionary on the product, with the postcondition that a value must be present for each attribute key on the product. */
         attributes?: { [key: string]: string };
         /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -17272,8 +17560,14 @@ export interface operations {
           acceptance?: {
             date?: number;
             ip?: string;
-            offline?: { contact_email: string };
-            online?: { date?: number; ip?: string; user_agent?: string };
+            offline?: {
+              contact_email: string;
+            };
+            online?: {
+              date?: number;
+              ip?: string;
+              user_agent?: string;
+            };
             status: "accepted" | "pending" | "refused" | "revoked";
             type?: "offline" | "online";
             user_agent?: string;
@@ -17306,9 +17600,13 @@ export interface operations {
           phone?: string;
         };
         /** Optional parameters for the receiver flow. Can be set only if the source is a receiver (`flow` is `receiver`). */
-        receiver?: { refund_attributes_method?: "email" | "manual" | "none" };
+        receiver?: {
+          refund_attributes_method?: "email" | "manual" | "none";
+        };
         /** Parameters required for the redirect flow. Required if the source is authenticated by a redirect (`flow` is `redirect`). */
-        redirect?: { return_url: string };
+        redirect?: {
+          return_url: string;
+        };
         /** Information about the items and shipping associated with the source. Required for transactional credit (for example Klarna) sources before you can charge it. */
         source_order?: {
           items?: {
@@ -17394,7 +17692,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** Amount associated with the source. */ amount?: number;
+        /** Amount associated with the source. */
+        amount?: number;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Information about a mandate possibility attached to a source object (generally for bank debits) as well as its acceptance status. */
@@ -17402,8 +17701,14 @@ export interface operations {
           acceptance?: {
             date?: number;
             ip?: string;
-            offline?: { contact_email: string };
-            online?: { date?: number; ip?: string; user_agent?: string };
+            offline?: {
+              contact_email: string;
+            };
+            online?: {
+              date?: number;
+              ip?: string;
+              user_agent?: string;
+            };
             status: "accepted" | "pending" | "refused" | "revoked";
             type?: "offline" | "online";
             user_agent?: string;
@@ -17632,7 +17937,10 @@ export interface operations {
     requestBody: {
       "application/x-www-form-urlencoded": {
         /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-        billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+        billing_thresholds?: Partial<{
+          usage_gte: number;
+        }> &
+          Partial<"">;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -17752,7 +18060,10 @@ export interface operations {
     requestBody: {
       "application/x-www-form-urlencoded": {
         /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-        billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+        billing_thresholds?: Partial<{
+          usage_gte: number;
+        }> &
+          Partial<"">;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -17969,7 +18280,9 @@ export interface operations {
             Partial<"">;
           collection_method?: "charge_automatically" | "send_invoice";
           default_payment_method?: string;
-          invoice_settings?: { days_until_due?: number };
+          invoice_settings?: {
+            days_until_due?: number;
+          };
         };
         /** Configures how the subscription schedule behaves when it ends. Possible values are `release` or `cancel` with the default being `release`. `release` will end the subscription schedule and keep the underlying subscription running.`cancel` will end the subscription schedule and cancel the underlying subscription. */
         end_behavior?: "cancel" | "none" | "release" | "renew";
@@ -17992,10 +18305,15 @@ export interface operations {
           default_payment_method?: string;
           default_tax_rates?: Partial<string[]> & Partial<"">;
           end_date?: number;
-          invoice_settings?: { days_until_due?: number };
+          invoice_settings?: {
+            days_until_due?: number;
+          };
           iterations?: number;
           plans: {
-            billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+            billing_thresholds?: Partial<{
+              usage_gte: number;
+            }> &
+              Partial<"">;
             plan?: string;
             quantity?: number;
             tax_rates?: Partial<string[]> & Partial<"">;
@@ -18063,7 +18381,9 @@ export interface operations {
             Partial<"">;
           collection_method?: "charge_automatically" | "send_invoice";
           default_payment_method?: string;
-          invoice_settings?: { days_until_due?: number };
+          invoice_settings?: {
+            days_until_due?: number;
+          };
         };
         /** Configures how the subscription schedule behaves when it ends. Possible values are `release` or `cancel` with the default being `release`. `release` will end the subscription schedule and keep the underlying subscription running.`cancel` will end the subscription schedule and cancel the underlying subscription. */
         end_behavior?: "cancel" | "none" | "release" | "renew";
@@ -18084,10 +18404,15 @@ export interface operations {
           default_payment_method?: string;
           default_tax_rates?: Partial<string[]> & Partial<"">;
           end_date?: Partial<number> & Partial<"now">;
-          invoice_settings?: { days_until_due?: number };
+          invoice_settings?: {
+            days_until_due?: number;
+          };
           iterations?: number;
           plans: {
-            billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+            billing_thresholds?: Partial<{
+              usage_gte: number;
+            }> &
+              Partial<"">;
             plan?: string;
             quantity?: number;
             tax_rates?: Partial<string[]> & Partial<"">;
@@ -18281,7 +18606,10 @@ export interface operations {
         expand?: string[];
         /** A list of up to 20 subscription items, each with an attached plan. */
         items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           metadata?: { [key: string]: string };
           plan?: string;
           quantity?: number;
@@ -18435,7 +18763,10 @@ export interface operations {
         expand?: string[];
         /** List of subscription items, each with an attached plan. */
         items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
@@ -19047,7 +19378,12 @@ export interface operations {
             tax_id?: string;
             tax_id_registrar?: string;
             vat_id?: string;
-            verification?: { document?: { back?: string; front?: string } };
+            verification?: {
+              document?: {
+                back?: string;
+                front?: string;
+              };
+            };
           };
           individual?: {
             address?: {
@@ -19076,7 +19412,11 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: Partial<{ day: number; month: number; year: number }> &
+            dob?: Partial<{
+              day: number;
+              month: number;
+              year: number;
+            }> &
               Partial<"">;
             email?: string;
             first_name?: string;
@@ -19092,8 +19432,14 @@ export interface operations {
             phone?: string;
             ssn_last_4?: string;
             verification?: {
-              additional_document?: { back?: string; front?: string };
-              document?: { back?: string; front?: string };
+              additional_document?: {
+                back?: string;
+                front?: string;
+              };
+              document?: {
+                back?: string;
+                front?: string;
+              };
             };
           };
           tos_shown_and_accepted?: boolean;
@@ -19154,7 +19500,11 @@ export interface operations {
             state?: string;
             town?: string;
           };
-          dob?: Partial<{ day: number; month: number; year: number }> &
+          dob?: Partial<{
+            day: number;
+            month: number;
+            year: number;
+          }> &
             Partial<"">;
           email?: string;
           first_name?: string;
@@ -19178,12 +19528,20 @@ export interface operations {
           };
           ssn_last_4?: string;
           verification?: {
-            additional_document?: { back?: string; front?: string };
-            document?: { back?: string; front?: string };
+            additional_document?: {
+              back?: string;
+              front?: string;
+            };
+            document?: {
+              back?: string;
+              front?: string;
+            };
           };
         };
         /** The PII this token will represent. */
-        pii?: { id_number?: string };
+        pii?: {
+          id_number?: string;
+        };
       };
     };
     responses: {
@@ -20452,7 +20810,8 @@ export interface components {
       user_agent?: string | null;
     };
     address: {
-      /** City, district, suburb, town, or village. */ city?: string | null;
+      /** City, district, suburb, town, or village. */
+      city?: string | null;
       /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
       country?: string | null;
       /** Address line 1 (e.g., street, PO Box, or company name). */
@@ -20495,7 +20854,8 @@ export interface components {
       username: string;
     };
     api_errors: {
-      /** For card errors, the ID of the failed charge. */ charge?: string;
+      /** For card errors, the ID of the failed charge. */
+      charge?: string;
       /** For some errors that could be handled programmatically, a short string indicating the [error code](https://stripe.com/docs/error-codes) reported. */
       code?: string;
       /** For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://stripe.com/docs/declines#issuer-declines) if they provide one. */
@@ -20535,7 +20895,8 @@ export interface components {
       object: "apple_pay_domain";
     };
     application: {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** The name of the application. */
       name?: string | null;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -20612,13 +20973,15 @@ export interface components {
       pending: components["schemas"]["balance_amount"][];
     };
     balance_amount: {
-      /** Balance amount. */ amount: number;
+      /** Balance amount. */
+      amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       source_types?: components["schemas"]["balance_amount_by_source_type"];
     };
     balance_amount_by_source_type: {
-      /** Amount for bank account. */ bank_account?: number;
+      /** Amount for bank account. */
+      bank_account?: number;
       /** Amount for card. */
       card?: number;
       /** Amount for FPX. */
@@ -20631,7 +20994,8 @@ export interface components {
      * Related guide: [Balance Transaction Types](https://stripe.com/docs/reports/balance-transaction-types).
      */
     balance_transaction: {
-      /** Gross amount of the transaction, in %s. */ amount: number;
+      /** Gross amount of the transaction, in %s. */
+      amount: number;
       /** The date the transaction's net funds will become available in the Stripe balance. */
       available_on: number;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -21240,14 +21604,16 @@ export interface components {
       success_url: string;
     };
     checkout_session_custom_display_item_description: {
-      /** The description of the line item. */ description?: string | null;
+      /** The description of the line item. */
+      description?: string | null;
       /** The images of the line item. */
       images?: string[] | null;
       /** The name of the line item. */
       name: string;
     };
     checkout_session_display_item: {
-      /** Amount for the display item. */ amount?: number;
+      /** Amount for the display item. */
+      amount?: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency?: string;
       custom?: components["schemas"]["checkout_session_custom_display_item_description"];
@@ -21259,7 +21625,8 @@ export interface components {
       type?: string;
     };
     connect_collection_transfer: {
-      /** Amount transferred, in %s. */ amount: number;
+      /** Amount transferred, in %s. */
+      amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** ID of the account that funds are being collected for. */
@@ -21448,7 +21815,8 @@ export interface components {
       unit_amount_decimal?: string | null;
     };
     credit_note_tax_amount: {
-      /** The amount, in %s, of the tax. */ amount: number;
+      /** The amount, in %s, of the tax. */
+      amount: number;
       /** Whether this tax amount is inclusive or exclusive. */
       inclusive: boolean;
       /** The tax rate that was applied to get this tax amount. */
@@ -21611,21 +21979,24 @@ export interface components {
         | "unspent_receiver_credit";
     };
     deleted_account: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "account";
     };
     deleted_alipay_account: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "alipay_account";
     };
     deleted_apple_pay_domain: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -21642,7 +22013,8 @@ export interface components {
       object: "bank_account";
     };
     deleted_bitcoin_receiver: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -21659,21 +22031,24 @@ export interface components {
       object: "card";
     };
     deleted_coupon: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "coupon";
     };
     deleted_customer: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "customer";
     };
     deleted_discount: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "discount";
     };
@@ -21682,14 +22057,16 @@ export interface components {
     > &
       Partial<components["schemas"]["deleted_card"]>;
     deleted_invoice: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "invoice";
     };
     deleted_invoiceitem: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -21702,84 +22079,96 @@ export interface components {
       Partial<components["schemas"]["deleted_bitcoin_receiver"]> &
       Partial<components["schemas"]["deleted_card"]>;
     deleted_person: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "person";
     };
     deleted_plan: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "plan";
     };
     deleted_product: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "product";
     };
     "deleted_radar.value_list": {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "radar.value_list";
     };
     "deleted_radar.value_list_item": {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "radar.value_list_item";
     };
     deleted_recipient: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "recipient";
     };
     deleted_sku: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "sku";
     };
     deleted_subscription_item: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "subscription_item";
     };
     deleted_tax_id: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "tax_id";
     };
     "deleted_terminal.location": {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "terminal.location";
     };
     "deleted_terminal.reader": {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "terminal.reader";
     };
     deleted_webhook_endpoint: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -21967,7 +22356,9 @@ export interface components {
       secret?: string;
     };
     /** An error response from the Stripe API */
-    error: { error: components["schemas"]["api_errors"] };
+    error: {
+      error: components["schemas"]["api_errors"];
+    };
     /**
      * Events are our way of letting you know when something interesting happens in
      * your account. When an interesting event occurs, we create a new `Event`
@@ -22000,7 +22391,8 @@ export interface components {
      * guaranteed only for 30 days.
      */
     event: {
-      /** The connected account that originated the event. */ account?: string;
+      /** The connected account that originated the event. */
+      account?: string;
       /** The Stripe API version used to render `data`. *Note: This property is populated only for events on or after October 31, 2014*. */
       api_version?: string | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -22045,7 +22437,8 @@ export interface components {
     external_account: Partial<components["schemas"]["bank_account"]> &
       Partial<components["schemas"]["card"]>;
     fee: {
-      /** Amount of the fee, in cents. */ amount: number;
+      /** Amount of the fee, in cents. */
+      amount: number;
       /** ID of the Connect application that earned the fee. */
       application?: string | null;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -22063,7 +22456,8 @@ export interface components {
      * Related guide: [Refunding Application Fees](https://stripe.com/docs/connect/destination-charges#refunding-app-fee).
      */
     fee_refund: {
-      /** Amount, in %s. */ amount: number;
+      /** Amount, in %s. */
+      amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
         | (Partial<string> &
@@ -22377,12 +22771,14 @@ export interface components {
       usage_gte: number;
     };
     invoice_line_item_period: {
-      /** End of the line item's billing period */ end: number;
+      /** End of the line item's billing period */
+      end: number;
       /** Start of the line item's billing period */
       start: number;
     };
     invoice_setting_custom_field: {
-      /** The name of the custom field. */ name: string;
+      /** The name of the custom field. */
+      name: string;
       /** The value of the custom field. */
       value: string;
     };
@@ -22403,7 +22799,8 @@ export interface components {
       days_until_due?: number | null;
     };
     invoice_tax_amount: {
-      /** The amount, in %s, of the tax. */ amount: number;
+      /** The amount, in %s, of the tax. */
+      amount: number;
       /** Whether this tax amount is inclusive or exclusive. */
       inclusive: boolean;
       /** The tax rate that was applied to get this tax amount. */
@@ -22596,7 +22993,8 @@ export interface components {
     };
     /** You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders. */
     "issuing.card": {
-      /** The brand of the card. */ brand: string;
+      /** The brand of the card. */
+      brand: string;
       /** The reason why the card was canceled. */
       cancellation_reason?: ("lost" | "stolen") | null;
       cardholder: components["schemas"]["issuing.cardholder"];
@@ -22687,7 +23085,8 @@ export interface components {
      * Related guide: [Disputing Transactions](https://stripe.com/docs/issuing/purchases/disputes)
      */
     "issuing.dispute": {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -23465,7 +23864,8 @@ export interface components {
       type: "bulk" | "individual";
     };
     issuing_card_spending_limit: {
-      /** Maximum amount allowed to spend per time interval. */ amount: number;
+      /** Maximum amount allowed to spend per time interval. */
+      amount: number;
       /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges. */
       categories?:
         | (
@@ -23768,7 +24168,9 @@ export interface components {
         | "weekly"
         | "yearly";
     };
-    issuing_cardholder_address: { address: components["schemas"]["address"] };
+    issuing_cardholder_address: {
+      address: components["schemas"]["address"];
+    };
     issuing_cardholder_authorization_controls: {
       /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this cardholder's cards. */
       allowed_categories?:
@@ -24388,7 +24790,8 @@ export interface components {
       > | null;
     };
     issuing_cardholder_individual_dob: {
-      /** The day of birth, between 1 and 31. */ day?: number | null;
+      /** The day of birth, between 1 and 31. */
+      day?: number | null;
       /** The month of birth, between 1 and 12. */
       month?: number | null;
       /** The four-digit year of birth. */
@@ -24411,7 +24814,8 @@ export interface components {
         | null;
     };
     issuing_cardholder_spending_limit: {
-      /** Maximum amount allowed to spend per time interval. */ amount: number;
+      /** Maximum amount allowed to spend per time interval. */
+      amount: number;
       /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges. */
       categories?:
         | (
@@ -24786,14 +25190,16 @@ export interface components {
       front?: (Partial<string> & Partial<components["schemas"]["file"]>) | null;
     };
     legal_entity_dob: {
-      /** The day of birth, between 1 and 31. */ day?: number | null;
+      /** The day of birth, between 1 and 31. */
+      day?: number | null;
       /** The month of birth, between 1 and 12. */
       month?: number | null;
       /** The four-digit year of birth. */
       year?: number | null;
     };
     legal_entity_japan_address: {
-      /** City/Ward. */ city?: string | null;
+      /** City/Ward. */
+      city?: string | null;
       /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
       country?: string | null;
       /** Block/Building number. */
@@ -24832,7 +25238,8 @@ export interface components {
     };
     light_account_logout: { [key: string]: any };
     line_item: {
-      /** The amount, in %s. */ amount: number;
+      /** The amount, in %s. */
+      amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
@@ -24908,12 +25315,14 @@ export interface components {
       type: string;
     };
     mandate_sepa_debit: {
-      /** The unique reference of the mandate. */ reference: string;
+      /** The unique reference of the mandate. */
+      reference: string;
       /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
       url: string;
     };
     mandate_single_use: {
-      /** On a single use mandate, the amount of the payment. */ amount: number;
+      /** On a single use mandate, the amount of the payment. */
+      amount: number;
       /** On a single use mandate, the currency of the payment. */
       currency: string;
     };
@@ -25061,7 +25470,8 @@ export interface components {
         | null;
     };
     package_dimensions: {
-      /** Height, in inches. */ height: number;
+      /** Height, in inches. */
+      height: number;
       /** Length, in inches. */
       length: number;
       /** Weight, in ounces. */
@@ -25324,7 +25734,8 @@ export interface components {
       cvc_check?: string | null;
     };
     payment_method_card_generated_card: {
-      /** The charge that created this object. */ charge?: string | null;
+      /** The charge that created this object. */
+      charge?: string | null;
       /** Transaction-specific details of the payment method used in the payment. */
       payment_method_details?: Partial<
         components["schemas"]["payment_method_details"]
@@ -26228,7 +26639,8 @@ export interface components {
      * Related guides: [Set up a subscription](https://stripe.com/docs/billing/subscriptions/set-up-subscription) and more about [products and plans](https://stripe.com/docs/billing/subscriptions/products-and-plans).
      */
     plan: {
-      /** Whether the plan can be used for new purchases. */ active: boolean;
+      /** Whether the plan can be used for new purchases. */
+      active: boolean;
       /** Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`. */
       aggregate_usage?:
         | ("last_during_period" | "last_ever" | "max" | "sum")
@@ -26277,7 +26689,8 @@ export interface components {
       usage_type: "licensed" | "metered";
     };
     plan_tier: {
-      /** Price for the entire tier. */ flat_amount?: number | null;
+      /** Price for the entire tier. */
+      flat_amount?: number | null;
       /** Same as `flat_amount`, but contains a decimal value with at most 12 decimal places. */
       flat_amount_decimal?: string | null;
       /** Per unit price for units relevant to the tier. */
@@ -26288,7 +26701,8 @@ export interface components {
       up_to?: number | null;
     };
     platform_tax_fee: {
-      /** The Connected account that incurred this charge. */ account: string;
+      /** The Connected account that incurred this charge. */
+      account: string;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -26378,7 +26792,8 @@ export interface components {
      * Related guide: [Default Stripe Lists](https://stripe.com/docs/radar/lists#managing-list-items).
      */
     "radar.value_list": {
-      /** The name of the value list for use in rules. */ alias: string;
+      /** The name of the value list for use in rules. */
+      alias: string;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** The name or email address of the user who created this value list. */
@@ -26436,7 +26851,8 @@ export interface components {
       value_list: string;
     };
     radar_review_resource_location: {
-      /** The city where the payment originated. */ city?: string | null;
+      /** The city where the payment originated. */
+      city?: string | null;
       /** Two-letter ISO code representing the country where the payment originated. */
       country?: string | null;
       /** The geographic latitude where the payment originated. */
@@ -26517,7 +26933,8 @@ export interface components {
      * Related guide: [Refunds](https://stripe.com/docs/refunds).
      */
     refund: {
-      /** Amount, in %s. */ amount: number;
+      /** Amount, in %s. */
+      amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
         | (Partial<string> &
@@ -26696,7 +27113,8 @@ export interface components {
       > | null;
     };
     rule: {
-      /** The action taken on the payment. */ action: string;
+      /** The action taken on the payment. */
+      action: string;
       /** Unique identifier for the object. */
       id: string;
       /** The predicate to evaluate the payment against. */
@@ -26881,7 +27299,8 @@ export interface components {
       id: string;
     };
     sigma_scheduled_query_run_error: {
-      /** Information about the run failure. */ message: string;
+      /** Information about the run failure. */
+      message: string;
     };
     /**
      * Stores representations of [stock keeping units](http://en.wikipedia.org/wiki/Stock_keeping_unit).
@@ -26894,7 +27313,8 @@ export interface components {
      * Related guide: [Tax, Shipping, and Inventory](https://stripe.com/docs/orders).
      */
     sku: {
-      /** Whether the SKU is available for purchase. */ active: boolean;
+      /** Whether the SKU is available for purchase. */
+      active: boolean;
       /** A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`. */
       attributes: { [key: string]: string };
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -27038,7 +27458,8 @@ export interface components {
       last4?: string;
     };
     source_mandate_notification_sepa_debit_data: {
-      /** SEPA creditor ID. */ creditor_identifier?: string;
+      /** SEPA creditor ID. */
+      creditor_identifier?: string;
       /** Last 4 digits of the account number associated with the debit. */
       last4?: string;
       /** Mandate reference associated with the debit. */
@@ -27056,7 +27477,8 @@ export interface components {
       shipping?: components["schemas"]["shipping"];
     };
     source_order_item: {
-      /** The amount (price) for this order item. */ amount?: number | null;
+      /** The amount (price) for this order item. */
+      amount?: number | null;
       /** This currency of this order item. Required when `amount` is present. */
       currency?: string | null;
       /** Human-readable description for this order item. */
@@ -27156,7 +27578,8 @@ export interface components {
         | "wechat";
     };
     source_transaction_ach_credit_transfer_data: {
-      /** Customer data associated with the transfer. */ customer_data?: string;
+      /** Customer data associated with the transfer. */
+      customer_data?: string;
       /** Bank account fingerprint associated with the transfer. */
       fingerprint?: string;
       /** Last 4 digits of the account number associated with the transfer. */
@@ -27165,7 +27588,8 @@ export interface components {
       routing_number?: string;
     };
     source_transaction_chf_credit_transfer_data: {
-      /** Reference associated with the transfer. */ reference?: string;
+      /** Reference associated with the transfer. */
+      reference?: string;
       /** Sender's country address. */
       sender_address_country?: string;
       /** Sender's line 1 address. */
@@ -27198,7 +27622,8 @@ export interface components {
       invoices?: string;
     };
     source_transaction_sepa_credit_transfer_data: {
-      /** Reference associated with the transfer. */ reference?: string;
+      /** Reference associated with the transfer. */
+      reference?: string;
       /** Sender's bank account IBAN. */
       sender_iban?: string;
       /** Sender's name. */
@@ -27336,7 +27761,9 @@ export interface components {
       refund_account_holder_name?: string | null;
       refund_iban?: string | null;
     };
-    source_type_p24: { reference?: string | null };
+    source_type_p24: {
+      reference?: string | null;
+    };
     source_type_sepa_debit: {
       bank_code?: string | null;
       branch_code?: string | null;
@@ -27380,7 +27807,8 @@ export interface components {
       statement_descriptor?: string;
     };
     status_transitions: {
-      /** The time that the order was canceled. */ canceled?: number | null;
+      /** The time that the order was canceled. */
+      canceled?: number | null;
       /** The time that the order was fulfilled. */
       fulfiled?: number | null;
       /** The time that the order was paid. */
@@ -27709,7 +28137,8 @@ export interface components {
       trial_from_plan?: boolean | null;
     };
     tax_deducted_at_source: {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "tax_deducted_at_source";
       /** The end of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period. */
@@ -27900,7 +28329,8 @@ export interface components {
       version: string;
     };
     three_d_secure_usage: {
-      /** Whether 3D Secure is supported on this card. */ supported: boolean;
+      /** Whether 3D Secure is supported on this card. */
+      supported: boolean;
     };
     /**
      * Tokenization is the process Stripe uses to collect sensitive card or bank
@@ -27952,7 +28382,8 @@ export interface components {
      * Related guide: [Topping Up your Platform Account](https://stripe.com/docs/connect/top-ups).
      */
     topup: {
-      /** Amount transferred. */ amount: number;
+      /** Amount transferred. */
+      amount: number;
       /** ID of the balance transaction that describes the impact of this top-up on your account balance. May not be specified depending on status of top-up. */
       balance_transaction?:
         | (Partial<string> &
@@ -27999,7 +28430,8 @@ export interface components {
      * Related guide: [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers).
      */
     transfer: {
-      /** Amount in %s to be transferred. */ amount: number;
+      /** Amount in %s to be transferred. */
+      amount: number;
       /** Amount in %s reversed (can be less than the amount attribute on the transfer if a partial reversal was issued). */
       amount_reversed: number;
       /** Balance transaction that describes the impact of this transfer on your account balance. */
@@ -28076,7 +28508,8 @@ export interface components {
      * Related guide: [Reversing Transfers](https://stripe.com/docs/connect/charges-transfers#reversing-transfers).
      */
     transfer_reversal: {
-      /** Amount, in %s. */ amount: number;
+      /** Amount, in %s. */
+      amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
         | (Partial<string> &
@@ -28114,7 +28547,8 @@ export interface components {
       weekly_anchor?: string;
     };
     transform_usage: {
-      /** Divide usage by this number. */ divide_by: number;
+      /** Divide usage by this number. */
+      divide_by: number;
       /** After division, either round the result `up` or `down`. */
       round: "down" | "up";
     };
@@ -28125,7 +28559,8 @@ export interface components {
      * Related guide: [Metered Billing](https://stripe.com/docs/billing/subscriptions/metered-billing).
      */
     usage_record: {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -28138,7 +28573,8 @@ export interface components {
       timestamp: number;
     };
     usage_record_summary: {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** The invoice in which this usage period has been billed for. */
       invoice?: string | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,8 +11,7 @@ export function comment(text: string): string {
   // if multi-line comment
   return `/**
   * ${commentText.replace(/\n/g, "\n  * ")}
-  */
-`;
+  */\n`;
 }
 
 /** shim for Object.fromEntries() for Node < 13 */
@@ -27,7 +26,7 @@ export function nodeType(obj: any): SchemaObjectType | undefined {
     return undefined;
   }
 
-  if (obj["$ref"]) {
+  if (obj.$ref) {
     return "ref";
   }
 
@@ -111,6 +110,7 @@ export function tsTupleOf(types: string[]): string {
 
 /** Convert T, U into T & U; */
 export function tsIntersectionOf(types: string[]): string {
+  if (types.length === 1) return types[0]; // don’t add parentheses around one thing
   return `(${types.join(") & (")})`;
 }
 
@@ -121,6 +121,7 @@ export function tsPartial(type: string): string {
 
 /** Convert [X, Y, Z] into X | Y | Z */
 export function tsUnionOf(types: string[]): string {
+  if (types.length === 1) return types[0]; // don’t add parentheses around one thing
   return `(${types.join(") | (")})`;
 }
 

--- a/src/v2.ts
+++ b/src/v2.ts
@@ -80,7 +80,7 @@ export default function generateTypesV2(input: OpenAPI2 | OpenAPI2Schemas, optio
 
         return tsIntersectionOf([
           ...(node.allOf ? (node.allOf as any[]).map(transform) : []), // append allOf first
-          ...(properties ? [`{ ${properties} }`] : []), // then properties + additionalProperties
+          ...(properties ? [`{\n${properties}\n}`] : []), // then properties + additionalProperties
         ]);
         break;
       }

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -104,7 +104,7 @@ export default function generateTypesV3(input: OpenAPI3 | OpenAPI3Schemas, optio
 
         return tsIntersectionOf([
           ...(node.allOf ? (node.allOf as any[]).map(transform) : []), // append allOf first
-          ...(properties ? [`{ ${properties} }`] : []), // then properties
+          ...(properties ? [`{\n${properties}\n}`] : []), // then properties
           ...(additionalProperties ? [additionalProperties] : []), // then additional properties
         ]);
       }

--- a/tests/bin/expected/prettier-js.ts
+++ b/tests/bin/expected/prettier-js.ts
@@ -144,7 +144,8 @@ export interface operations {
     }
     requestBody: {
       'application/x-www-form-urlencoded': {
-        /** Updated name of the pet */ name?: string
+        /** Updated name of the pet */
+        name?: string
         /** Updated status of the pet */
         status?: string
       }
@@ -180,7 +181,8 @@ export interface operations {
     }
     requestBody: {
       'multipart/form-data': {
-        /** Additional data to pass to server */ additionalMetadata?: string
+        /** Additional data to pass to server */
+        additionalMetadata?: string
         /** file to upload */
         file?: string
       }
@@ -368,7 +370,10 @@ export interface components {
       status?: 'placed' | 'approved' | 'delivered'
       complete?: boolean
     }
-    Category: { id?: number; name?: string }
+    Category: {
+      id?: number
+      name?: string
+    }
     User: {
       id?: number
       username?: string
@@ -380,7 +385,10 @@ export interface components {
       /** User Status */
       userStatus?: number
     }
-    Tag: { id?: number; name?: string }
+    Tag: {
+      id?: number
+      name?: string
+    }
     Pet: {
       id?: number
       category?: components['schemas']['Category']
@@ -390,6 +398,10 @@ export interface components {
       /** pet status in the store */
       status?: 'available' | 'pending' | 'sold'
     }
-    ApiResponse: { code?: number; type?: string; message?: string }
+    ApiResponse: {
+      code?: number
+      type?: string
+      message?: string
+    }
   }
 }

--- a/tests/bin/expected/prettier-json.ts
+++ b/tests/bin/expected/prettier-json.ts
@@ -144,7 +144,8 @@ export interface operations {
     }
     requestBody: {
       'application/x-www-form-urlencoded': {
-        /** Updated name of the pet */ name?: string
+        /** Updated name of the pet */
+        name?: string
         /** Updated status of the pet */
         status?: string
       }
@@ -180,7 +181,8 @@ export interface operations {
     }
     requestBody: {
       'multipart/form-data': {
-        /** Additional data to pass to server */ additionalMetadata?: string
+        /** Additional data to pass to server */
+        additionalMetadata?: string
         /** file to upload */
         file?: string
       }
@@ -368,7 +370,10 @@ export interface components {
       status?: 'placed' | 'approved' | 'delivered'
       complete?: boolean
     }
-    Category: { id?: number; name?: string }
+    Category: {
+      id?: number
+      name?: string
+    }
     User: {
       id?: number
       username?: string
@@ -380,7 +385,10 @@ export interface components {
       /** User Status */
       userStatus?: number
     }
-    Tag: { id?: number; name?: string }
+    Tag: {
+      id?: number
+      name?: string
+    }
     Pet: {
       id?: number
       category?: components['schemas']['Category']
@@ -390,6 +398,10 @@ export interface components {
       /** pet status in the store */
       status?: 'available' | 'pending' | 'sold'
     }
-    ApiResponse: { code?: number; type?: string; message?: string }
+    ApiResponse: {
+      code?: number
+      type?: string
+      message?: string
+    }
   }
 }

--- a/tests/bin/expected/stdout.ts
+++ b/tests/bin/expected/stdout.ts
@@ -144,7 +144,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** Updated name of the pet */ name?: string;
+        /** Updated name of the pet */
+        name?: string;
         /** Updated status of the pet */
         status?: string;
       };
@@ -180,7 +181,8 @@ export interface operations {
     };
     requestBody: {
       "multipart/form-data": {
-        /** Additional data to pass to server */ additionalMetadata?: string;
+        /** Additional data to pass to server */
+        additionalMetadata?: string;
         /** file to upload */
         file?: string;
       };
@@ -368,7 +370,10 @@ export interface components {
       status?: "placed" | "approved" | "delivered";
       complete?: boolean;
     };
-    Category: { id?: number; name?: string };
+    Category: {
+      id?: number;
+      name?: string;
+    };
     User: {
       id?: number;
       username?: string;
@@ -380,7 +385,10 @@ export interface components {
       /** User Status */
       userStatus?: number;
     };
-    Tag: { id?: number; name?: string };
+    Tag: {
+      id?: number;
+      name?: string;
+    };
     Pet: {
       id?: number;
       category?: components["schemas"]["Category"];
@@ -390,6 +398,10 @@ export interface components {
       /** pet status in the store */
       status?: "available" | "pending" | "sold";
     };
-    ApiResponse: { code?: number; type?: string; message?: string };
+    ApiResponse: {
+      code?: number;
+      type?: string;
+      message?: string;
+    };
   };
 }

--- a/tests/v2/expected/http.ts
+++ b/tests/v2/expected/http.ts
@@ -50,8 +50,12 @@ export interface definitions {
     version: 1;
     body: definitions["RegionBody"];
   };
-  CreateRegion: { body: definitions["RegionBody"] };
-  UpdateRegion: { name: string };
+  CreateRegion: {
+    body: definitions["RegionBody"];
+  };
+  UpdateRegion: {
+    name: string;
+  };
   ProviderBody: {
     owner_id?: definitions["OptionalFlexID"];
     team_id?: definitions["OptionalID"];
@@ -76,7 +80,9 @@ export interface definitions {
     type: "provider";
     body: definitions["ProviderBody"];
   };
-  CreateProvider: { body: definitions["ProviderBody"] };
+  CreateProvider: {
+    body: definitions["ProviderBody"];
+  };
   UpdateProvider: {
     id: definitions["ID"];
     body: definitions["UpdateProviderBody"];
@@ -121,7 +127,10 @@ export interface definitions {
     platform_ids?: definitions["ID"][];
     tags?: definitions["ProductTags"];
   };
-  UpdatePlan: { id: definitions["ID"]; body: definitions["UpdatePlanBody"] };
+  UpdatePlan: {
+    id: definitions["ID"];
+    body: definitions["UpdatePlanBody"];
+  };
   UpdatePlanBody: {
     name?: definitions["Name"];
     label?: definitions["Label"];
@@ -254,7 +263,8 @@ export interface definitions {
     value: definitions["FeatureValueLabel"];
   };
   ValueProp: {
-    /** Heading of a value proposition. */ header: string;
+    /** Heading of a value proposition. */
+    header: string;
     /** Body of a value proposition. */
     body: string;
   };
@@ -369,7 +379,10 @@ export interface definitions {
      * URL to this Product's Terms of Service. If provided is true, then
      * a url must be set. Otherwise, provided is false.
      */
-    terms: { url?: string; provided: boolean };
+    terms: {
+      url?: string;
+      provided: boolean;
+    };
     feature_types: definitions["FeatureType"][];
     billing: {
       type: "monthly-prorated" | "monthly-anniversary" | "annual-anniversary";
@@ -390,7 +403,9 @@ export interface definitions {
     type: "product";
     body: definitions["ProductBody"];
   };
-  CreateProduct: { body: definitions["ProductBody"] };
+  CreateProduct: {
+    body: definitions["ProductBody"];
+  };
   /** Array of Plan IDs that this Plan can be resized to, if null all will be assumed */
   PlanResizeList: definitions["ID"][];
   PlanBody: {
@@ -441,10 +456,13 @@ export interface definitions {
     type: "plan";
     body: definitions["ExpandedPlanBody"];
   };
-  CreatePlan: { body: definitions["PlanBody"] };
+  CreatePlan: {
+    body: definitions["PlanBody"];
+  };
   /** Unexpected error */
   Error: {
-    /** The error type */ type: string;
+    /** The error type */
+    type: string;
     /** Explanation of the errors */
     message: string[];
   };

--- a/tests/v2/expected/manifold.ts
+++ b/tests/v2/expected/manifold.ts
@@ -50,8 +50,12 @@ export interface definitions {
     version: 1;
     body: definitions["RegionBody"];
   };
-  CreateRegion: { body: definitions["RegionBody"] };
-  UpdateRegion: { name: string };
+  CreateRegion: {
+    body: definitions["RegionBody"];
+  };
+  UpdateRegion: {
+    name: string;
+  };
   ProviderBody: {
     owner_id?: definitions["OptionalFlexID"];
     team_id?: definitions["OptionalID"];
@@ -76,7 +80,9 @@ export interface definitions {
     type: "provider";
     body: definitions["ProviderBody"];
   };
-  CreateProvider: { body: definitions["ProviderBody"] };
+  CreateProvider: {
+    body: definitions["ProviderBody"];
+  };
   UpdateProvider: {
     id: definitions["ID"];
     body: definitions["UpdateProviderBody"];
@@ -121,7 +127,10 @@ export interface definitions {
     platform_ids?: definitions["ID"][];
     tags?: definitions["ProductTags"];
   };
-  UpdatePlan: { id: definitions["ID"]; body: definitions["UpdatePlanBody"] };
+  UpdatePlan: {
+    id: definitions["ID"];
+    body: definitions["UpdatePlanBody"];
+  };
   UpdatePlanBody: {
     name?: definitions["Name"];
     label?: definitions["Label"];
@@ -254,7 +263,8 @@ export interface definitions {
     value: definitions["FeatureValueLabel"];
   };
   ValueProp: {
-    /** Heading of a value proposition. */ header: string;
+    /** Heading of a value proposition. */
+    header: string;
     /** Body of a value proposition. */
     body: string;
   };
@@ -369,7 +379,10 @@ export interface definitions {
      * URL to this Product's Terms of Service. If provided is true, then
      * a url must be set. Otherwise, provided is false.
      */
-    terms: { url?: string; provided: boolean };
+    terms: {
+      url?: string;
+      provided: boolean;
+    };
     feature_types: definitions["FeatureType"][];
     billing: {
       type: "monthly-prorated" | "monthly-anniversary" | "annual-anniversary";
@@ -390,7 +403,9 @@ export interface definitions {
     type: "product";
     body: definitions["ProductBody"];
   };
-  CreateProduct: { body: definitions["ProductBody"] };
+  CreateProduct: {
+    body: definitions["ProductBody"];
+  };
   /** Array of Plan IDs that this Plan can be resized to, if null all will be assumed */
   PlanResizeList: definitions["ID"][];
   PlanBody: {
@@ -441,10 +456,13 @@ export interface definitions {
     type: "plan";
     body: definitions["ExpandedPlanBody"];
   };
-  CreatePlan: { body: definitions["PlanBody"] };
+  CreatePlan: {
+    body: definitions["PlanBody"];
+  };
   /** Unexpected error */
   Error: {
-    /** The error type */ type: string;
+    /** The error type */
+    type: string;
     /** Explanation of the errors */
     message: string[];
   };

--- a/tests/v2/expected/petstore.ts
+++ b/tests/v2/expected/petstore.ts
@@ -13,7 +13,10 @@ export interface definitions {
     status?: "placed" | "approved" | "delivered";
     complete?: boolean;
   };
-  Category: { id?: number; name?: string };
+  Category: {
+    id?: number;
+    name?: string;
+  };
   User: {
     id?: number;
     username?: string;
@@ -25,7 +28,10 @@ export interface definitions {
     /** User Status */
     userStatus?: number;
   };
-  Tag: { id?: number; name?: string };
+  Tag: {
+    id?: number;
+    name?: string;
+  };
   Pet: {
     id?: number;
     category?: definitions["Category"];
@@ -35,5 +41,9 @@ export interface definitions {
     /** pet status in the store */
     status?: "available" | "pending" | "sold";
   };
-  ApiResponse: { code?: number; type?: string; message?: string };
+  ApiResponse: {
+    code?: number;
+    type?: string;
+    message?: string;
+  };
 }

--- a/tests/v2/expected/stripe.ts
+++ b/tests/v2/expected/stripe.ts
@@ -245,7 +245,8 @@ export interface definitions {
     user_agent?: string;
   };
   address: {
-    /** City, district, suburb, town, or village. */ city?: string;
+    /** City, district, suburb, town, or village. */
+    city?: string;
     /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
     country?: string;
     /** Address line 1 (e.g., street, PO Box, or company name). */
@@ -284,7 +285,8 @@ export interface definitions {
     username: string;
   };
   api_errors: {
-    /** For card errors, the ID of the failed charge. */ charge?: string;
+    /** For card errors, the ID of the failed charge. */
+    charge?: string;
     /** For some errors that could be handled programmatically, a short string indicating the [error code](https://stripe.com/docs/error-codes) reported. */
     code?: string;
     /** For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://stripe.com/docs/declines#issuer-declines) if they provide one. */
@@ -321,14 +323,16 @@ export interface definitions {
     object: "apple_pay_domain";
   };
   application: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** The name of the application. */
     name?: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "application";
   };
   application_fee: {
-    /** ID of the Stripe account this fee was taken from. */ account: string;
+    /** ID of the Stripe account this fee was taken from. */
+    account: string;
     /** Amount earned, in %s. */
     amount: number;
     /** Amount in %s refunded (can be less than the amount attribute on the fee if a partial refund was issued) */
@@ -355,7 +359,8 @@ export interface definitions {
     refunded: boolean;
     /** A list of refunds that have been applied to the fee. */
     refunds: {
-      /** Details about each object. */ data: definitions["fee_refund"][];
+      /** Details about each object. */
+      data: definitions["fee_refund"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -390,13 +395,15 @@ export interface definitions {
     pending: definitions["balance_amount"][];
   };
   balance_amount: {
-    /** Balance amount. */ amount: number;
+    /** Balance amount. */
+    amount: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
     currency: string;
     source_types?: definitions["balance_amount_by_source_type"];
   };
   balance_amount_by_source_type: {
-    /** Amount for bank account. */ bank_account?: number;
+    /** Amount for bank account. */
+    bank_account?: number;
     /** Amount for card. */
     card?: number;
     /** Amount for FPX. */
@@ -409,7 +416,8 @@ export interface definitions {
    * Related guide: [Balance Transaction Types](https://stripe.com/docs/reports/balance-transaction-types).
    */
   balance_transaction: {
-    /** Gross amount of the transaction, in %s. */ amount: number;
+    /** Gross amount of the transaction, in %s. */
+    amount: number;
     /** The date the transaction's net funds will become available in the Stripe balance. */
     available_on: number;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -775,7 +783,8 @@ export interface definitions {
     refunded: boolean;
     /** A list of refunds that have been applied to the charge. */
     refunds: {
-      /** Details about each object. */ data: definitions["refund"][];
+      /** Details about each object. */
+      data: definitions["refund"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -934,14 +943,16 @@ export interface definitions {
     success_url: string;
   };
   checkout_session_custom_display_item_description: {
-    /** The description of the line item. */ description?: string;
+    /** The description of the line item. */
+    description?: string;
     /** The images of the line item. */
     images?: string[];
     /** The name of the line item. */
     name: string;
   };
   checkout_session_display_item: {
-    /** Amount for the display item. */ amount?: number;
+    /** Amount for the display item. */
+    amount?: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
     currency?: string;
     custom?: definitions["checkout_session_custom_display_item_description"];
@@ -953,7 +964,8 @@ export interface definitions {
     type?: string;
   };
   connect_collection_transfer: {
-    /** Amount transferred, in %s. */ amount: number;
+    /** Amount transferred, in %s. */
+    amount: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
     currency: string;
     /** ID of the account that funds are being collected for. */
@@ -1134,7 +1146,8 @@ export interface definitions {
     unit_amount_decimal?: string;
   };
   credit_note_tax_amount: {
-    /** The amount, in %s, of the tax. */ amount: number;
+    /** The amount, in %s, of the tax. */
+    amount: number;
     /** Whether this tax amount is inclusive or exclusive. */
     inclusive: boolean;
     /** The tax rate that was applied to get this tax amount. */
@@ -1191,7 +1204,8 @@ export interface definitions {
     shipping?: definitions["shipping"];
     /** The customer's payment sources, if any. */
     sources: {
-      /** Details about each object. */ data: definitions["alipay_account"][];
+      /** Details about each object. */
+      data: definitions["alipay_account"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -1201,7 +1215,8 @@ export interface definitions {
     };
     /** The customer's current subscriptions, if any. */
     subscriptions?: {
-      /** Details about each object. */ data: definitions["subscription"][];
+      /** Details about each object. */
+      data: definitions["subscription"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -1213,7 +1228,8 @@ export interface definitions {
     tax_exempt?: "exempt" | "none" | "reverse";
     /** The customer's tax IDs. */
     tax_ids?: {
-      /** Details about each object. */ data: definitions["tax_id"][];
+      /** Details about each object. */
+      data: definitions["tax_id"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -1276,21 +1292,24 @@ export interface definitions {
       | "unspent_receiver_credit";
   };
   deleted_account: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "account";
   };
   deleted_alipay_account: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "alipay_account";
   };
   deleted_apple_pay_domain: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -1307,7 +1326,8 @@ export interface definitions {
     object: "bank_account";
   };
   deleted_bitcoin_receiver: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -1324,21 +1344,24 @@ export interface definitions {
     object: "card";
   };
   deleted_coupon: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "coupon";
   };
   deleted_customer: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "customer";
   };
   deleted_discount: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "discount";
   };
@@ -1353,105 +1376,120 @@ export interface definitions {
     object: "bank_account";
   };
   deleted_invoice: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "invoice";
   };
   deleted_invoiceitem: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "invoiceitem";
   };
   deleted_payment_source: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "alipay_account";
   };
   deleted_person: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "person";
   };
   deleted_plan: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "plan";
   };
   deleted_product: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "product";
   };
   "deleted_radar.value_list": {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "radar.value_list";
   };
   "deleted_radar.value_list_item": {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "radar.value_list_item";
   };
   deleted_recipient: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "recipient";
   };
   deleted_sku: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "sku";
   };
   deleted_subscription_item: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "subscription_item";
   };
   deleted_tax_id: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "tax_id";
   };
   "deleted_terminal.location": {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "terminal.location";
   };
   "deleted_terminal.reader": {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "terminal.reader";
   };
   deleted_webhook_endpoint: {
-    /** Always true for a deleted object */ deleted: true;
+    /** Always true for a deleted object */
+    deleted: true;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -1615,7 +1653,9 @@ export interface definitions {
     secret?: string;
   };
   /** An error response from the Stripe API */
-  error: { error: definitions["api_errors"] };
+  error: {
+    error: definitions["api_errors"];
+  };
   /**
    * Events are our way of letting you know when something interesting happens in
    * your account. When an interesting event occurs, we create a new `Event`
@@ -1648,7 +1688,8 @@ export interface definitions {
    * guaranteed only for 30 days.
    */
   event: {
-    /** The connected account that originated the event. */ account?: string;
+    /** The connected account that originated the event. */
+    account?: string;
     /** The Stripe API version used to render `data`. *Note: This property is populated only for events on or after October 31, 2014*. */
     api_version?: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -1710,7 +1751,8 @@ export interface definitions {
     object: "bank_account";
   };
   fee: {
-    /** Amount of the fee, in cents. */ amount: number;
+    /** Amount of the fee, in cents. */
+    amount: number;
     /** ID of the Connect application that earned the fee. */
     application?: string;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -1728,7 +1770,8 @@ export interface definitions {
    * Related guide: [Refunding Application Fees](https://stripe.com/docs/connect/destination-charges#refunding-app-fee).
    */
   fee_refund: {
-    /** Amount, in %s. */ amount: number;
+    /** Amount, in %s. */
+    amount: number;
     /** Balance transaction that describes the impact on your account balance. */
     balance_transaction?: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -1762,7 +1805,8 @@ export interface definitions {
     id: string;
     /** A list of [file links](https://stripe.com/docs/api#file_links) that point at this file. */
     links?: {
-      /** Details about each object. */ data: definitions["file_link"][];
+      /** Details about each object. */
+      data: definitions["file_link"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -1944,7 +1988,8 @@ export interface definitions {
     invoice_pdf?: string;
     /** The individual line items that make up the invoice. `lines` is sorted as follows: invoice items in reverse chronological order, followed by the subscription, if any. */
     lines: {
-      /** Details about each object. */ data: definitions["line_item"][];
+      /** Details about each object. */
+      data: definitions["line_item"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -2008,12 +2053,14 @@ export interface definitions {
     usage_gte: number;
   };
   invoice_line_item_period: {
-    /** End of the line item's billing period */ end: number;
+    /** End of the line item's billing period */
+    end: number;
     /** Start of the line item's billing period */
     start: number;
   };
   invoice_setting_custom_field: {
-    /** The name of the custom field. */ name: string;
+    /** The name of the custom field. */
+    name: string;
     /** The value of the custom field. */
     value: string;
   };
@@ -2030,7 +2077,8 @@ export interface definitions {
     days_until_due?: number;
   };
   invoice_tax_amount: {
-    /** The amount, in %s, of the tax. */ amount: number;
+    /** The amount, in %s, of the tax. */
+    amount: number;
     /** Whether this tax amount is inclusive or exclusive. */
     inclusive: boolean;
     /** The tax rate that was applied to get this tax amount. */
@@ -2122,7 +2170,8 @@ export interface definitions {
     value?: string;
   };
   invoices_status_transitions: {
-    /** The time that the invoice draft was finalized. */ finalized_at?: number;
+    /** The time that the invoice draft was finalized. */
+    finalized_at?: number;
     /** The time that the invoice was marked uncollectible. */
     marked_uncollectible_at?: number;
     /** The time that the invoice was paid. */
@@ -2209,7 +2258,8 @@ export interface definitions {
   };
   /** You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders. */
   "issuing.card": {
-    /** The brand of the card. */ brand: string;
+    /** The brand of the card. */
+    brand: string;
     /** The reason why the card was canceled. */
     cancellation_reason?: "lost" | "stolen";
     cardholder: definitions["issuing.cardholder"];
@@ -2286,7 +2336,8 @@ export interface definitions {
    * Related guide: [Disputing Transactions](https://stripe.com/docs/issuing/purchases/disputes)
    */
   "issuing.dispute": {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -3046,7 +3097,8 @@ export interface definitions {
     type: "bulk" | "individual";
   };
   issuing_card_spending_limit: {
-    /** Maximum amount allowed to spend per time interval. */ amount: number;
+    /** Maximum amount allowed to spend per time interval. */
+    amount: number;
     /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges. */
     categories?: (
       | "ac_refrigeration_repair"
@@ -3347,7 +3399,9 @@ export interface definitions {
       | "weekly"
       | "yearly";
   };
-  issuing_cardholder_address: { address: definitions["address"] };
+  issuing_cardholder_address: {
+    address: definitions["address"];
+  };
   issuing_cardholder_authorization_controls: {
     /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this cardholder's cards. */
     allowed_categories?: (
@@ -3955,7 +4009,8 @@ export interface definitions {
     verification?: definitions["issuing_cardholder_verification"];
   };
   issuing_cardholder_individual_dob: {
-    /** The day of birth, between 1 and 31. */ day?: number;
+    /** The day of birth, between 1 and 31. */
+    day?: number;
     /** The month of birth, between 1 and 12. */
     month?: number;
     /** The four-digit year of birth. */
@@ -3976,7 +4031,8 @@ export interface definitions {
     )[];
   };
   issuing_cardholder_spending_limit: {
-    /** Maximum amount allowed to spend per time interval. */ amount: number;
+    /** Maximum amount allowed to spend per time interval. */
+    amount: number;
     /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges. */
     categories?: (
       | "ac_refrigeration_repair"
@@ -4337,14 +4393,16 @@ export interface definitions {
     front?: string;
   };
   legal_entity_dob: {
-    /** The day of birth, between 1 and 31. */ day?: number;
+    /** The day of birth, between 1 and 31. */
+    day?: number;
     /** The month of birth, between 1 and 12. */
     month?: number;
     /** The four-digit year of birth. */
     year?: number;
   };
   legal_entity_japan_address: {
-    /** City/Ward. */ city?: string;
+    /** City/Ward. */
+    city?: string;
     /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
     country?: string;
     /** Block/Building number. */
@@ -4380,7 +4438,8 @@ export interface definitions {
   };
   light_account_logout: { [key: string]: any };
   line_item: {
-    /** The amount, in %s. */ amount: number;
+    /** The amount, in %s. */
+    amount: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
     currency: string;
     /** An arbitrary string attached to the object. Often useful for displaying to users. */
@@ -4454,12 +4513,14 @@ export interface definitions {
     type: string;
   };
   mandate_sepa_debit: {
-    /** The unique reference of the mandate. */ reference: string;
+    /** The unique reference of the mandate. */
+    reference: string;
     /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
     url: string;
   };
   mandate_single_use: {
-    /** On a single use mandate, the amount of the payment. */ amount: number;
+    /** On a single use mandate, the amount of the payment. */
+    amount: number;
     /** On a single use mandate, the currency of the payment. */
     currency: string;
   };
@@ -4522,7 +4583,8 @@ export interface definitions {
     object: "order";
     /** A list of returns that have taken place for this order. */
     returns?: {
-      /** Details about each object. */ data: definitions["order_return"][];
+      /** Details about each object. */
+      data: definitions["order_return"][];
       /** True if this list has another page of items after this one that can be fetched. */
       has_more: boolean;
       /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
@@ -4592,7 +4654,8 @@ export interface definitions {
     refund?: string;
   };
   package_dimensions: {
-    /** Height, in inches. */ height: number;
+    /** Height, in inches. */
+    height: number;
     /** Length, in inches. */
     length: number;
     /** Weight, in ounces. */
@@ -4808,7 +4871,8 @@ export interface definitions {
     cvc_check?: string;
   };
   payment_method_card_generated_card: {
-    /** The charge that created this object. */ charge?: string;
+    /** The charge that created this object. */
+    charge?: string;
     payment_method_details?: definitions["payment_method_details"];
   };
   payment_method_card_present: { [key: string]: any };
@@ -4877,7 +4941,8 @@ export interface definitions {
     wechat?: definitions["payment_method_details_wechat"];
   };
   payment_method_details_ach_credit_transfer: {
-    /** Account number to transfer funds to. */ account_number?: string;
+    /** Account number to transfer funds to. */
+    account_number?: string;
     /** Name of the bank associated with the routing number. */
     bank_name?: string;
     /** Routing transit number for the bank account to transfer funds to. */
@@ -4901,7 +4966,8 @@ export interface definitions {
   };
   payment_method_details_alipay: { [key: string]: any };
   payment_method_details_au_becs_debit: {
-    /** Bank-State-Branch number of the bank account. */ bsb_number?: string;
+    /** Bank-State-Branch number of the bank account. */
+    bsb_number?: string;
     /** Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same. */
     fingerprint?: string;
     /** Last four digits of the bank account number. */
@@ -5149,7 +5215,8 @@ export interface definitions {
     reference?: string;
   };
   payment_method_details_p24: {
-    /** Unique reference for this Przelewy24 payment. */ reference?: string;
+    /** Unique reference for this Przelewy24 payment. */
+    reference?: string;
     /**
      * Owner's verified full name. Values are verified or provided by Przelewy24 directly
      * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
@@ -5508,7 +5575,8 @@ export interface definitions {
     )[];
   };
   payment_source: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
     metadata?: { [key: string]: any };
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -5642,7 +5710,8 @@ export interface definitions {
    * Related guides: [Set up a subscription](https://stripe.com/docs/billing/subscriptions/set-up-subscription) and more about [products and plans](https://stripe.com/docs/billing/subscriptions/products-and-plans).
    */
   plan: {
-    /** Whether the plan can be used for new purchases. */ active: boolean;
+    /** Whether the plan can be used for new purchases. */
+    active: boolean;
     /** Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`. */
     aggregate_usage?: "last_during_period" | "last_ever" | "max" | "sum";
     /** The amount in %s to be charged on the interval specified. */
@@ -5682,7 +5751,8 @@ export interface definitions {
     usage_type: "licensed" | "metered";
   };
   plan_tier: {
-    /** Price for the entire tier. */ flat_amount?: number;
+    /** Price for the entire tier. */
+    flat_amount?: number;
     /** Same as `flat_amount`, but contains a decimal value with at most 12 decimal places. */
     flat_amount_decimal?: string;
     /** Per unit price for units relevant to the tier. */
@@ -5693,7 +5763,8 @@ export interface definitions {
     up_to?: number;
   };
   platform_tax_fee: {
-    /** The Connected account that incurred this charge. */ account: string;
+    /** The Connected account that incurred this charge. */
+    account: string;
     /** Unique identifier for the object. */
     id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -5780,7 +5851,8 @@ export interface definitions {
    * Related guide: [Default Stripe Lists](https://stripe.com/docs/radar/lists#managing-list-items).
    */
   "radar.value_list": {
-    /** The name of the value list for use in rules. */ alias: string;
+    /** The name of the value list for use in rules. */
+    alias: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
     created: number;
     /** The name or email address of the user who created this value list. */
@@ -5838,7 +5910,8 @@ export interface definitions {
     value_list: string;
   };
   radar_review_resource_location: {
-    /** The city where the payment originated. */ city?: string;
+    /** The city where the payment originated. */
+    city?: string;
     /** Two-letter ISO code representing the country where the payment originated. */
     country?: string;
     /** The geographic latitude where the payment originated. */
@@ -5913,7 +5986,8 @@ export interface definitions {
    * Related guide: [Refunds](https://stripe.com/docs/refunds).
    */
   refund: {
-    /** Amount, in %s. */ amount: number;
+    /** Amount, in %s. */
+    amount: number;
     /** Balance transaction that describes the impact on your account balance. */
     balance_transaction?: string;
     /** ID of the charge that was refunded. */
@@ -6063,7 +6137,8 @@ export interface definitions {
     session?: definitions["radar_review_resource_session"];
   };
   rule: {
-    /** The action taken on the payment. */ action: string;
+    /** The action taken on the payment. */
+    action: string;
     /** Unique identifier for the object. */
     id: string;
     /** The predicate to evaluate the payment against. */
@@ -6221,7 +6296,8 @@ export interface definitions {
     id: string;
   };
   sigma_scheduled_query_run_error: {
-    /** Information about the run failure. */ message: string;
+    /** Information about the run failure. */
+    message: string;
   };
   /**
    * Stores representations of [stock keeping units](http://en.wikipedia.org/wiki/Stock_keeping_unit).
@@ -6234,7 +6310,8 @@ export interface definitions {
    * Related guide: [Tax, Shipping, and Inventory](https://stripe.com/docs/orders).
    */
   sku: {
-    /** Whether the SKU is available for purchase. */ active: boolean;
+    /** Whether the SKU is available for purchase. */
+    active: boolean;
     /** A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`. */
     attributes: { [key: string]: any };
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -6374,7 +6451,8 @@ export interface definitions {
     last4?: string;
   };
   source_mandate_notification_sepa_debit_data: {
-    /** SEPA creditor ID. */ creditor_identifier?: string;
+    /** SEPA creditor ID. */
+    creditor_identifier?: string;
     /** Last 4 digits of the account number associated with the debit. */
     last4?: string;
     /** Mandate reference associated with the debit. */
@@ -6392,7 +6470,8 @@ export interface definitions {
     shipping?: definitions["shipping"];
   };
   source_order_item: {
-    /** The amount (price) for this order item. */ amount?: number;
+    /** The amount (price) for this order item. */
+    amount?: number;
     /** This currency of this order item. Required when `amount` is present. */
     currency?: string;
     /** Human-readable description for this order item. */
@@ -6490,7 +6569,8 @@ export interface definitions {
       | "wechat";
   };
   source_transaction_ach_credit_transfer_data: {
-    /** Customer data associated with the transfer. */ customer_data?: string;
+    /** Customer data associated with the transfer. */
+    customer_data?: string;
     /** Bank account fingerprint associated with the transfer. */
     fingerprint?: string;
     /** Last 4 digits of the account number associated with the transfer. */
@@ -6499,7 +6579,8 @@ export interface definitions {
     routing_number?: string;
   };
   source_transaction_chf_credit_transfer_data: {
-    /** Reference associated with the transfer. */ reference?: string;
+    /** Reference associated with the transfer. */
+    reference?: string;
     /** Sender's country address. */
     sender_address_country?: string;
     /** Sender's line 1 address. */
@@ -6532,7 +6613,8 @@ export interface definitions {
     invoices?: string;
   };
   source_transaction_sepa_credit_transfer_data: {
-    /** Reference associated with the transfer. */ reference?: string;
+    /** Reference associated with the transfer. */
+    reference?: string;
     /** Sender's bank account IBAN. */
     sender_iban?: string;
     /** Sender's name. */
@@ -6615,7 +6697,10 @@ export interface definitions {
     terminal_verification_results?: string;
     transaction_status_information?: string;
   };
-  source_type_eps: { reference?: string; statement_descriptor?: string };
+  source_type_eps: {
+    reference?: string;
+    statement_descriptor?: string;
+  };
   source_type_giropay: {
     bank_code?: string;
     bank_name?: string;
@@ -6667,7 +6752,9 @@ export interface definitions {
     refund_account_holder_name?: string;
     refund_iban?: string;
   };
-  source_type_p24: { reference?: string };
+  source_type_p24: {
+    reference?: string;
+  };
   source_type_sepa_debit: {
     bank_code?: string;
     branch_code?: string;
@@ -6711,7 +6798,8 @@ export interface definitions {
     statement_descriptor?: string;
   };
   status_transitions: {
-    /** The time that the order was canceled. */ canceled?: number;
+    /** The time that the order was canceled. */
+    canceled?: number;
     /** The time that the order was fulfilled. */
     fulfiled?: number;
     /** The time that the order was paid. */
@@ -6904,7 +6992,8 @@ export interface definitions {
     tax_rates?: definitions["tax_rate"][];
   };
   subscription_schedule_current_phase: {
-    /** The end of this phase of the subscription schedule. */ end_date: number;
+    /** The end of this phase of the subscription schedule. */
+    end_date: number;
     /** The start of this phase of the subscription schedule. */
     start_date: number;
   };
@@ -6970,7 +7059,8 @@ export interface definitions {
     trial_from_plan?: boolean;
   };
   tax_deducted_at_source: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "tax_deducted_at_source";
     /** The end of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period. */
@@ -7161,7 +7251,8 @@ export interface definitions {
     version: string;
   };
   three_d_secure_usage: {
-    /** Whether 3D Secure is supported on this card. */ supported: boolean;
+    /** Whether 3D Secure is supported on this card. */
+    supported: boolean;
   };
   /**
    * Tokenization is the process Stripe uses to collect sensitive card or bank
@@ -7213,7 +7304,8 @@ export interface definitions {
    * Related guide: [Topping Up your Platform Account](https://stripe.com/docs/connect/top-ups).
    */
   topup: {
-    /** Amount transferred. */ amount: number;
+    /** Amount transferred. */
+    amount: number;
     /** ID of the balance transaction that describes the impact of this top-up on your account balance. May not be specified depending on status of top-up. */
     balance_transaction?: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -7257,7 +7349,8 @@ export interface definitions {
    * Related guide: [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers).
    */
   transfer: {
-    /** Amount in %s to be transferred. */ amount: number;
+    /** Amount in %s to be transferred. */
+    amount: number;
     /** Amount in %s reversed (can be less than the amount attribute on the transfer if a partial reversal was issued). */
     amount_reversed: number;
     /** Balance transaction that describes the impact of this transfer on your account balance. */
@@ -7326,7 +7419,8 @@ export interface definitions {
    * Related guide: [Reversing Transfers](https://stripe.com/docs/connect/charges-transfers#reversing-transfers).
    */
   transfer_reversal: {
-    /** Amount, in %s. */ amount: number;
+    /** Amount, in %s. */
+    amount: number;
     /** Balance transaction that describes the impact on your account balance. */
     balance_transaction?: string;
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -7357,7 +7451,8 @@ export interface definitions {
     weekly_anchor?: string;
   };
   transform_usage: {
-    /** Divide usage by this number. */ divide_by: number;
+    /** Divide usage by this number. */
+    divide_by: number;
     /** After division, either round the result `up` or `down`. */
     round: "down" | "up";
   };
@@ -7368,7 +7463,8 @@ export interface definitions {
    * Related guide: [Metered Billing](https://stripe.com/docs/billing/subscriptions/metered-billing).
    */
   usage_record: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -7381,7 +7477,8 @@ export interface definitions {
     timestamp: number;
   };
   usage_record_summary: {
-    /** Unique identifier for the object. */ id: string;
+    /** Unique identifier for the object. */
+    id: string;
     /** The invoice in which this usage period has been billed for. */
     invoice?: string;
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */

--- a/tests/v2/index.test.ts
+++ b/tests/v2/index.test.ts
@@ -120,7 +120,9 @@ describe("transformation", () => {
       expect(swaggerToTS(schema)).toBe(
         format(`
         export interface definitions {
-          object: { boolean?: boolean };
+          object: {
+            boolean?: boolean;
+          };
           boolean: boolean;
           boolean_ref: definitions['boolean'];
         }`)
@@ -161,10 +163,15 @@ describe("transformation", () => {
         export interface definitions {
           object: {
             object?: {
-              object?: { string?: string; number?: definitions['object_ref'] };
+              object?: {
+                string?: string;
+                number?: definitions['object_ref'];
+              };
             };
           };
-          object_ref: { number?: number };
+          object_ref: {
+            number?: number;
+          };
           object_unknown: { [key: string]: any };
           object_empty: { [key: string]: any };
         }`)
@@ -226,7 +233,9 @@ describe("transformation", () => {
       expect(swaggerToTS(schema)).toBe(
         format(`
         export interface definitions {
-          union: { string?: 'Totoro' | 'Sats\\'uki' | 'Mei' }
+          union: {
+            string?: 'Totoro' | 'Sats\\'uki' | 'Mei';
+          }
         }`)
       );
     });
@@ -252,8 +261,14 @@ describe("transformation", () => {
       expect(swaggerToTS(schema)).toBe(
         format(`
         export interface definitions {
-          additional_properties: { number?: number; [key: string]: any };
-          additional_properties_string: { string?: string; [key: string]: string };
+          additional_properties: {
+            number?: number;
+            [key: string]: any;
+          };
+          additional_properties_string: {
+            string?: string;
+            [key: string]: string;
+          };
         }`)
       );
     });
@@ -284,8 +299,13 @@ describe("transformation", () => {
       expect(swaggerToTS(schema)).toBe(
         format(`
         export interface definitions {
-          Messages: { [key: string]: definitions["Message"] }
-          Message: { code?: number; text?: string }
+          Messages: {
+            [key: string]:definitions["Message"];
+          }
+          Message: {
+            code?: number;
+            text?: string;
+          }
         }`)
       );
     });
@@ -311,8 +331,15 @@ describe("transformation", () => {
       expect(swaggerToTS(schema)).toBe(
         format(`
         export interface definitions {
-          base: { boolean?: boolean; number?: number };
-          all_of: definitions['base'] & { string?: string } & { password?: string };
+          base: {
+            boolean?: boolean;
+            number?: number;
+          };
+          all_of: definitions['base'] & {
+            string?: string;
+          } & {
+            password?: string;
+          };
         }`)
       );
     });
@@ -334,7 +361,10 @@ describe("transformation", () => {
       expect(swaggerToTS(schema)).toBe(
         format(`
         export interface definitions {
-          required: { required: string; optional?: boolean  }
+          required: {
+            required: string;
+            optional?: boolean;
+          }
         }`)
       );
     });
@@ -405,7 +435,10 @@ describe("transformation", () => {
       expect(swaggerToTS(schema, { propertyMapper })).toBe(
         format(`
         export interface definitions {
-          Name: { first?: string; last: string }
+          Name: {
+            first?: string;
+            last: string;
+          }
         }`)
       );
     });

--- a/tests/v3/expected/github.ts
+++ b/tests/v3/expected/github.ts
@@ -1947,7 +1947,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The access_token of the OAuth application. */ access_token: string;
+        /** The access_token of the OAuth application. */
+        access_token: string;
       };
     };
     responses: {
@@ -1968,7 +1969,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The access_token of the OAuth application. */ access_token: string;
+        /** The access_token of the OAuth application. */
+        access_token: string;
       };
     };
     responses: {
@@ -2334,7 +2336,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The title of the attachment */ title: string;
+        /** The title of the attachment */
+        title: string;
         /** The body of the attachment */
         body: string;
       };
@@ -2559,7 +2562,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Name of the runner group. */ name: string;
+        /** Name of the runner group. */
+        name: string;
         /** Visibility of a runner group. You can select all organizations or select individual organization. Can be one of: `all` or `selected` */
         visibility?: "selected" | "all";
         /** List of organization IDs that can access the runner group. */
@@ -2608,7 +2612,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Name of the runner group. */ name?: string;
+        /** Name of the runner group. */
+        name?: string;
         /** Visibility of a runner group. You can select all organizations or select individual organizations. Can be one of: `all` or `selected` */
         visibility?: "selected" | "all";
       };
@@ -2762,7 +2767,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** List of runner IDs to add to the runner group. */ runners: number[];
+        /** List of runner IDs to add to the runner group. */
+        runners: number[];
       };
     };
     responses: {
@@ -3066,11 +3072,13 @@ export interface operations {
     parameters: {};
     requestBody: {
       "application/json": {
-        /** Description of the gist */ description?: string;
+        /** Description of the gist */
+        description?: string;
         /** Names and content for the files that make up the gist */
         files: {
           [key: string]: {
-            /** Content of the file */ content: string;
+            /** Content of the file */
+            content: string;
           };
         };
         public?: boolean | ("true" | "false");
@@ -3207,7 +3215,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The comment text. */ body: string;
+        /** The comment text. */
+        body: string;
       };
     };
     responses: {
@@ -3246,7 +3255,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The comment text. */ body: string;
+        /** The comment text. */
+        body: string;
       };
     };
     responses: {
@@ -3545,7 +3555,8 @@ export interface operations {
     parameters: {};
     requestBody: {
       "application/json": {
-        /** The Markdown text to render in HTML. */ text: string;
+        /** The Markdown text to render in HTML. */
+        text: string;
         /** The rendering mode. */
         mode?: "markdown" | "gfm";
         /** The repository context to use when creating references in `gfm` mode. */
@@ -3782,7 +3793,9 @@ export interface operations {
     responses: {
       /** response */
       202: {
-        "application/json": { message?: string };
+        "application/json": {
+          message?: string;
+        };
       };
       /** response */
       205: unknown;
@@ -4246,7 +4259,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Name of the runner group. */ name: string;
+        /** Name of the runner group. */
+        name: string;
         /** Visibility of a runner group. You can select all repositories, select individual repositories, or limit access to private repositories. Can be one of: `all`, `selected`, or `private`. */
         visibility?: "selected" | "all" | "private";
         /** List of repository IDs that can access the runner group. */
@@ -4299,7 +4313,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Name of the runner group. */ name?: string;
+        /** Name of the runner group. */
+        name?: string;
         /** Visibility of a runner group. You can select all repositories, select individual repositories, or all private repositories. Can be one of: `all`, `selected`, or `private`. */
         visibility?: "selected" | "all" | "private";
       };
@@ -4466,7 +4481,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** List of runner IDs to add to the runner group. */ runners: number[];
+        /** List of runner IDs to add to the runner group. */
+        runners: number[];
       };
     };
     responses: {
@@ -5025,7 +5041,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Must be passed as "web". */ name: string;
+        /** Must be passed as "web". */
+        name: string;
         /** Key/value pairs to provide settings for this webhook. [These are defined below](https://docs.github.com/rest/reference/orgs#create-hook-config-params). */
         config: {
           url: components["schemas"]["webhook-config-url"];
@@ -5691,7 +5708,10 @@ export interface operations {
       204: never;
       /** response */
       403: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
       404: components["responses"]["not_found"];
     };
@@ -5709,7 +5729,10 @@ export interface operations {
       204: never;
       /** Response if user is a member of the organization */
       422: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
     };
   };
@@ -5743,7 +5766,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the project. */ name: string;
+        /** The name of the project. */
+        name: string;
         /** The description of the project. */
         body?: string;
       };
@@ -5871,7 +5895,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the repository. */ name: string;
+        /** The name of the repository. */
+        name: string;
         /** A short description of the repository. */
         description?: string;
         /** A URL with more information about the repository. */
@@ -6034,7 +6059,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the team. */ name: string;
+        /** The name of the team. */
+        name: string;
         /** The description of the team. */
         description?: string;
         /** List GitHub IDs for organization members who will become team maintainers. */
@@ -6106,7 +6132,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the team. */ name: string;
+        /** The name of the team. */
+        name: string;
         /** The description of the team. */
         description?: string;
         /**
@@ -6195,7 +6222,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The discussion post's title. */ title: string;
+        /** The discussion post's title. */
+        title: string;
         /** The discussion post's body text. */
         body: string;
         /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
@@ -6244,7 +6272,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The discussion post's title. */ title?: string;
+        /** The discussion post's title. */
+        title?: string;
         /** The discussion post's body text. */
         body?: string;
       };
@@ -6316,7 +6345,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The discussion comment's body text. */ body: string;
+        /** The discussion comment's body text. */
+        body: string;
       };
     };
     responses: {
@@ -6363,7 +6393,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The discussion comment's body text. */ body: string;
+        /** The discussion comment's body text. */
+        body: string;
       };
     };
     responses: {
@@ -6690,7 +6721,11 @@ export interface operations {
       422: {
         "application/json": {
           message?: string;
-          errors?: { code?: string; field?: string; resource?: string }[];
+          errors?: {
+            code?: string;
+            field?: string;
+            resource?: string;
+          }[];
         };
       };
     };
@@ -6794,7 +6829,10 @@ export interface operations {
       204: never;
       /** Response if the project is not owned by the organization */
       403: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
     };
   };
@@ -6962,7 +7000,8 @@ export interface operations {
       "application/json": {
         /** The IdP groups you want to connect to a GitHub team. When updating, the new `groups` object will replace the original one. You must include any existing groups that you don't want to remove. */
         groups: {
-          /** ID of the IdP group. */ group_id: string;
+          /** ID of the IdP group. */
+          group_id: string;
           /** Name of the IdP group. */
           group_name: string;
           /** Description of the IdP group. */
@@ -7025,7 +7064,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The project card's note */ note?: string | null;
+        /** The project card's note */
+        note?: string | null;
         /** Whether or not the card is archived */
         archived?: boolean;
       };
@@ -7072,7 +7112,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The position of the card in a column */ position: string;
+        /** The position of the card in a column */
+        position: string;
         /** The unique identifier of the column the card should be moved to */
         column_id?: number;
       };
@@ -7104,7 +7145,10 @@ export interface operations {
           code?: string;
           message?: string;
           documentation_url?: string;
-          errors?: { code?: string; message?: string }[];
+          errors?: {
+            code?: string;
+            message?: string;
+          }[];
         };
       };
     };
@@ -7134,7 +7178,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Name of the project column */ name: string;
+        /** Name of the project column */
+        name: string;
       };
     };
     responses: {
@@ -7197,7 +7242,8 @@ export interface operations {
     requestBody: {
       "application/json":
         | {
-            /** The project card's note */ note: string | null;
+            /** The project card's note */
+            note: string | null;
           }
         | {
             /** The unique identifier of the content associated with the card */
@@ -7226,7 +7272,10 @@ export interface operations {
           code?: string;
           message?: string;
           documentation_url?: string;
-          errors?: { code?: string; message?: string }[];
+          errors?: {
+            code?: string;
+            message?: string;
+          }[];
         };
       };
     };
@@ -7239,7 +7288,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The position of the column in a project */ position: string;
+        /** The position of the column in a project */
+        position: string;
       };
     };
     responses: {
@@ -7279,7 +7329,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Name of the project */ name?: string;
+        /** Name of the project */
+        name?: string;
         /** Body of the project */
         body?: string | null;
         /** State of the project; either 'open' or 'closed' */
@@ -7459,7 +7510,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Name of the project column */ name: string;
+        /** Name of the project column */
+        name: string;
       };
     };
     responses: {
@@ -7542,7 +7594,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the repository. */ name?: string;
+        /** The name of the repository. */
+        name?: string;
         /** A short description of the repository. */
         description?: string;
         /** A URL with more information about the repository. */
@@ -7604,7 +7657,10 @@ export interface operations {
       204: never;
       /** If an organization owner has configured the organization to prevent members from deleting organization-owned repositories, a member will get this response: */
       403: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
       404: components["responses"]["not_found"];
     };
@@ -8629,7 +8685,8 @@ export interface operations {
         } | null;
         /** Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable. */
         restrictions: {
-          /** The list of user `login`s with push access */ users: string[];
+          /** The list of user `login`s with push access */
+          users: string[];
           /** The list of team `slug`s with push access */
           teams: string[];
           /** The list of app `slug`s with push access */
@@ -9400,7 +9457,8 @@ export interface operations {
         completed_at?: string;
         /** Check runs can accept a variety of data in the `output` object, including a `title` and `summary` and can optionally provide descriptive details about the run. See the [`output` object](https://docs.github.com/rest/reference/checks#output-object) description. */
         output?: {
-          /** The title of the check run. */ title: string;
+          /** The title of the check run. */
+          title: string;
           /** The summary of the check run. This parameter supports Markdown. */
           summary: string;
           /** The details of the check run. This parameter supports Markdown. */
@@ -9428,7 +9486,8 @@ export interface operations {
           }[];
           /** Adds images to the output displayed in the GitHub pull request UI. See the [`images` object](https://docs.github.com/rest/reference/checks#images-object) description for details. */
           images?: {
-            /** The alternative text for the image. */ alt: string;
+            /** The alternative text for the image. */
+            alt: string;
             /** The full URL of the image. */
             image_url: string;
             /** A short image description. */
@@ -9514,7 +9573,8 @@ export interface operations {
         completed_at?: string;
         /** Check runs can accept a variety of data in the `output` object, including a `title` and `summary` and can optionally provide descriptive details about the run. See the [`output` object](https://docs.github.com/rest/reference/checks#output-object-1) description. */
         output?: {
-          /** **Required**. */ title?: string;
+          /** **Required**. */
+          title?: string;
           /** Can contain Markdown. */
           summary: string;
           /** Can contain Markdown. */
@@ -9542,7 +9602,8 @@ export interface operations {
           }[];
           /** Adds images to the output displayed in the GitHub pull request UI. See the [`images` object](https://docs.github.com/rest/reference/checks#annotations-object-1) description for details. */
           images?: {
-            /** The alternative text for the image. */ alt: string;
+            /** The alternative text for the image. */
+            alt: string;
             /** The full URL of the image. */
             image_url: string;
             /** A short image description. */
@@ -9601,7 +9662,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The sha of the head commit. */ head_sha: string;
+        /** The sha of the head commit. */
+        head_sha: string;
       };
     };
     responses: {
@@ -9623,7 +9685,8 @@ export interface operations {
       "application/json": {
         /** Enables or disables automatic creation of CheckSuite events upon pushes to the repository. Enabled by default. See the [`auto_trigger_checks` object](https://docs.github.com/rest/reference/checks#auto_trigger_checks-object) description for details. */
         auto_trigger_checks?: {
-          /** The `id` of the GitHub App. */ app_id: number;
+          /** The `id` of the GitHub App. */
+          app_id: number;
           /** Set to `true` to enable automatic creation of CheckSuite events upon pushes to the repository, or `false` to disable them. */
           setting: boolean;
         }[];
@@ -10012,7 +10075,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The contents of the comment */ body: string;
+        /** The contents of the comment */
+        body: string;
       };
     };
     responses: {
@@ -10242,7 +10306,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The contents of the comment. */ body: string;
+        /** The contents of the comment. */
+        body: string;
         /** Relative path of the file to comment on. */
         path?: string;
         /** Line index in the diff to comment on. */
@@ -10620,7 +10685,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The commit message. */ message: string;
+        /** The commit message. */
+        message: string;
         /** The new file content, using Base64 encoding. */
         content: string;
         /** **Required if you are updating a file**. The blob SHA of the file being replaced. */
@@ -10679,7 +10745,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The commit message. */ message: string;
+        /** The commit message. */
+        message: string;
         /** The blob SHA of the file being replaced. */
         sha: string;
         /** The branch name. Default: the repository’s default branch (usually `master`) */
@@ -10857,11 +10924,16 @@ export interface operations {
       };
       /** Merged branch response */
       202: {
-        "application/json": { message?: string };
+        "application/json": {
+          message?: string;
+        };
       };
       /** response */
       409: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
       422: components["responses"]["validation_failed"];
     };
@@ -11021,7 +11093,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** A custom webhook event name. */ event_type: string;
+        /** A custom webhook event name. */
+        event_type: string;
         /** JSON payload with extra information about the webhook event that your action or worklow may use. */
         client_payload?: { [key: string]: any };
       };
@@ -11109,7 +11182,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The new blob's content. */ content: string;
+        /** The new blob's content. */
+        content: string;
         /** The encoding used for `content`. Currently, `"utf-8"` and `"base64"` are supported. */
         encoding?: string;
       };
@@ -11189,7 +11263,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The commit message */ message: string;
+        /** The commit message */
+        message: string;
         /** The SHA of the tree object this commit points to */
         tree: string;
         /** The SHAs of the commits that were the parents of this commit. If omitted or empty, the commit will be written as a root commit. For a single parent, an array of one SHA should be provided; for a merge commit, an array of more than one should be provided. */
@@ -11360,7 +11435,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The SHA1 value to set this reference to */ sha: string;
+        /** The SHA1 value to set this reference to */
+        sha: string;
         /** Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to `false` will make sure you're not overwriting work. */
         force?: boolean;
       };
@@ -11439,7 +11515,8 @@ export interface operations {
         type: "commit" | "tree" | "blob";
         /** An object with information about the individual creating the tag. */
         tagger?: {
-          /** The name of the author of the tag */ name?: string;
+          /** The name of the author of the tag */
+          name?: string;
           /** The email of the author of the tag */
           email?: string;
           /** When this object was tagged. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
@@ -11517,7 +11594,8 @@ export interface operations {
       "application/json": {
         /** Objects (of `path`, `mode`, `type`, and `sha`) specifying a tree structure. */
         tree: {
-          /** The file referenced in the tree. */ path?: string;
+          /** The file referenced in the tree. */
+          path?: string;
           /** The file mode; one of `100644` for file (blob), `100755` for executable (blob), `040000` for subdirectory (tree), `160000` for submodule (commit), or `120000` for a blob that specifies the path of a symlink. */
           mode?: "100644" | "100755" | "040000" | "160000" | "120000";
           /** Either `blob`, `tree`, or `commit`. */
@@ -11847,7 +11925,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The URL of the originating repository. */ vcs_url: string;
+        /** The URL of the originating repository. */
+        vcs_url: string;
         /** The originating VCS type. Can be one of `subversion`, `git`, `mercurial`, or `tfvc`. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response. */
         vcs?: "subversion" | "git" | "mercurial" | "tfvc";
         /** If authentication is required, the username to provide to `vcs_url`. */
@@ -11942,7 +12021,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The new Git author email. */ email?: string;
+        /** The new Git author email. */
+        email?: string;
         /** The new Git author name. */
         name?: string;
         remote_id?: string;
@@ -12175,7 +12255,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The title of the issue. */ title: string;
+        /** The title of the issue. */
+        title: string;
         /** The contents of the issue. */
         body?: string;
         /** Login for the user that this issue should be assigned to. _NOTE: Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise. **This field is deprecated.**_ */
@@ -12185,7 +12266,12 @@ export interface operations {
         /** Labels to associate with this issue. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._ */
         labels?: (
           | string
-          | { id?: number; name?: string; description?: string; color?: string }
+          | {
+              id?: number;
+              name?: string;
+              description?: string;
+              color?: string;
+            }
         )[];
         /** Logins for Users to assign to this issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._ */
         assignees?: string[];
@@ -12254,7 +12340,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The contents of the comment. */ body: string;
+        /** The contents of the comment. */
+        body: string;
       };
     };
     responses: {
@@ -12445,7 +12532,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The title of the issue. */ title?: string;
+        /** The title of the issue. */
+        title?: string;
         /** The contents of the issue. */
         body?: string;
         /** Login for the user that this issue should be assigned to. **This field is deprecated.** */
@@ -12457,7 +12545,12 @@ export interface operations {
         /** Labels to associate with this issue. Pass one or more Labels to _replace_ the set of Labels on this Issue. Send an empty array (`[]`) to clear all Labels from the Issue. _NOTE: Only users with push access can set labels for issues. Labels are silently dropped otherwise._ */
         labels?: (
           | string
-          | { id?: number; name?: string; description?: string; color?: string }
+          | {
+              id?: number;
+              name?: string;
+              description?: string;
+              color?: string;
+            }
         )[];
         /** Logins for Users to assign to this issue. Pass one or more user logins to _replace_ the set of assignees on this Issue. Send an empty array (`[]`) to clear all assignees from the Issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._ */
         assignees?: string[];
@@ -12554,7 +12647,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The contents of the comment. */ body: string;
+        /** The contents of the comment. */
+        body: string;
       };
     };
     responses: {
@@ -12872,7 +12966,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** A name for the key. */ title?: string;
+        /** A name for the key. */
+        title?: string;
         /** The contents of the key. */
         key: string;
         /**
@@ -13079,11 +13174,17 @@ export interface operations {
       403: components["responses"]["forbidden"];
       /** response */
       404: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
       /** Merge conflict response */
       409: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
       422: components["responses"]["validation_failed"];
     };
@@ -13122,7 +13223,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The title of the milestone. */ title: string;
+        /** The title of the milestone. */
+        title: string;
         /** The state of the milestone. Either `open` or `closed`. */
         state?: "open" | "closed";
         /** A description of the milestone. */
@@ -13166,7 +13268,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The title of the milestone. */ title?: string;
+        /** The title of the milestone. */
+        title?: string;
         /** The state of the milestone. Either `open` or `closed`. */
         state?: "open" | "closed";
         /** A description of the milestone. */
@@ -13446,7 +13549,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the project. */ name: string;
+        /** The name of the project. */
+        name: string;
         /** The description of the project. */
         body?: string;
       };
@@ -13512,7 +13616,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The title of the new pull request. */ title?: string;
+        /** The title of the new pull request. */
+        title?: string;
         /** The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`. */
         head: string;
         /** The name of the branch you want the changes pulled into. This should be an existing branch on the current repository. You cannot submit a pull request to one repository that requests a merge to a base of another repository. */
@@ -13650,7 +13755,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The text of the reply to the review comment. */ body: string;
+        /** The text of the reply to the review comment. */
+        body: string;
       };
     };
     responses: {
@@ -13812,7 +13918,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The title of the pull request. */ title?: string;
+        /** The title of the pull request. */
+        title?: string;
         /** The contents of the pull request. */
         body?: string;
         /** State of this Pull Request. Either `open` or `closed`. */
@@ -13915,7 +14022,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The text of the review comment. */ body: string;
+        /** The text of the review comment. */
+        body: string;
         /** The SHA of the commit needing a comment. Not using the latest commit SHA may render your comment outdated if a subsequent commit modifies the line you specify as the `position`. */
         commit_id?: string;
         /** The relative path to the file that necessitates a comment. */
@@ -13958,7 +14066,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The text of the review comment. */ body: string;
+        /** The text of the review comment. */
+        body: string;
       };
     };
     responses: {
@@ -14037,7 +14146,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** Title for the automatic commit message. */ commit_title?: string;
+        /** Title for the automatic commit message. */
+        commit_title?: string;
         /** Extra detail to append to automatic commit message. */
         commit_message?: string;
         /** SHA that pull request head must match to allow merge. */
@@ -14055,11 +14165,17 @@ export interface operations {
       404: components["responses"]["not_found"];
       /** Response if merge cannot be performed */
       405: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
       /** Response if sha was provided and pull request head did not match */
       409: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
       422: components["responses"]["validation_failed"];
     };
@@ -14230,7 +14346,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The body text of the pull request review. */ body: string;
+        /** The body text of the pull request review. */
+        body: string;
       };
     };
     responses: {
@@ -14318,7 +14435,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The body text of the pull request review */ body?: string;
+        /** The body text of the pull request review */
+        body?: string;
         /** The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action. */
         event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
       };
@@ -14351,7 +14469,10 @@ export interface operations {
     responses: {
       /** response */
       202: {
-        "application/json": { message?: string; url?: string };
+        "application/json": {
+          message?: string;
+          url?: string;
+        };
       };
       403: components["responses"]["forbidden"];
       415: components["responses"]["preview_header_missing"];
@@ -14421,7 +14542,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the tag. */ tag_name: string;
+        /** The name of the tag. */
+        tag_name: string;
         /** Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually `master`). */
         target_commitish?: string;
         /** The name of the release. */
@@ -14472,7 +14594,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The file name of the asset. */ name?: string;
+        /** The file name of the asset. */
+        name?: string;
         /** An alternate short description of the asset. Used in place of the filename. */
         label?: string;
         state?: string;
@@ -14563,7 +14686,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the tag. */ tag_name?: string;
+        /** The name of the tag. */
+        tag_name?: string;
         /** Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists. Default: the repository's default branch (usually `master`). */
         target_commitish?: string;
         /** The name of the release. */
@@ -15227,11 +15351,13 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The SCIM schema URIs. */ schemas: string[];
+        /** The SCIM schema URIs. */
+        schemas: string[];
         /** The name of the SCIM group. This must match the GitHub organization that the group maps to. */
         displayName: string;
         members?: {
-          /** The SCIM user ID for a user. */ value: string;
+          /** The SCIM user ID for a user. */
+          value: string;
         }[];
       };
     };
@@ -15271,11 +15397,13 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The SCIM schema URIs. */ schemas: string[];
+        /** The SCIM schema URIs. */
+        schemas: string[];
         /** The name of the SCIM group. This must match the GitHub organization that the group maps to. */
         displayName: string;
         members?: {
-          /** The SCIM user ID for a user. */ value: string;
+          /** The SCIM user ID for a user. */
+          value: string;
         }[];
       };
     };
@@ -15300,7 +15428,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The SCIM schema URIs. */ schemas: string[];
+        /** The SCIM schema URIs. */
+        schemas: string[];
         /** Array of [SCIM operations](https://tools.ietf.org/html/rfc7644#section-3.5.2). */
         Operations: { [key: string]: any }[];
       };
@@ -15377,24 +15506,29 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The SCIM schema URIs. */ schemas: string[];
+        /** The SCIM schema URIs. */
+        schemas: string[];
         /** The username for the user. */
         userName: string;
         name: {
-          /** The first name of the user. */ givenName: string;
+          /** The first name of the user. */
+          givenName: string;
           /** The last name of the user. */
           familyName: string;
         };
         /** List of user emails. */
         emails: {
-          /** The email address. */ value: string;
+          /** The email address. */
+          value: string;
           /** The type of email address. */
           type: string;
           /** Whether this email address is the primary address. */
           primary: boolean;
         }[];
         /** List of SCIM group IDs the user is a member of. */
-        groups?: { value?: string }[];
+        groups?: {
+          value?: string;
+        }[];
       };
     };
     responses: {
@@ -15437,24 +15571,29 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The SCIM schema URIs. */ schemas: string[];
+        /** The SCIM schema URIs. */
+        schemas: string[];
         /** The username for the user. */
         userName: string;
         name: {
-          /** The first name of the user. */ givenName: string;
+          /** The first name of the user. */
+          givenName: string;
           /** The last name of the user. */
           familyName: string;
         };
         /** List of user emails. */
         emails: {
-          /** The email address. */ value: string;
+          /** The email address. */
+          value: string;
           /** The type of email address. */
           type: string;
           /** Whether this email address is the primary address. */
           primary: boolean;
         }[];
         /** List of SCIM group IDs the user is a member of. */
-        groups?: { value?: string }[];
+        groups?: {
+          value?: string;
+        }[];
       };
     };
     responses: {
@@ -15493,7 +15632,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The SCIM schema URIs. */ schemas: string[];
+        /** The SCIM schema URIs. */
+        schemas: string[];
         /** Array of [SCIM operations](https://tools.ietf.org/html/rfc7644#section-3.5.2). */
         Operations: { [key: string]: any }[];
       };
@@ -15582,9 +15722,17 @@ export interface operations {
         userName: string;
         /** The name of the user, suitable for display to end-users */
         displayName?: string;
-        name: { givenName: string; familyName: string; formatted?: string };
+        name: {
+          givenName: string;
+          familyName: string;
+          formatted?: string;
+        };
         /** user emails */
-        emails: { value: string; primary?: boolean; type?: string }[];
+        emails: {
+          value: string;
+          primary?: boolean;
+          type?: string;
+        }[];
         schemas?: string[];
         externalId?: string;
         groups?: string[];
@@ -15645,9 +15793,17 @@ export interface operations {
         active?: boolean;
         /** Configured by the admin. Could be an email, login, or username */
         userName: string;
-        name: { givenName: string; familyName: string; formatted?: string };
+        name: {
+          givenName: string;
+          familyName: string;
+          formatted?: string;
+        };
         /** user emails */
-        emails: { type?: string; value: string; primary?: boolean }[];
+        emails: {
+          type?: string;
+          value: string;
+          primary?: boolean;
+        }[];
       };
     };
     responses: {
@@ -15700,7 +15856,10 @@ export interface operations {
                 givenName?: string | null;
                 familyName?: string | null;
               }
-            | { value?: string; primary?: boolean }[]
+            | {
+                value?: string;
+                primary?: boolean;
+              }[]
             | string;
         }[];
       };
@@ -16046,7 +16205,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The name of the team. */ name: string;
+        /** The name of the team. */
+        name: string;
         /** The description of the team. */
         description?: string;
         /**
@@ -16137,7 +16297,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The discussion post's title. */ title: string;
+        /** The discussion post's title. */
+        title: string;
         /** The discussion post's body text. */
         body: string;
         /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
@@ -16184,7 +16345,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The discussion post's title. */ title?: string;
+        /** The discussion post's title. */
+        title?: string;
         /** The discussion post's body text. */
         body?: string;
       };
@@ -16253,7 +16415,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The discussion comment's body text. */ body: string;
+        /** The discussion comment's body text. */
+        body: string;
       };
     };
     responses: {
@@ -16298,7 +16461,8 @@ export interface operations {
     };
     requestBody: {
       "application/json": {
-        /** The discussion comment's body text. */ body: string;
+        /** The discussion comment's body text. */
+        body: string;
       };
     };
     responses: {
@@ -16563,7 +16727,11 @@ export interface operations {
       422: {
         "application/json": {
           message?: string;
-          errors?: { code?: string; field?: string; resource?: string }[];
+          errors?: {
+            code?: string;
+            field?: string;
+            resource?: string;
+          }[];
           documentation_url?: string;
         };
       };
@@ -16660,7 +16828,11 @@ export interface operations {
       422: {
         "application/json": {
           message?: string;
-          errors?: { code?: string; field?: string; resource?: string }[];
+          errors?: {
+            code?: string;
+            field?: string;
+            resource?: string;
+          }[];
           documentation_url?: string;
         };
       };
@@ -16764,7 +16936,10 @@ export interface operations {
       204: never;
       /** Response if the project is not owned by the organization */
       403: {
-        "application/json": { message?: string; documentation_url?: string };
+        "application/json": {
+          message?: string;
+          documentation_url?: string;
+        };
       };
       404: components["responses"]["not_found"];
       415: components["responses"]["preview_header_missing"];
@@ -16928,7 +17103,8 @@ export interface operations {
       "application/json": {
         /** The IdP groups you want to connect to a GitHub team. When updating, the new `groups` object will replace the original one. You must include any existing groups that you don't want to remove. */
         groups: {
-          /** ID of the IdP group. */ group_id: string;
+          /** ID of the IdP group. */
+          group_id: string;
           /** Name of the IdP group. */
           group_name: string;
           /** Description of the IdP group. */
@@ -16994,7 +17170,8 @@ export interface operations {
     parameters: {};
     requestBody: {
       "application/json": {
-        /** The new name of the user. */ name?: string;
+        /** The new name of the user. */
+        name?: string;
         /** The publicly visible email address of the user. */
         email?: string;
         /** The new blog URL of the user. */
@@ -17294,7 +17471,8 @@ export interface operations {
     parameters: {};
     requestBody: {
       "application/json": {
-        /** A GPG key in ASCII-armored format. */ armored_public_key: string;
+        /** A GPG key in ASCII-armored format. */
+        armored_public_key: string;
       };
     };
     responses: {
@@ -17511,7 +17689,8 @@ export interface operations {
     parameters: {};
     requestBody: {
       "application/json": {
-        /** A descriptive name for the new key. */ title?: string;
+        /** A descriptive name for the new key. */
+        title?: string;
         /** The public SSH key to add to your GitHub account. */
         key: string;
       };
@@ -17844,7 +18023,8 @@ export interface operations {
     parameters: {};
     requestBody: {
       "application/json": {
-        /** Name of the project */ name: string;
+        /** Name of the project */
+        name: string;
         /** Body of the project */
         body?: string | null;
       };
@@ -17940,7 +18120,8 @@ export interface operations {
     parameters: {};
     requestBody: {
       "application/json": {
-        /** The name of the repository. */ name: string;
+        /** The name of the repository. */
+        name: string;
         /** A short description of the repository. */
         description?: string;
         /** A URL with more information about the repository. */
@@ -18782,7 +18963,8 @@ export interface components {
     } | null;
     /** GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub. */
     integration: {
-      /** Unique identifier of the GitHub app */ id: number;
+      /** Unique identifier of the GitHub app */
+      id: number;
       /** The slug name of the GitHub app */
       slug?: string;
       node_id: string;
@@ -18812,7 +18994,10 @@ export interface components {
       pem?: string;
     } & { [key: string]: any };
     /** Basic Error */
-    "basic-error": { message?: string; documentation_url?: string };
+    "basic-error": {
+      message?: string;
+      documentation_url?: string;
+    };
     /** Validation Error Simple */
     "validation-error-simple": {
       message: string;
@@ -18836,7 +19021,8 @@ export interface components {
     };
     /** An enterprise account */
     enterprise: {
-      /** A short description of the enterprise. */ description?: string | null;
+      /** A short description of the enterprise. */
+      description?: string | null;
       html_url: string;
       /** The enterprise's website URL. */
       website_url?: string | null;
@@ -18853,7 +19039,8 @@ export interface components {
     };
     /** Installation */
     installation: {
-      /** The ID of the installation. */ id: number;
+      /** The ID of the installation. */
+      id: number;
       account:
         | (Partial<components["schemas"]["simple-user"]> &
             Partial<components["schemas"]["enterprise"]>)
@@ -18899,7 +19086,8 @@ export interface components {
     };
     /** A git repository */
     repository: {
-      /** Unique identifier of the repository */ id: number;
+      /** Unique identifier of the repository */
+      id: number;
       node_id: string;
       /** The name of the repository. */
       name: string;
@@ -19085,7 +19273,11 @@ export interface components {
         pushed_at?: string;
         created_at?: string;
         updated_at?: string;
-        permissions?: { admin?: boolean; push?: boolean; pull?: boolean };
+        permissions?: {
+          admin?: boolean;
+          push?: boolean;
+          pull?: boolean;
+        };
         allow_rebase_merge?: boolean;
         template_repository?: string;
         temp_clone_token?: string;
@@ -19142,7 +19334,11 @@ export interface components {
     "application-grant": {
       id: number;
       url: string;
-      app: { client_id: string; name: string; url: string };
+      app: {
+        client_id: string;
+        name: string;
+        url: string;
+      };
       created_at: string;
       updated_at: string;
       scopes: string[];
@@ -19167,7 +19363,11 @@ export interface components {
       token: string;
       token_last_eight: string | null;
       hashed_token: string | null;
-      app: { client_id: string; name: string; url: string };
+      app: {
+        client_id: string;
+        name: string;
+        url: string;
+      };
       note: string | null;
       note_url: string | null;
       updated_at: string;
@@ -19186,7 +19386,8 @@ export interface components {
     };
     /** Content Reference attachments allow you to provide context around URLs posted in comments */
     "content-reference-attachment": {
-      /** The ID of the attachment */ id: number;
+      /** The ID of the attachment */
+      id: number;
       /** The title of the attachment */
       title: string;
       /** The body of the attachment */
@@ -19240,7 +19441,8 @@ export interface components {
     };
     /** A self hosted runner */
     runner: {
-      /** The id of the runner. */ id: number;
+      /** The id of the runner. */
+      id: number;
       /** The name of the runner. */
       name: string;
       /** The Operating System of the runner. */
@@ -19249,7 +19451,8 @@ export interface components {
       status: string;
       busy: boolean;
       labels: {
-        /** Unique identifier of the label. */ id?: number;
+        /** Unique identifier of the label. */
+        id?: number;
         /** Name of the label. */
         name?: string;
         /** The type of label. Read-only labels are applied automatically when the runner is configured. */
@@ -19265,7 +19468,8 @@ export interface components {
     };
     /** Authentication Token */
     "authentication-token": {
-      /** The token used for authentication */ token: string;
+      /** The token used for authentication */
+      token: string;
       /** The time this token expires */
       expires_at: string;
       permissions?: { [key: string]: any };
@@ -19283,7 +19487,8 @@ export interface components {
       /** The amount of free GitHub Actions minutes available. */
       included_minutes?: number;
       minutes_used_breakdown?: {
-        /** Total minutes used on Ubuntu runner machines. */ UBUNTU?: number;
+        /** Total minutes used on Ubuntu runner machines. */
+        UBUNTU?: number;
         /** Total minutes used on macOS runner machines. */
         MACOS?: number;
         /** Total minutes used on Windows runner machines. */
@@ -19398,7 +19603,8 @@ export interface components {
     };
     /** Comments provide a way for people to collaborate on an issue. */
     "issue-comment": {
-      /** Unique identifier of the issue comment */ id: number;
+      /** Unique identifier of the issue comment */
+      id: number;
       node_id: string;
       /** URL for the issue comment */
       url: string;
@@ -19428,7 +19634,11 @@ export interface components {
       id: string;
       type: string | null;
       actor: components["schemas"]["actor"];
-      repo: { id: number; name: string; url: string };
+      repo: {
+        id: number;
+        name: string;
+        url: string;
+      };
       org?: components["schemas"]["actor"];
       payload: {
         action: string;
@@ -19447,7 +19657,10 @@ export interface components {
       created_at: string | null;
     };
     /** Hypermedia Link with Type */
-    "link-with-type": { href: string; type: string };
+    "link-with-type": {
+      href: string;
+      type: string;
+    };
     /** Feed */
     feed: {
       timeline_url: string;
@@ -19621,11 +19834,18 @@ export interface components {
       url: string;
       version: string;
       user: components["schemas"]["simple-user"] | null;
-      change_status: { total?: number; additions?: number; deletions?: number };
+      change_status: {
+        total?: number;
+        additions?: number;
+        deletions?: number;
+      };
       committed_at: string;
     };
     /** Gitignore Template */
-    "gitignore-template": { name: string; source: string };
+    "gitignore-template": {
+      name: string;
+      source: string;
+    };
     /** Issues are a great way to keep track of tasks, enhancements, and bugs for your projects. */
     issue: {
       id: number;
@@ -19833,7 +20053,11 @@ export interface components {
       pushed_at?: string | null;
       created_at?: string | null;
       updated_at?: string | null;
-      permissions?: { admin?: boolean; push?: boolean; pull?: boolean };
+      permissions?: {
+        admin?: boolean;
+        push?: boolean;
+        pull?: boolean;
+      };
       template_repository?: string;
       temp_clone_token?: string;
       delete_branch_on_merge?: boolean;
@@ -19950,7 +20174,8 @@ export interface components {
     };
     /** Secrets for GitHub Actions for an organization. */
     "organization-actions-secret": {
-      /** The name of the secret. */ name: string;
+      /** The name of the secret. */
+      name: string;
       created_at: string;
       updated_at: string;
       /** Visibility of a secret */
@@ -19959,7 +20184,8 @@ export interface components {
     };
     /** The public key used for setting Actions Secrets. */
     "actions-public-key": {
-      /** The identifier for the key. */ key_id: string;
+      /** The identifier for the key. */
+      key_id: string;
       /** The Base64 encoded public key. */
       key: string;
       id?: number;
@@ -19969,7 +20195,8 @@ export interface components {
     };
     /** Credential Authorization */
     "credential-authorization": {
-      /** User login that owns the underlying credential. */ login: string;
+      /** User login that owns the underlying credential. */
+      login: string;
       /** Unique identifier for the credential. */
       credential_id: number;
       /** Human-readable description of the credential type. */
@@ -20025,7 +20252,8 @@ export interface components {
     };
     /** Groups of organization members that gives permissions on specified repositories. */
     "team-simple": {
-      /** Unique identifier of the team */ id: number;
+      /** Unique identifier of the team */
+      id: number;
       node_id: string;
       /** URL for the team */
       url: string;
@@ -20067,7 +20295,9 @@ export interface components {
       organization_url: string;
       organization: components["schemas"]["organization-simple"];
       user: components["schemas"]["simple-user"] | null;
-      permissions?: { can_create_repository: boolean };
+      permissions?: {
+        can_create_repository: boolean;
+      };
     };
     /** A migration. */
     migration: {
@@ -20108,13 +20338,18 @@ export interface components {
       /** Whether or not this project can be seen by everyone. */
       private?: boolean;
       cards_url?: string;
-      permissions?: { read: boolean; write: boolean; admin: boolean };
+      permissions?: {
+        read: boolean;
+        write: boolean;
+        admin: boolean;
+      };
     };
     /** External Groups to be mapped to a team for membership */
     "group-mapping": {
       /** Array of groups to be mapped to this team */
       groups?: {
-        /** The ID of the group */ group_id: string;
+        /** The ID of the group */
+        group_id: string;
         /** The name of the group */
         group_name: string;
         /** a description of the group */
@@ -20133,7 +20368,8 @@ export interface components {
     };
     /** Groups of organization members that gives permissions on specified repositories. */
     "team-full": {
-      /** Unique identifier of the team */ id: number;
+      /** Unique identifier of the team */
+      id: number;
       node_id: string;
       /** URL for the team */
       url: string;
@@ -20244,11 +20480,16 @@ export interface components {
       updated_at?: string;
       organization_permission?: string;
       private?: boolean;
-      permissions?: { read?: boolean; write?: boolean; admin?: boolean };
+      permissions?: {
+        read?: boolean;
+        write?: boolean;
+        admin?: boolean;
+      };
     };
     /** A team's access to a repository. */
     "team-repository": {
-      /** Unique identifier of the repository */ id: number;
+      /** Unique identifier of the repository */
+      id: number;
       node_id: string;
       /** The name of the repository. */
       name: string;
@@ -20434,7 +20675,11 @@ export interface components {
         pushed_at?: string;
         created_at?: string;
         updated_at?: string;
-        permissions?: { admin?: boolean; push?: boolean; pull?: boolean };
+        permissions?: {
+          admin?: boolean;
+          push?: boolean;
+          pull?: boolean;
+        };
         allow_rebase_merge?: boolean;
         template_repository?: string;
         temp_clone_token?: string;
@@ -20491,7 +20736,11 @@ export interface components {
       permission: string;
       user: components["schemas"]["simple-user"] | null;
     };
-    "rate-limit": { limit: number; remaining: number; reset: number };
+    "rate-limit": {
+      limit: number;
+      remaining: number;
+      reset: number;
+    };
     /** Rate Limit Overview */
     "rate-limit-overview": {
       resources: {
@@ -20580,7 +20829,11 @@ export interface components {
       pushed_at: string;
       created_at: string;
       updated_at: string;
-      permissions?: { admin: boolean; pull: boolean; push: boolean };
+      permissions?: {
+        admin: boolean;
+        pull: boolean;
+        push: boolean;
+      };
       allow_rebase_merge?: boolean;
       template_repository?: components["schemas"]["repository"] | null;
       temp_clone_token?: string | null;
@@ -20618,7 +20871,8 @@ export interface components {
     };
     /** Information of a job execution in a workflow run */
     job: {
-      /** The id of the job. */ id: number;
+      /** The id of the job. */
+      id: number;
       /** The id of the associated workflow run. */
       run_id: number;
       run_url: string;
@@ -20667,12 +20921,20 @@ export interface components {
       head: {
         ref: string;
         sha: string;
-        repo: { id: number; url: string; name: string };
+        repo: {
+          id: number;
+          url: string;
+          name: string;
+        };
       };
       base: {
         ref: string;
         sha: string;
-        repo: { id: number; url: string; name: string };
+        repo: {
+          id: number;
+          url: string;
+          name: string;
+        };
       };
     };
     /** Simple Commit */
@@ -20681,12 +20943,19 @@ export interface components {
       tree_id: string;
       message: string;
       timestamp: string;
-      author: { name: string; email: string } | null;
-      committer: { name: string; email: string } | null;
+      author: {
+        name: string;
+        email: string;
+      } | null;
+      committer: {
+        name: string;
+        email: string;
+      } | null;
     };
     /** An invocation of a workflow */
     "workflow-run": {
-      /** The ID of the workflow run. */ id: number;
+      /** The ID of the workflow run. */
+      id: number;
       /** The name of the workflow run. */
       name?: string;
       node_id: string;
@@ -20728,15 +20997,25 @@ export interface components {
     /** Workflow Run Usage */
     "workflow-run-usage": {
       billable?: {
-        UBUNTU?: { total_ms?: number; jobs?: number };
-        MACOS?: { total_ms?: number; jobs?: number };
-        WINDOWS?: { total_ms?: number; jobs?: number };
+        UBUNTU?: {
+          total_ms?: number;
+          jobs?: number;
+        };
+        MACOS?: {
+          total_ms?: number;
+          jobs?: number;
+        };
+        WINDOWS?: {
+          total_ms?: number;
+          jobs?: number;
+        };
       };
       run_duration_ms?: number;
     };
     /** Set secrets for GitHub Actions. */
     "actions-secret": {
-      /** The name of the secret. */ name: string;
+      /** The name of the secret. */
+      name: string;
       created_at: string;
       updated_at: string;
     };
@@ -20757,13 +21036,22 @@ export interface components {
     /** Workflow Usage */
     "workflow-usage": {
       billable?: {
-        UBUNTU?: { total_ms?: number };
-        MACOS?: { total_ms?: number };
-        WINDOWS?: { total_ms?: number };
+        UBUNTU?: {
+          total_ms?: number;
+        };
+        MACOS?: {
+          total_ms?: number;
+        };
+        WINDOWS?: {
+          total_ms?: number;
+        };
       };
     };
     /** Protected Branch Admin Enforced */
-    "protected-branch-admin-enforced": { url: string; enabled: boolean };
+    "protected-branch-admin-enforced": {
+      url: string;
+      enabled: boolean;
+    };
     /** Protected Branch Pull Request Review */
     "protected-branch-pull-request-review": {
       url?: string;
@@ -20875,9 +21163,15 @@ export interface components {
       enforce_admins?: components["schemas"]["protected-branch-admin-enforced"];
       required_pull_request_reviews?: components["schemas"]["protected-branch-pull-request-review"];
       restrictions?: components["schemas"]["branch-restriction-policy"];
-      required_linear_history?: { enabled?: boolean };
-      allow_force_pushes?: { enabled?: boolean };
-      allow_deletions?: { enabled?: boolean };
+      required_linear_history?: {
+        enabled?: boolean;
+      };
+      allow_force_pushes?: {
+        enabled?: boolean;
+      };
+      allow_deletions?: {
+        enabled?: boolean;
+      };
       enabled: boolean;
       name?: string;
       protection_url?: string;
@@ -20885,13 +21179,20 @@ export interface components {
     /** Short Branch */
     "short-branch": {
       name: string;
-      commit: { sha: string; url: string };
+      commit: {
+        sha: string;
+        url: string;
+      };
       protected: boolean;
       protection?: components["schemas"]["branch-protection"];
       protection_url?: string;
     };
     /** Metaproperties for Git author/committer information. */
-    "git-user": { name?: string; email?: string; date?: string };
+    "git-user": {
+      name?: string;
+      email?: string;
+      date?: string;
+    };
     verification: {
       verified: boolean;
       reason: string;
@@ -20911,13 +21212,24 @@ export interface components {
         committer: components["schemas"]["git-user"] | null;
         message: string;
         comment_count: number;
-        tree: { sha: string; url: string };
+        tree: {
+          sha: string;
+          url: string;
+        };
         verification?: components["schemas"]["verification"];
       };
       author: components["schemas"]["simple-user"] | null;
       committer: components["schemas"]["simple-user"] | null;
-      parents: { sha: string; url: string; html_url?: string }[];
-      stats?: { additions?: number; deletions?: number; total?: number };
+      parents: {
+        sha: string;
+        url: string;
+        html_url?: string;
+      }[];
+      stats?: {
+        additions?: number;
+        deletions?: number;
+        total?: number;
+      };
       files?: {
         filename?: string;
         additions?: number;
@@ -20936,7 +21248,10 @@ export interface components {
     "branch-with-protection": {
       name: string;
       commit: components["schemas"]["commit"];
-      _links: { html: string; self: string };
+      _links: {
+        html: string;
+        self: string;
+      };
       protected: boolean;
       protection: components["schemas"]["branch-protection"];
       protection_url: string;
@@ -20967,16 +21282,29 @@ export interface components {
           teams: components["schemas"]["team"][];
         };
       };
-      required_signatures?: { url: string; enabled: boolean };
-      enforce_admins?: { url: string; enabled: boolean };
-      required_linear_history?: { enabled: boolean };
-      allow_force_pushes?: { enabled: boolean };
-      allow_deletions?: { enabled: boolean };
+      required_signatures?: {
+        url: string;
+        enabled: boolean;
+      };
+      enforce_admins?: {
+        url: string;
+        enabled: boolean;
+      };
+      required_linear_history?: {
+        enabled: boolean;
+      };
+      allow_force_pushes?: {
+        enabled: boolean;
+      };
+      allow_deletions?: {
+        enabled: boolean;
+      };
       restrictions?: components["schemas"]["branch-restriction-policy"];
     };
     /** A check performed on the code of a given code change */
     "check-run": {
-      /** The id of the check. */ id: number;
+      /** The id of the check. */
+      id: number;
       /** The SHA of the commit that is being checked. */
       head_sha: string;
       node_id: string;
@@ -20998,7 +21326,9 @@ export interface components {
       };
       /** The name of the check. */
       name: string;
-      check_suite: { id: number } | null;
+      check_suite: {
+        id: number;
+      } | null;
       app: components["schemas"]["integration"] | null;
       pull_requests: components["schemas"]["pull-request-minimal"][];
     };
@@ -21039,7 +21369,10 @@ export interface components {
     /** Check suite configuration preferences for a repository. */
     "check-suite-preference": {
       preferences?: {
-        auto_trigger_checks?: { app_id: number; setting: boolean }[];
+        auto_trigger_checks?: {
+          app_id: number;
+          setting: boolean;
+        }[];
       };
       repository?: components["schemas"]["repository"];
     };
@@ -21155,11 +21488,16 @@ export interface components {
       received_events_url: string;
       type: string;
       site_admin: boolean;
-      permissions?: { pull: boolean; push: boolean; admin: boolean };
+      permissions?: {
+        pull: boolean;
+        push: boolean;
+        admin: boolean;
+      };
     };
     /** Repository invitations let you manage who you collaborate with. */
     "repository-invitation": {
-      /** Unique identifier of the repository invitation. */ id: number;
+      /** Unique identifier of the repository invitation. */
+      id: number;
       repository: components["schemas"]["minimal-repository"];
       invitee: components["schemas"]["simple-user"] | null;
       inviter: components["schemas"]["simple-user"] | null;
@@ -21200,11 +21538,16 @@ export interface components {
     /** Branch Short */
     "branch-short": {
       name?: string;
-      commit?: { sha?: string; url?: string };
+      commit?: {
+        sha?: string;
+        url?: string;
+      };
       protected?: boolean;
     };
     /** Hypermedia Link */
-    link: { href: string };
+    link: {
+      href: string;
+    };
     /** Pull Request Simple */
     "pull-request-simple": {
       url: string;
@@ -21317,7 +21660,10 @@ export interface components {
       name: string;
       html_url: string | null;
     };
-    "community-health-file": { url: string; html_url: string };
+    "community-health-file": {
+      url: string;
+      html_url: string;
+    };
     /** Community Profile */
     "community-profile": {
       health_percentage: number;
@@ -21387,9 +21733,17 @@ export interface components {
         git_url: string | null;
         html_url: string | null;
         download_url: string | null;
-        _links: { git: string | null; html: string | null; self: string };
+        _links: {
+          git: string | null;
+          html: string | null;
+          self: string;
+        };
       }[];
-      _links: { git: string | null; html: string | null; self: string };
+      _links: {
+        git: string | null;
+        html: string | null;
+        self: string;
+      };
     };
     /** A list of directory items */
     "content-directory": {
@@ -21403,7 +21757,11 @@ export interface components {
       git_url: string | null;
       html_url: string | null;
       download_url: string | null;
-      _links: { git: string | null; html: string | null; self: string };
+      _links: {
+        git: string | null;
+        html: string | null;
+        self: string;
+      };
     }[];
     /** Content File */
     "content-file": {
@@ -21418,7 +21776,11 @@ export interface components {
       git_url: string | null;
       html_url: string | null;
       download_url: string | null;
-      _links: { git: string | null; html: string | null; self: string };
+      _links: {
+        git: string | null;
+        html: string | null;
+        self: string;
+      };
       target?: string;
       submodule_git_url?: string;
     };
@@ -21434,7 +21796,11 @@ export interface components {
       git_url: string | null;
       html_url: string | null;
       download_url: string | null;
-      _links: { git: string | null; html: string | null; self: string };
+      _links: {
+        git: string | null;
+        html: string | null;
+        self: string;
+      };
     };
     /** An object describing a symlink */
     "content-submodule": {
@@ -21448,7 +21814,11 @@ export interface components {
       git_url: string | null;
       html_url: string | null;
       download_url: string | null;
-      _links: { git: string | null; html: string | null; self: string };
+      _links: {
+        git: string | null;
+        html: string | null;
+        self: string;
+      };
     };
     /** File Commit */
     "file-commit": {
@@ -21462,18 +21832,37 @@ export interface components {
         git_url?: string;
         download_url?: string;
         type?: string;
-        _links?: { self?: string; git?: string; html?: string };
+        _links?: {
+          self?: string;
+          git?: string;
+          html?: string;
+        };
       } | null;
       commit?: {
         sha?: string;
         node_id?: string;
         url?: string;
         html_url?: string;
-        author?: { date?: string; name?: string; email?: string };
-        committer?: { date?: string; name?: string; email?: string };
+        author?: {
+          date?: string;
+          name?: string;
+          email?: string;
+        };
+        committer?: {
+          date?: string;
+          name?: string;
+          email?: string;
+        };
         message?: string;
-        tree?: { url?: string; sha?: string };
-        parents?: { url?: string; html_url?: string; sha?: string }[];
+        tree?: {
+          url?: string;
+          sha?: string;
+        };
+        parents?: {
+          url?: string;
+          html_url?: string;
+          sha?: string;
+        }[];
         verification?: {
           verified?: boolean;
           reason?: string;
@@ -21565,7 +21954,10 @@ export interface components {
       performed_via_github_app?: components["schemas"]["integration"] | null;
     };
     /** Short Blob */
-    "short-blob": { url?: string; sha?: string };
+    "short-blob": {
+      url?: string;
+      sha?: string;
+    };
     /** Blob */
     blob: {
       content: string;
@@ -21578,12 +21970,14 @@ export interface components {
     };
     /** Low-level Git commit operations within a repository */
     "git-commit": {
-      /** SHA for the commit */ sha?: string;
+      /** SHA for the commit */
+      sha?: string;
       node_id?: string;
       url?: string;
       /** Identifying information for the git-user */
       author?: {
-        /** Timestamp of the commit */ date?: string;
+        /** Timestamp of the commit */
+        date?: string;
         /** Git email address of the user */
         email: string;
         /** Name of the git user */
@@ -21591,7 +21985,8 @@ export interface components {
       };
       /** Identifying information for the git-user */
       committer?: {
-        /** Timestamp of the commit */ date?: string;
+        /** Timestamp of the commit */
+        date?: string;
         /** Git email address of the user */
         email: string;
         /** Name of the git user */
@@ -21600,11 +21995,13 @@ export interface components {
       /** Message describing the purpose of the commit */
       message?: string;
       tree?: {
-        /** SHA for the commit */ sha?: string;
+        /** SHA for the commit */
+        sha?: string;
         url?: string;
       };
       parents?: {
-        /** SHA for the commit */ sha?: string;
+        /** SHA for the commit */
+        sha?: string;
         url?: string;
         html_url?: string;
       }[];
@@ -21638,8 +22035,16 @@ export interface components {
       url: string;
       /** Message describing the purpose of the tag */
       message: string;
-      tagger: { date: string; email: string; name: string };
-      object: { sha: string; type: string; url: string };
+      tagger: {
+        date: string;
+        email: string;
+        name: string;
+      };
+      object: {
+        sha: string;
+        type: string;
+        url: string;
+      };
       verification?: components["schemas"]["verification"];
     };
     /** The hierarchy between files in a Git repository. */
@@ -21757,7 +22162,10 @@ export interface components {
       size: number;
     };
     /** Issue Event Label */
-    "issue-event-label": { name: string | null; color: string | null };
+    "issue-event-label": {
+      name: string | null;
+      color: string | null;
+    };
     "issue-event-dismissed-review": {
       state: string;
       review_id: number;
@@ -21765,7 +22173,9 @@ export interface components {
       dismissal_commit_id?: string | null;
     };
     /** Issue Event Milestone */
-    "issue-event-milestone": { title: string };
+    "issue-event-milestone": {
+      title: string;
+    };
     /** Issue Event Project Card */
     "issue-event-project-card": {
       url: string;
@@ -21776,7 +22186,10 @@ export interface components {
       previous_column_name?: string;
     };
     /** Issue Event Rename */
-    "issue-event-rename": { from: string; to: string };
+    "issue-event-rename": {
+      from: string;
+      to: string;
+    };
     /** Issue Event */
     "issue-event": {
       id: number;
@@ -21863,13 +22276,21 @@ export interface components {
       type: string;
       content: string;
       encoding: string;
-      _links: { git: string | null; html: string | null; self: string };
+      _links: {
+        git: string | null;
+        html: string | null;
+        self: string;
+      };
       license: components["schemas"]["license-simple"] | null;
     };
-    "pages-source-hash": { branch: string; path: string };
+    "pages-source-hash": {
+      branch: string;
+      path: string;
+    };
     /** The configuration for GitHub Pages for a repository. */
     page: {
-      /** The API address for accessing this Page resource. */ url: string;
+      /** The API address for accessing this Page resource. */
+      url: string;
       /** The status of the most recent build of the Page. */
       status: ("built" | "building" | "errored") | null;
       /** The Pages site's custom domain */
@@ -21884,7 +22305,9 @@ export interface components {
     "page-build": {
       url: string;
       status: string;
-      error: { message: string | null };
+      error: {
+        message: string | null;
+      };
       pusher: components["schemas"]["simple-user"] | null;
       commit: string;
       duration: number;
@@ -21892,7 +22315,10 @@ export interface components {
       updated_at: string;
     };
     /** Page Build Status */
-    "page-build-status": { url: string; status: string };
+    "page-build-status": {
+      url: string;
+      status: string;
+    };
     /** Pull requests let you tell others about changes you've pushed to a repository on GitHub. Once a pull request is sent, interested parties can review the set of changes, discuss potential modifications, and even push follow-up commits if necessary. */
     "pull-request": {
       url: string;
@@ -22023,7 +22449,11 @@ export interface components {
           mirror_url: string | null;
           open_issues: number;
           open_issues_count: number;
-          permissions?: { admin: boolean; pull: boolean; push: boolean };
+          permissions?: {
+            admin: boolean;
+            pull: boolean;
+            push: boolean;
+          };
           temp_clone_token?: string;
           allow_merge_commit?: boolean;
           allow_squash_merge?: boolean;
@@ -22155,7 +22585,11 @@ export interface components {
           mirror_url: string | null;
           open_issues: number;
           open_issues_count: number;
-          permissions?: { admin: boolean; pull: boolean; push: boolean };
+          permissions?: {
+            admin: boolean;
+            pull: boolean;
+            push: boolean;
+          };
           temp_clone_token?: string;
           allow_merge_commit?: boolean;
           allow_squash_merge?: boolean;
@@ -22223,7 +22657,8 @@ export interface components {
     };
     /** Pull Request Review Comments are comments on a portion of the Pull Request's diff. */
     "pull-request-review-comment": {
-      /** URL for the pull request review comment */ url: string;
+      /** URL for the pull request review comment */
+      url: string;
       /** The ID of the pull request review to which the comment belongs. */
       pull_request_review_id: number | null;
       /** The ID of the pull request review comment. */
@@ -22256,9 +22691,15 @@ export interface components {
       /** How the author of the comment is associated with the pull request. */
       author_association: string;
       _links: {
-        self: { href: string };
-        html: { href: string };
-        pull_request: { href: string };
+        self: {
+          href: string;
+        };
+        html: {
+          href: string;
+        };
+        pull_request: {
+          href: string;
+        };
       };
       /** The first line of the range for a multi-line comment. */
       start_line?: number | null;
@@ -22321,7 +22762,8 @@ export interface components {
     };
     /** Pull Request Reviews are reviews on pull requests. */
     "pull-request-review": {
-      /** Unique identifier of the review */ id: number;
+      /** Unique identifier of the review */
+      id: number;
       node_id: string;
       user: components["schemas"]["simple-user"] | null;
       /** The text of the review. */
@@ -22329,7 +22771,14 @@ export interface components {
       state: string;
       html_url: string;
       pull_request_url: string;
-      _links: { html: { href: string }; pull_request: { href: string } };
+      _links: {
+        html: {
+          href: string;
+        };
+        pull_request: {
+          href: string;
+        };
+      };
       submitted_at?: string;
       /** A commit SHA for the review. */
       commit_id: string;
@@ -22430,14 +22879,26 @@ export interface components {
     /** Code Frequency Stat */
     "code-frequency-stat": number[];
     /** Commit Activity */
-    "commit-activity": { days: number[]; total: number; week: number };
+    "commit-activity": {
+      days: number[];
+      total: number;
+      week: number;
+    };
     /** Contributor Activity */
     "contributor-activity": {
       author: components["schemas"]["simple-user"] | null;
       total: number;
-      weeks: { w?: string; a?: number; d?: number; c?: number }[];
+      weeks: {
+        w?: string;
+        a?: number;
+        d?: number;
+        c?: number;
+      }[];
     };
-    "participation-stats": { all?: number[]; owner?: number[] };
+    "participation-stats": {
+      all?: number[];
+      owner?: number[];
+    };
     /** Repository invitations let you manage who you collaborate with. */
     "repository-subscription": {
       /** Determines if notifications should be received from this repository. */
@@ -22452,14 +22913,23 @@ export interface components {
     /** Tag */
     tag: {
       name: string;
-      commit: { sha: string; url: string };
+      commit: {
+        sha: string;
+        url: string;
+      };
       zipball_url: string;
       tarball_url: string;
       node_id: string;
     };
     /** A topic aggregates entities that are related to a subject. */
-    topic: { names?: string[] };
-    traffic: { timestamp: string; uniques: number; count: number };
+    topic: {
+      names?: string[];
+    };
+    traffic: {
+      timestamp: string;
+      uniques: number;
+      count: number;
+    };
     /** Clone Traffic */
     "clone-traffic": {
       count: number;
@@ -22474,7 +22944,11 @@ export interface components {
       uniques: number;
     };
     /** Referrer Traffic */
-    "referrer-traffic": { referrer: string; count: number; uniques: number };
+    "referrer-traffic": {
+      referrer: string;
+      count: number;
+      uniques: number;
+    };
     /** View Traffic */
     "view-traffic": {
       count: number;
@@ -22491,7 +22965,11 @@ export interface components {
         id?: string;
         externalId?: string | null;
         displayName?: string;
-        members?: { value?: string; $ref?: string; display?: string }[];
+        members?: {
+          value?: string;
+          $ref?: string;
+          display?: string;
+        }[];
         meta?: {
           resourceType?: string;
           created?: string;
@@ -22505,7 +22983,11 @@ export interface components {
       id?: string;
       externalId?: string | null;
       displayName?: string;
-      members?: { value?: string; $ref?: string; display?: string }[];
+      members?: {
+        value?: string;
+        $ref?: string;
+        display?: string;
+      }[];
       meta?: {
         resourceType?: string;
         created?: string;
@@ -22523,9 +23005,18 @@ export interface components {
         id?: string;
         externalId?: string;
         userName?: string;
-        name?: { givenName?: string; familyName?: string };
-        emails?: { value?: string; primary?: boolean; type?: string }[];
-        groups?: { value?: string }[];
+        name?: {
+          givenName?: string;
+          familyName?: string;
+        };
+        emails?: {
+          value?: string;
+          primary?: boolean;
+          type?: string;
+        }[];
+        groups?: {
+          value?: string;
+        }[];
         active?: boolean;
         meta?: {
           resourceType?: string;
@@ -22540,9 +23031,18 @@ export interface components {
       id?: string;
       externalId?: string;
       userName?: string;
-      name?: { givenName?: string; familyName?: string };
-      emails?: { value?: string; type?: string; primary?: boolean }[];
-      groups?: { value?: string }[];
+      name?: {
+        givenName?: string;
+        familyName?: string;
+      };
+      emails?: {
+        value?: string;
+        type?: string;
+        primary?: boolean;
+      }[];
+      groups?: {
+        value?: string;
+      }[];
       active?: boolean;
       meta?: {
         resourceType?: string;
@@ -22553,7 +23053,8 @@ export interface components {
     };
     /** SCIM /Users provisioning endpoints */
     "scim-user": {
-      /** SCIM schema used. */ schemas: string[];
+      /** SCIM schema used. */
+      schemas: string[];
       /** Unique identifier of an external identity */
       id: string;
       /** The ID of the User. */
@@ -22568,7 +23069,10 @@ export interface components {
         formatted?: string | null;
       };
       /** user emails */
-      emails: { value: string; primary?: boolean }[];
+      emails: {
+        value: string;
+        primary?: boolean;
+      }[];
       /** The active status of the User. */
       active: boolean;
       meta: {
@@ -22586,11 +23090,15 @@ export interface components {
         value?: string | { [key: string]: any } | { [key: string]: any }[];
       }[];
       /** associated groups */
-      groups?: { value?: string; display?: string }[];
+      groups?: {
+        value?: string;
+        display?: string;
+      }[];
     };
     /** SCIM User List */
     "scim-user-list": {
-      /** SCIM schema used. */ schemas: string[];
+      /** SCIM schema used. */
+      schemas: string[];
       totalResults: number;
       itemsPerPage: number;
       startIndex: number;
@@ -22601,7 +23109,10 @@ export interface components {
       object_type?: string | null;
       property?: string;
       fragment?: string;
-      matches?: { text?: string; indices?: number[] }[];
+      matches?: {
+        text?: string;
+        indices?: number[];
+      }[];
     }[];
     /** Code Search Result Item */
     "code-search-result-item": {
@@ -22626,17 +23137,28 @@ export interface components {
       html_url: string;
       comments_url: string;
       commit: {
-        author: { name: string; email: string; date: string };
+        author: {
+          name: string;
+          email: string;
+          date: string;
+        };
         committer: components["schemas"]["git-user"] | null;
         comment_count: number;
         message: string;
-        tree: { sha: string; url: string };
+        tree: {
+          sha: string;
+          url: string;
+        };
         url: string;
         verification?: components["schemas"]["verification"];
       };
       author: components["schemas"]["simple-user"] | null;
       committer: components["schemas"]["git-user"] | null;
-      parents: { url?: string; html_url?: string; sha?: string }[];
+      parents: {
+        url?: string;
+        html_url?: string;
+        sha?: string;
+      }[];
       repository: components["schemas"]["minimal-repository"];
       score: number;
       node_id: string;
@@ -22783,7 +23305,11 @@ export interface components {
       /** Returns whether or not this repository disabled. */
       disabled: boolean;
       license: components["schemas"]["license-simple"] | null;
-      permissions?: { admin: boolean; pull: boolean; push: boolean };
+      permissions?: {
+        admin: boolean;
+        pull: boolean;
+        push: boolean;
+      };
       text_matches?: components["schemas"]["search-result-text-matches"];
       temp_clone_token?: string;
       allow_merge_commit?: boolean;
@@ -22977,7 +23503,10 @@ export interface components {
       primary_key_id: number | null;
       key_id: string;
       public_key: string;
-      emails: { email?: string; verified?: boolean }[];
+      emails: {
+        email?: string;
+        verified?: boolean;
+      }[];
       subkeys: {
         id?: number;
         primary_key_id?: number;
@@ -23038,9 +23567,17 @@ export interface components {
       repo: components["schemas"]["repository"];
     };
     /** Hovercard */
-    hovercard: { contexts: { message: string; octicon: string }[] };
+    hovercard: {
+      contexts: {
+        message: string;
+        octicon: string;
+      }[];
+    };
     /** Key Simple */
-    "key-simple": { id: number; key: string };
+    "key-simple": {
+      id: number;
+      key: string;
+    };
   };
   responses: {
     /** Resource Not Found */
@@ -23058,7 +23595,10 @@ export interface components {
     /** Preview Header Missing */
     preview_header_missing: {
       content: {
-        "application/json": { message: string; documentation_url: string };
+        "application/json": {
+          message: string;
+          documentation_url: string;
+        };
       };
     };
     /** Forbidden */

--- a/tests/v3/expected/http.ts
+++ b/tests/v3/expected/http.ts
@@ -543,8 +543,12 @@ export interface components {
       version: number;
       body: components["schemas"]["RegionBody"];
     };
-    CreateRegion: { body: components["schemas"]["RegionBody"] };
-    UpdateRegion: { name: string };
+    CreateRegion: {
+      body: components["schemas"]["RegionBody"];
+    };
+    UpdateRegion: {
+      name: string;
+    };
     ProviderBody: {
       owner_id?: components["schemas"]["OptionalFlexID"];
       team_id?: components["schemas"]["OptionalID"];
@@ -569,7 +573,9 @@ export interface components {
       type: "provider";
       body: components["schemas"]["ProviderBody"];
     };
-    CreateProvider: { body: components["schemas"]["ProviderBody"] };
+    CreateProvider: {
+      body: components["schemas"]["ProviderBody"];
+    };
     UpdateProvider: {
       id: components["schemas"]["ID"];
       body: components["schemas"]["UpdateProviderBody"];
@@ -749,7 +755,8 @@ export interface components {
       value: components["schemas"]["FeatureValueLabel"];
     };
     ValueProp: {
-      /** Heading of a value proposition. */ header: string;
+      /** Heading of a value proposition. */
+      header: string;
       /** Body of a value proposition. */
       body: string;
     };
@@ -863,7 +870,10 @@ export interface components {
        * URL to this Product's Terms of Service. If provided is true, then
        * a url must be set. Otherwise, provided is false.
        */
-      terms: { url?: string | null; provided: boolean };
+      terms: {
+        url?: string | null;
+        provided: boolean;
+      };
       feature_types: components["schemas"]["FeatureType"][];
       billing: {
         type: "monthly-prorated" | "monthly-anniversary" | "annual-anniversary";
@@ -884,7 +894,9 @@ export interface components {
       type: "product";
       body: components["schemas"]["ProductBody"];
     };
-    CreateProduct: { body: components["schemas"]["ProductBody"] };
+    CreateProduct: {
+      body: components["schemas"]["ProductBody"];
+    };
     /** Array of Plan IDs that this Plan can be resized to, if null all will be assumed */
     PlanResizeList: components["schemas"]["ID"][] | null;
     PlanBody: {
@@ -935,10 +947,13 @@ export interface components {
       type: "plan";
       body: components["schemas"]["ExpandedPlanBody"];
     };
-    CreatePlan: { body: components["schemas"]["PlanBody"] };
+    CreatePlan: {
+      body: components["schemas"]["PlanBody"];
+    };
     /** Unexpected error */
     Error: {
-      /** The error type */ type: string;
+      /** The error type */
+      type: string;
       /** Explanation of the errors */
       message: string[];
     };

--- a/tests/v3/expected/manifold.ts
+++ b/tests/v3/expected/manifold.ts
@@ -543,8 +543,12 @@ export interface components {
       version: number;
       body: components["schemas"]["RegionBody"];
     };
-    CreateRegion: { body: components["schemas"]["RegionBody"] };
-    UpdateRegion: { name: string };
+    CreateRegion: {
+      body: components["schemas"]["RegionBody"];
+    };
+    UpdateRegion: {
+      name: string;
+    };
     ProviderBody: {
       owner_id?: components["schemas"]["OptionalFlexID"];
       team_id?: components["schemas"]["OptionalID"];
@@ -569,7 +573,9 @@ export interface components {
       type: "provider";
       body: components["schemas"]["ProviderBody"];
     };
-    CreateProvider: { body: components["schemas"]["ProviderBody"] };
+    CreateProvider: {
+      body: components["schemas"]["ProviderBody"];
+    };
     UpdateProvider: {
       id: components["schemas"]["ID"];
       body: components["schemas"]["UpdateProviderBody"];
@@ -749,7 +755,8 @@ export interface components {
       value: components["schemas"]["FeatureValueLabel"];
     };
     ValueProp: {
-      /** Heading of a value proposition. */ header: string;
+      /** Heading of a value proposition. */
+      header: string;
       /** Body of a value proposition. */
       body: string;
     };
@@ -863,7 +870,10 @@ export interface components {
        * URL to this Product's Terms of Service. If provided is true, then
        * a url must be set. Otherwise, provided is false.
        */
-      terms: { url?: string | null; provided: boolean };
+      terms: {
+        url?: string | null;
+        provided: boolean;
+      };
       feature_types: components["schemas"]["FeatureType"][];
       billing: {
         type: "monthly-prorated" | "monthly-anniversary" | "annual-anniversary";
@@ -884,7 +894,9 @@ export interface components {
       type: "product";
       body: components["schemas"]["ProductBody"];
     };
-    CreateProduct: { body: components["schemas"]["ProductBody"] };
+    CreateProduct: {
+      body: components["schemas"]["ProductBody"];
+    };
     /** Array of Plan IDs that this Plan can be resized to, if null all will be assumed */
     PlanResizeList: components["schemas"]["ID"][] | null;
     PlanBody: {
@@ -935,10 +947,13 @@ export interface components {
       type: "plan";
       body: components["schemas"]["ExpandedPlanBody"];
     };
-    CreatePlan: { body: components["schemas"]["PlanBody"] };
+    CreatePlan: {
+      body: components["schemas"]["PlanBody"];
+    };
     /** Unexpected error */
     Error: {
-      /** The error type */ type: string;
+      /** The error type */
+      type: string;
       /** Explanation of the errors */
       message: string[];
     };

--- a/tests/v3/expected/petstore.ts
+++ b/tests/v3/expected/petstore.ts
@@ -144,7 +144,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** Updated name of the pet */ name?: string;
+        /** Updated name of the pet */
+        name?: string;
         /** Updated status of the pet */
         status?: string;
       };
@@ -180,7 +181,8 @@ export interface operations {
     };
     requestBody: {
       "multipart/form-data": {
-        /** Additional data to pass to server */ additionalMetadata?: string;
+        /** Additional data to pass to server */
+        additionalMetadata?: string;
         /** file to upload */
         file?: string;
       };
@@ -368,7 +370,10 @@ export interface components {
       status?: "placed" | "approved" | "delivered";
       complete?: boolean;
     };
-    Category: { id?: number; name?: string };
+    Category: {
+      id?: number;
+      name?: string;
+    };
     User: {
       id?: number;
       username?: string;
@@ -380,7 +385,10 @@ export interface components {
       /** User Status */
       userStatus?: number;
     };
-    Tag: { id?: number; name?: string };
+    Tag: {
+      id?: number;
+      name?: string;
+    };
     Pet: {
       id?: number;
       category?: components["schemas"]["Category"];
@@ -390,6 +398,10 @@ export interface components {
       /** pet status in the store */
       status?: "available" | "pending" | "sold";
     };
-    ApiResponse: { code?: number; type?: string; message?: string };
+    ApiResponse: {
+      code?: number;
+      type?: string;
+      message?: string;
+    };
   };
 }

--- a/tests/v3/expected/stripe.ts
+++ b/tests/v3/expected/stripe.ts
@@ -840,7 +840,9 @@ export interface operations {
    */
   DeleteAccount: {
     requestBody: {
-      "application/x-www-form-urlencoded": { account?: string };
+      "application/x-www-form-urlencoded": {
+        account?: string;
+      };
     };
     responses: {
       /** Successful response. */
@@ -967,7 +969,12 @@ export interface operations {
           tax_id?: string;
           tax_id_registrar?: string;
           vat_id?: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts). */
         default_currency?: string;
@@ -1005,7 +1012,11 @@ export interface operations {
             state?: string;
             town?: string;
           };
-          dob?: Partial<{ day: number; month: number; year: number }> &
+          dob?: Partial<{
+            day: number;
+            month: number;
+            year: number;
+          }> &
             Partial<"">;
           email?: string;
           first_name?: string;
@@ -1021,8 +1032,14 @@ export interface operations {
           phone?: string;
           ssn_last_4?: string;
           verification?: {
-            additional_document?: { back?: string; front?: string };
-            document?: { back?: string; front?: string };
+            additional_document?: {
+              back?: string;
+              front?: string;
+            };
+            document?: {
+              back?: string;
+              front?: string;
+            };
           };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -1046,7 +1063,10 @@ export interface operations {
             secondary_color?: string;
           };
           card_payments?: {
-            decline_on?: { avs_failure?: boolean; cvc_failure?: boolean };
+            decline_on?: {
+              avs_failure?: boolean;
+              cvc_failure?: boolean;
+            };
             statement_descriptor_prefix?: string;
           };
           payments?: {
@@ -1073,7 +1093,11 @@ export interface operations {
           };
         };
         /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
-        tos_acceptance?: { date?: number; ip?: string; user_agent?: string };
+        tos_acceptance?: {
+          date?: number;
+          ip?: string;
+          user_agent?: string;
+        };
       };
     };
     responses: {
@@ -1604,7 +1628,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -1647,8 +1675,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -1749,7 +1783,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -1792,8 +1830,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -1886,7 +1930,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -1929,8 +1977,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -2031,7 +2085,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -2074,8 +2132,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -2256,7 +2320,12 @@ export interface operations {
           tax_id?: string;
           tax_id_registrar?: string;
           vat_id?: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** The country in which the account holder resides, or in which the business is legally established. This should be an ISO 3166-1 alpha-2 country code. For example, if you are in the United States and the business for which you're creating an account is legally represented in Canada, you would use `CA` as the country for the account being created. */
         country?: string;
@@ -2296,7 +2365,11 @@ export interface operations {
             state?: string;
             town?: string;
           };
-          dob?: Partial<{ day: number; month: number; year: number }> &
+          dob?: Partial<{
+            day: number;
+            month: number;
+            year: number;
+          }> &
             Partial<"">;
           email?: string;
           first_name?: string;
@@ -2312,8 +2385,14 @@ export interface operations {
           phone?: string;
           ssn_last_4?: string;
           verification?: {
-            additional_document?: { back?: string; front?: string };
-            document?: { back?: string; front?: string };
+            additional_document?: {
+              back?: string;
+              front?: string;
+            };
+            document?: {
+              back?: string;
+              front?: string;
+            };
           };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -2337,7 +2416,10 @@ export interface operations {
             secondary_color?: string;
           };
           card_payments?: {
-            decline_on?: { avs_failure?: boolean; cvc_failure?: boolean };
+            decline_on?: {
+              avs_failure?: boolean;
+              cvc_failure?: boolean;
+            };
             statement_descriptor_prefix?: string;
           };
           payments?: {
@@ -2364,7 +2446,11 @@ export interface operations {
           };
         };
         /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
-        tos_acceptance?: { date?: number; ip?: string; user_agent?: string };
+        tos_acceptance?: {
+          date?: number;
+          ip?: string;
+          user_agent?: string;
+        };
         /** The type of Stripe account to create. Currently must be `custom`, as only [Custom accounts](https://stripe.com/docs/connect/custom-accounts) may be created via the API. */
         type?: "custom" | "express" | "standard";
       };
@@ -2529,7 +2615,12 @@ export interface operations {
           tax_id?: string;
           tax_id_registrar?: string;
           vat_id?: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts). */
         default_currency?: string;
@@ -2567,7 +2658,11 @@ export interface operations {
             state?: string;
             town?: string;
           };
-          dob?: Partial<{ day: number; month: number; year: number }> &
+          dob?: Partial<{
+            day: number;
+            month: number;
+            year: number;
+          }> &
             Partial<"">;
           email?: string;
           first_name?: string;
@@ -2583,8 +2678,14 @@ export interface operations {
           phone?: string;
           ssn_last_4?: string;
           verification?: {
-            additional_document?: { back?: string; front?: string };
-            document?: { back?: string; front?: string };
+            additional_document?: {
+              back?: string;
+              front?: string;
+            };
+            document?: {
+              back?: string;
+              front?: string;
+            };
           };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -2608,7 +2709,10 @@ export interface operations {
             secondary_color?: string;
           };
           card_payments?: {
-            decline_on?: { avs_failure?: boolean; cvc_failure?: boolean };
+            decline_on?: {
+              avs_failure?: boolean;
+              cvc_failure?: boolean;
+            };
             statement_descriptor_prefix?: string;
           };
           payments?: {
@@ -2635,7 +2739,11 @@ export interface operations {
           };
         };
         /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
-        tos_acceptance?: { date?: number; ip?: string; user_agent?: string };
+        tos_acceptance?: {
+          date?: number;
+          ip?: string;
+          user_agent?: string;
+        };
       };
     };
     responses: {
@@ -3205,7 +3313,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -3248,8 +3360,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -3352,7 +3470,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -3395,8 +3517,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -3496,7 +3624,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -3539,8 +3671,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -3643,7 +3781,11 @@ export interface operations {
           town?: string;
         };
         /** The person's date of birth. */
-        dob?: Partial<{ day: number; month: number; year: number }> &
+        dob?: Partial<{
+          day: number;
+          month: number;
+          year: number;
+        }> &
           Partial<"">;
         /** The person's email address. */
         email?: string;
@@ -3686,8 +3828,14 @@ export interface operations {
         ssn_last_4?: string;
         /** The person's verification status. */
         verification?: {
-          additional_document?: { back?: string; front?: string };
-          document?: { back?: string; front?: string };
+          additional_document?: {
+            back?: string;
+            front?: string;
+          };
+          document?: {
+            back?: string;
+            front?: string;
+          };
         };
       };
     };
@@ -4276,7 +4424,8 @@ export interface operations {
   PostBillingPortalSessions: {
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The ID of an existing customer. */ customer: string;
+        /** The ID of an existing customer. */
+        customer: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** The URL to which Stripe should send customers when they click on the link to return to your website. This field is required if a default return URL has not been configured for the portal. */
@@ -4526,7 +4675,10 @@ export interface operations {
         customer?: string;
         /** An arbitrary string which you can attach to a `Charge` object. It is displayed when in the web interface alongside the charge. Note that if you use Stripe to send automatic email receipts to your customers, your receipt emails will include the `description` of the charge(s) that they are describing. */
         description?: string;
-        destination?: Partial<{ account: string; amount?: number }> &
+        destination?: Partial<{
+          account: string;
+          amount?: number;
+        }> &
           Partial<string>;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
@@ -4558,7 +4710,10 @@ export interface operations {
         /** Provides information about the charge that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
         statement_descriptor_suffix?: string;
         /** An optional dictionary including the account to automatically transfer to as part of a destination charge. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details. */
-        transfer_data?: { amount?: number; destination: string };
+        transfer_data?: {
+          amount?: number;
+          destination: string;
+        };
         /** A string that identifies this transaction as part of a group. For details, see [Grouping transactions](https://stripe.com/docs/connect/charges-transfers#transfer-options). */
         transfer_group?: string;
       };
@@ -4615,7 +4770,9 @@ export interface operations {
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** A set of key-value pairs you can attach to a charge giving information about its riskiness. If you believe a charge is fraudulent, include a `user_report` key with a value of `fraudulent`. If you believe a charge is safe, include a `user_report` key with a value of `safe`. Stripe will use the information you send to improve our fraud detection algorithms. */
-        fraud_details?: { user_report: "" | "fraudulent" | "safe" };
+        fraud_details?: {
+          user_report: "" | "fraudulent" | "safe";
+        };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: Partial<{ [key: string]: string }> & Partial<"">;
         /** This is the email address that the receipt for this charge will be sent to. If this field is updated, then a new email receipt will be sent to the updated address. */
@@ -4678,7 +4835,9 @@ export interface operations {
         /** Provides information about the charge that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
         statement_descriptor_suffix?: string;
         /** An optional dictionary including the account to automatically transfer to as part of a destination charge. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details. */
-        transfer_data?: { amount?: number };
+        transfer_data?: {
+          amount?: number;
+        };
         /** A string that identifies this transaction as part of a group. `transfer_group` may only be provided if it has not been set. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details. */
         transfer_group?: string;
       };
@@ -5101,7 +5260,10 @@ export interface operations {
           };
           statement_descriptor?: string;
           statement_descriptor_suffix?: string;
-          transfer_data?: { amount?: number; destination: string };
+          transfer_data?: {
+            amount?: number;
+            destination: string;
+          };
         };
         /** A list of the types of payment methods (e.g., card) this Checkout session can accept. */
         payment_method_types: ("card" | "fpx" | "ideal")[];
@@ -5364,7 +5526,11 @@ export interface operations {
         subscription_data?: {
           application_fee_percent?: number;
           default_tax_rates?: string[];
-          items?: { plan: string; quantity?: number; tax_rates?: string[] }[];
+          items?: {
+            plan: string;
+            quantity?: number;
+            tax_rates?: string[];
+          }[];
           metadata?: { [key: string]: string };
           trial_end?: number;
           trial_from_plan?: boolean;
@@ -6059,7 +6225,12 @@ export interface operations {
         invoice_prefix?: string;
         /** Default invoice settings for this customer. */
         invoice_settings?: {
-          custom_fields?: Partial<{ name: string; value: string }[]> &
+          custom_fields?: Partial<
+            {
+              name: string;
+              value: string;
+            }[]
+          > &
             Partial<"">;
           default_payment_method?: string;
           footer?: string;
@@ -6258,7 +6429,12 @@ export interface operations {
         invoice_prefix?: string;
         /** Default invoice settings for this customer. */
         invoice_settings?: {
-          custom_fields?: Partial<{ name: string; value: string }[]> &
+          custom_fields?: Partial<
+            {
+              name: string;
+              value: string;
+            }[]
+          > &
             Partial<"">;
           default_payment_method?: string;
           footer?: string;
@@ -7281,7 +7457,10 @@ export interface operations {
         expand?: string[];
         /** A list of up to 20 subscription items, each with an attached plan. */
         items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           metadata?: { [key: string]: string };
           plan?: string;
           quantity?: number;
@@ -7438,7 +7617,10 @@ export interface operations {
         expand?: string[];
         /** List of subscription items, each with an attached plan. */
         items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
@@ -8351,7 +8533,10 @@ export interface operations {
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: Partial<{ [key: string]: string }> & Partial<"">;
         /** The period associated with this invoice item. */
-        period?: { end: number; start: number };
+        period?: {
+          end: number;
+          start: number;
+        };
         /** Non-negative integer. The quantity of units for the invoice item. */
         quantity?: number;
         /** The ID of a subscription to add this invoice item to. When left blank, the invoice item will be be added to the next upcoming scheduled invoice. When set, scheduled invoices for subscriptions other than the specified subscription will ignore the invoice item. Use this when you want to express that an invoice item has been accrued within the context of a particular subscription. */
@@ -8441,7 +8626,10 @@ export interface operations {
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: Partial<{ [key: string]: string }> & Partial<"">;
         /** The period associated with this invoice item. */
-        period?: { end: number; start: number };
+        period?: {
+          end: number;
+          start: number;
+        };
         /** Non-negative integer. The quantity of units for the invoice item. */
         quantity?: number;
         /** The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the invoice do not apply to this invoice item. Pass an empty string to remove previously-defined tax rates. */
@@ -8532,7 +8720,12 @@ export interface operations {
         /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions. Defaults to `charge_automatically`. */
         collection_method?: "charge_automatically" | "send_invoice";
         /** A list of up to 4 custom fields to be displayed on the invoice. */
-        custom_fields?: Partial<{ name: string; value: string }[]> &
+        custom_fields?: Partial<
+          {
+            name: string;
+            value: string;
+          }[]
+        > &
           Partial<"">;
         /** The ID of the customer who will be billed. */
         customer: string;
@@ -8597,7 +8790,10 @@ export interface operations {
           discountable?: boolean;
           invoiceitem?: string;
           metadata?: Partial<{ [key: string]: string }> & Partial<"">;
-          period?: { end: number; start: number };
+          period?: {
+            end: number;
+            start: number;
+          };
           quantity?: number;
           tax_rates?: Partial<string[]> & Partial<"">;
           unit_amount?: number;
@@ -8620,7 +8816,10 @@ export interface operations {
         subscription_default_tax_rates?: Partial<string[]> & Partial<"">;
         /** List of subscription items, each with an attached plan. */
         subscription_items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
@@ -8688,7 +8887,10 @@ export interface operations {
           discountable?: boolean;
           invoiceitem?: string;
           metadata?: Partial<{ [key: string]: string }> & Partial<"">;
-          period?: { end: number; start: number };
+          period?: {
+            end: number;
+            start: number;
+          };
           quantity?: number;
           tax_rates?: Partial<string[]> & Partial<"">;
           unit_amount?: number;
@@ -8715,7 +8917,10 @@ export interface operations {
         subscription_default_tax_rates?: Partial<string[]> & Partial<"">;
         /** List of subscription items, each with an attached plan. */
         subscription_items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
@@ -8841,7 +9046,12 @@ export interface operations {
         /** Either `charge_automatically` or `send_invoice`. This field can be updated only on `draft` invoices. */
         collection_method?: "charge_automatically" | "send_invoice";
         /** A list of up to 4 custom fields to be displayed on the invoice. If a value for `custom_fields` is specified, the list specified will replace the existing custom field list on this invoice. Pass an empty string to remove previously-defined fields. */
-        custom_fields?: Partial<{ name: string; value: string }[]> &
+        custom_fields?: Partial<
+          {
+            name: string;
+            value: string;
+          }[]
+        > &
           Partial<"">;
         /** The number of days from which the invoice is created until it is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices. */
         days_until_due?: number;
@@ -9348,17 +9558,28 @@ export interface operations {
           };
         };
         /** Additional information about a `company` cardholder. */
-        company?: { tax_id?: string };
+        company?: {
+          tax_id?: string;
+        };
         /** The cardholder's email address. */
         email?: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Additional information about an `individual` cardholder. */
         individual?: {
-          dob?: { day: number; month: number; year: number };
+          dob?: {
+            day: number;
+            month: number;
+            year: number;
+          };
           first_name: string;
           last_name: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: { [key: string]: string };
@@ -10313,17 +10534,28 @@ export interface operations {
           };
         };
         /** Additional information about a `company` cardholder. */
-        company?: { tax_id?: string };
+        company?: {
+          tax_id?: string;
+        };
         /** The cardholder's email address. */
         email?: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Additional information about an `individual` cardholder. */
         individual?: {
-          dob?: { day: number; month: number; year: number };
+          dob?: {
+            day: number;
+            month: number;
+            year: number;
+          };
           first_name: string;
           last_name: string;
-          verification?: { document?: { back?: string; front?: string } };
+          verification?: {
+            document?: {
+              back?: string;
+              front?: string;
+            };
+          };
         };
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
         metadata?: { [key: string]: string };
@@ -13727,7 +13959,10 @@ export interface operations {
         /** The shipping method to select for fulfilling this order. If specified, must be one of the `id`s of a shipping method in the `shipping_methods` array. If specified, will overwrite the existing selected shipping method, updating `items` as necessary. */
         selected_shipping_method?: string;
         /** Tracking information once the order has been fulfilled. */
-        shipping?: { carrier: string; tracking_number: string };
+        shipping?: {
+          carrier: string;
+          tracking_number: string;
+        };
         /** Current order status. One of `created`, `paid`, `canceled`, `fulfilled`, or `returned`. More detail in the [Orders Guide](https://stripe.com/docs/orders/guide#understanding-order-statuses). */
         status?: "canceled" | "created" | "fulfilled" | "paid" | "returned";
       };
@@ -13909,7 +14144,10 @@ export interface operations {
           customer_acceptance: {
             accepted_at?: number;
             offline?: { [key: string]: any };
-            online?: { ip_address: string; user_agent: string };
+            online?: {
+              ip_address: string;
+              user_agent: string;
+            };
             type: "offline" | "online";
           };
         };
@@ -13978,7 +14216,10 @@ export interface operations {
          * The parameters used to automatically create a Transfer when the payment succeeds.
          * For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
          */
-        transfer_data?: { amount?: number; destination: string };
+        transfer_data?: {
+          amount?: number;
+          destination: string;
+        };
         /** A string that identifies the resulting payment as part of a group. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
         transfer_group?: string;
         /** Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle additional authentication steps. */
@@ -14119,7 +14360,9 @@ export interface operations {
         /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
         statement_descriptor_suffix?: string;
         /** The parameters used to automatically create a Transfer when the payment succeeds. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts). */
-        transfer_data?: { amount?: number };
+        transfer_data?: {
+          amount?: number;
+        };
         /** A string that identifies the resulting payment as part of a group. `transfer_group` may only be provided if it has not been set. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
         transfer_group?: string;
       };
@@ -14202,7 +14445,9 @@ export interface operations {
          * The parameters used to automatically create a Transfer when the payment
          * is captured. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
          */
-        transfer_data?: { amount?: number };
+        transfer_data?: {
+          amount?: number;
+        };
       };
     };
     responses: {
@@ -14251,7 +14496,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The client secret of the PaymentIntent. */ client_secret?: string;
+        /** The client secret of the PaymentIntent. */
+        client_secret?: string;
         /** Set to `true` to fail the payment attempt if the PaymentIntent transitions into `requires_action`. This parameter is intended for simpler integrations that do not handle customer actions, like [saving cards without authentication](https://stripe.com/docs/payments/save-card-without-authentication). */
         error_on_requires_action?: boolean;
         /** Specifies which fields in the response should be expanded. */
@@ -14263,13 +14509,19 @@ export interface operations {
           customer_acceptance: {
             accepted_at?: number;
             offline?: { [key: string]: any };
-            online?: { ip_address: string; user_agent: string };
+            online?: {
+              ip_address: string;
+              user_agent: string;
+            };
             type: "offline" | "online";
           };
         }> &
           Partial<{
             customer_acceptance: {
-              online: { ip_address?: string; user_agent?: string };
+              online: {
+                ip_address?: string;
+                user_agent?: string;
+              };
               type: "online";
             };
           }>;
@@ -14395,7 +14647,10 @@ export interface operations {
     requestBody: {
       "application/x-www-form-urlencoded": {
         /** If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account. */
-        au_becs_debit?: { account_number: string; bsb_number: string };
+        au_becs_debit?: {
+          account_number: string;
+          bsb_number: string;
+        };
         /** Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods. */
         billing_details?: {
           address?: {
@@ -14417,7 +14672,9 @@ export interface operations {
           exp_year: number;
           number: string;
         }> &
-          Partial<{ token: string }>;
+          Partial<{
+            token: string;
+          }>;
         /** The `Customer` to whom the original PaymentMethod is attached. */
         customer?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -14467,7 +14724,9 @@ export interface operations {
         /** The PaymentMethod to share. */
         payment_method?: string;
         /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
-        sepa_debit?: { iban: string };
+        sepa_debit?: {
+          iban: string;
+        };
         /** The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type. Required unless `payment_method` is specified (see the [Cloning PaymentMethods](https://stripe.com/docs/payments/payment-methods/connect#cloning-payment-methods) guide) */
         type?: "au_becs_debit" | "card" | "fpx" | "ideal" | "sepa_debit";
       };
@@ -14532,7 +14791,10 @@ export interface operations {
           phone?: string;
         };
         /** If this is a `card` PaymentMethod, this hash contains the user's card details. */
-        card?: { exp_month?: number; exp_year?: number };
+        card?: {
+          exp_month?: number;
+          exp_year?: number;
+        };
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -14880,7 +15142,10 @@ export interface operations {
         /** Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows. */
         tiers_mode?: "graduated" | "volume";
         /** Apply a transformation to the reported usage or set quantity before computing the billed price. Cannot be combined with `tiers`. */
-        transform_usage?: { divide_by: number; round: "down" | "up" };
+        transform_usage?: {
+          divide_by: number;
+          round: "down" | "up";
+        };
         /** Default number of trial days when subscribing a customer to this plan using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan). */
         trial_period_days?: number;
         /** Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`. */
@@ -15146,7 +15411,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** Whether the product is available for purchase. */ active?: boolean;
+        /** Whether the product is available for purchase. */
+        active?: boolean;
         /** A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g., `["color", "size"]`). If a value for `attributes` is specified, the list specified will replace the existing attributes list on this product. Any attributes not present after the update will be deleted from the SKUs for this product. */
         attributes?: Partial<string[]> & Partial<"">;
         /** A short one-line description of the product, meant to be displayable to the customer. May only be set if `type=good`. */
@@ -15431,7 +15697,8 @@ export interface operations {
   PostRadarValueLists: {
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The name of the value list for use in rules. */ alias: string;
+        /** The name of the value list for use in rules. */
+        alias: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Type of the items in the value list. One of `card_fingerprint`, `card_bin`, `email`, `ip_address`, `country`, `string`, or `case_sensitive_string`. Use `string` if the item type is unknown or mixed. */
@@ -15515,7 +15782,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The name of the value list for use in rules. */ alias?: string;
+        /** The name of the value list for use in rules. */
+        alias?: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -16787,7 +17055,10 @@ export interface operations {
           customer_acceptance: {
             accepted_at?: number;
             offline?: { [key: string]: any };
-            online?: { ip_address: string; user_agent: string };
+            online?: {
+              ip_address: string;
+              user_agent: string;
+            };
             type: "offline" | "online";
           };
         };
@@ -16799,14 +17070,19 @@ export interface operations {
         payment_method?: string;
         /** Payment-method-specific configuration for this SetupIntent. */
         payment_method_options?: {
-          card?: { request_three_d_secure?: "any" | "automatic" };
+          card?: {
+            request_three_d_secure?: "any" | "automatic";
+          };
         };
         /** The list of payment method types (e.g. card) that this SetupIntent is allowed to use. If this is not provided, defaults to ["card"]. */
         payment_method_types?: string[];
         /** The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site. If you'd prefer to redirect to a mobile application, you can alternatively supply an application URI scheme. This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm). */
         return_url?: string;
         /** If this hash is populated, this SetupIntent will generate a single_use Mandate on success. */
-        single_use?: { amount: number; currency: string };
+        single_use?: {
+          amount: number;
+          currency: string;
+        };
         /** Indicates how the payment method is intended to be used in the future. If not provided, this value defaults to `off_session`. */
         usage?: "off_session" | "on_session";
       };
@@ -16880,7 +17156,9 @@ export interface operations {
         payment_method?: string;
         /** Payment-method-specific configuration for this SetupIntent. */
         payment_method_options?: {
-          card?: { request_three_d_secure?: "any" | "automatic" };
+          card?: {
+            request_three_d_secure?: "any" | "automatic";
+          };
         };
         /** The list of payment method types (e.g. card) that this SetupIntent is allowed to set up. If this is not provided, defaults to ["card"]. */
         payment_method_types?: string[];
@@ -16953,7 +17231,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** The client secret of the SetupIntent. */ client_secret?: string;
+        /** The client secret of the SetupIntent. */
+        client_secret?: string;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** This hash contains details about the Mandate to create */
@@ -16961,13 +17240,19 @@ export interface operations {
           customer_acceptance: {
             accepted_at?: number;
             offline?: { [key: string]: any };
-            online?: { ip_address: string; user_agent: string };
+            online?: {
+              ip_address: string;
+              user_agent: string;
+            };
             type: "offline" | "online";
           };
         }> &
           Partial<{
             customer_acceptance: {
-              online: { ip_address?: string; user_agent?: string };
+              online: {
+                ip_address?: string;
+                user_agent?: string;
+              };
               type: "online";
             };
           }>;
@@ -16975,7 +17260,9 @@ export interface operations {
         payment_method?: string;
         /** Payment-method-specific configuration for this SetupIntent. */
         payment_method_options?: {
-          card?: { request_three_d_secure?: "any" | "automatic" };
+          card?: {
+            request_three_d_secure?: "any" | "automatic";
+          };
         };
         /**
          * The URL to redirect your customer back to after they authenticate on the payment method's app or site.
@@ -17211,7 +17498,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** Whether this SKU is available for purchase. */ active?: boolean;
+        /** Whether this SKU is available for purchase. */
+        active?: boolean;
         /** A dictionary of attributes and values for the attributes defined by the product. When specified, `attributes` will partially update the existing attributes dictionary on the product, with the postcondition that a value must be present for each attribute key on the product. */
         attributes?: { [key: string]: string };
         /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -17272,8 +17560,14 @@ export interface operations {
           acceptance?: {
             date?: number;
             ip?: string;
-            offline?: { contact_email: string };
-            online?: { date?: number; ip?: string; user_agent?: string };
+            offline?: {
+              contact_email: string;
+            };
+            online?: {
+              date?: number;
+              ip?: string;
+              user_agent?: string;
+            };
             status: "accepted" | "pending" | "refused" | "revoked";
             type?: "offline" | "online";
             user_agent?: string;
@@ -17306,9 +17600,13 @@ export interface operations {
           phone?: string;
         };
         /** Optional parameters for the receiver flow. Can be set only if the source is a receiver (`flow` is `receiver`). */
-        receiver?: { refund_attributes_method?: "email" | "manual" | "none" };
+        receiver?: {
+          refund_attributes_method?: "email" | "manual" | "none";
+        };
         /** Parameters required for the redirect flow. Required if the source is authenticated by a redirect (`flow` is `redirect`). */
-        redirect?: { return_url: string };
+        redirect?: {
+          return_url: string;
+        };
         /** Information about the items and shipping associated with the source. Required for transactional credit (for example Klarna) sources before you can charge it. */
         source_order?: {
           items?: {
@@ -17394,7 +17692,8 @@ export interface operations {
     };
     requestBody: {
       "application/x-www-form-urlencoded": {
-        /** Amount associated with the source. */ amount?: number;
+        /** Amount associated with the source. */
+        amount?: number;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Information about a mandate possibility attached to a source object (generally for bank debits) as well as its acceptance status. */
@@ -17402,8 +17701,14 @@ export interface operations {
           acceptance?: {
             date?: number;
             ip?: string;
-            offline?: { contact_email: string };
-            online?: { date?: number; ip?: string; user_agent?: string };
+            offline?: {
+              contact_email: string;
+            };
+            online?: {
+              date?: number;
+              ip?: string;
+              user_agent?: string;
+            };
             status: "accepted" | "pending" | "refused" | "revoked";
             type?: "offline" | "online";
             user_agent?: string;
@@ -17632,7 +17937,10 @@ export interface operations {
     requestBody: {
       "application/x-www-form-urlencoded": {
         /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-        billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+        billing_thresholds?: Partial<{
+          usage_gte: number;
+        }> &
+          Partial<"">;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -17752,7 +18060,10 @@ export interface operations {
     requestBody: {
       "application/x-www-form-urlencoded": {
         /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-        billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+        billing_thresholds?: Partial<{
+          usage_gte: number;
+        }> &
+          Partial<"">;
         /** Specifies which fields in the response should be expanded. */
         expand?: string[];
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -17969,7 +18280,9 @@ export interface operations {
             Partial<"">;
           collection_method?: "charge_automatically" | "send_invoice";
           default_payment_method?: string;
-          invoice_settings?: { days_until_due?: number };
+          invoice_settings?: {
+            days_until_due?: number;
+          };
         };
         /** Configures how the subscription schedule behaves when it ends. Possible values are `release` or `cancel` with the default being `release`. `release` will end the subscription schedule and keep the underlying subscription running.`cancel` will end the subscription schedule and cancel the underlying subscription. */
         end_behavior?: "cancel" | "none" | "release" | "renew";
@@ -17992,10 +18305,15 @@ export interface operations {
           default_payment_method?: string;
           default_tax_rates?: Partial<string[]> & Partial<"">;
           end_date?: number;
-          invoice_settings?: { days_until_due?: number };
+          invoice_settings?: {
+            days_until_due?: number;
+          };
           iterations?: number;
           plans: {
-            billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+            billing_thresholds?: Partial<{
+              usage_gte: number;
+            }> &
+              Partial<"">;
             plan?: string;
             quantity?: number;
             tax_rates?: Partial<string[]> & Partial<"">;
@@ -18063,7 +18381,9 @@ export interface operations {
             Partial<"">;
           collection_method?: "charge_automatically" | "send_invoice";
           default_payment_method?: string;
-          invoice_settings?: { days_until_due?: number };
+          invoice_settings?: {
+            days_until_due?: number;
+          };
         };
         /** Configures how the subscription schedule behaves when it ends. Possible values are `release` or `cancel` with the default being `release`. `release` will end the subscription schedule and keep the underlying subscription running.`cancel` will end the subscription schedule and cancel the underlying subscription. */
         end_behavior?: "cancel" | "none" | "release" | "renew";
@@ -18084,10 +18404,15 @@ export interface operations {
           default_payment_method?: string;
           default_tax_rates?: Partial<string[]> & Partial<"">;
           end_date?: Partial<number> & Partial<"now">;
-          invoice_settings?: { days_until_due?: number };
+          invoice_settings?: {
+            days_until_due?: number;
+          };
           iterations?: number;
           plans: {
-            billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+            billing_thresholds?: Partial<{
+              usage_gte: number;
+            }> &
+              Partial<"">;
             plan?: string;
             quantity?: number;
             tax_rates?: Partial<string[]> & Partial<"">;
@@ -18281,7 +18606,10 @@ export interface operations {
         expand?: string[];
         /** A list of up to 20 subscription items, each with an attached plan. */
         items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           metadata?: { [key: string]: string };
           plan?: string;
           quantity?: number;
@@ -18435,7 +18763,10 @@ export interface operations {
         expand?: string[];
         /** List of subscription items, each with an attached plan. */
         items?: {
-          billing_thresholds?: Partial<{ usage_gte: number }> & Partial<"">;
+          billing_thresholds?: Partial<{
+            usage_gte: number;
+          }> &
+            Partial<"">;
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
@@ -19047,7 +19378,12 @@ export interface operations {
             tax_id?: string;
             tax_id_registrar?: string;
             vat_id?: string;
-            verification?: { document?: { back?: string; front?: string } };
+            verification?: {
+              document?: {
+                back?: string;
+                front?: string;
+              };
+            };
           };
           individual?: {
             address?: {
@@ -19076,7 +19412,11 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: Partial<{ day: number; month: number; year: number }> &
+            dob?: Partial<{
+              day: number;
+              month: number;
+              year: number;
+            }> &
               Partial<"">;
             email?: string;
             first_name?: string;
@@ -19092,8 +19432,14 @@ export interface operations {
             phone?: string;
             ssn_last_4?: string;
             verification?: {
-              additional_document?: { back?: string; front?: string };
-              document?: { back?: string; front?: string };
+              additional_document?: {
+                back?: string;
+                front?: string;
+              };
+              document?: {
+                back?: string;
+                front?: string;
+              };
             };
           };
           tos_shown_and_accepted?: boolean;
@@ -19154,7 +19500,11 @@ export interface operations {
             state?: string;
             town?: string;
           };
-          dob?: Partial<{ day: number; month: number; year: number }> &
+          dob?: Partial<{
+            day: number;
+            month: number;
+            year: number;
+          }> &
             Partial<"">;
           email?: string;
           first_name?: string;
@@ -19178,12 +19528,20 @@ export interface operations {
           };
           ssn_last_4?: string;
           verification?: {
-            additional_document?: { back?: string; front?: string };
-            document?: { back?: string; front?: string };
+            additional_document?: {
+              back?: string;
+              front?: string;
+            };
+            document?: {
+              back?: string;
+              front?: string;
+            };
           };
         };
         /** The PII this token will represent. */
-        pii?: { id_number?: string };
+        pii?: {
+          id_number?: string;
+        };
       };
     };
     responses: {
@@ -20452,7 +20810,8 @@ export interface components {
       user_agent?: string | null;
     };
     address: {
-      /** City, district, suburb, town, or village. */ city?: string | null;
+      /** City, district, suburb, town, or village. */
+      city?: string | null;
       /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
       country?: string | null;
       /** Address line 1 (e.g., street, PO Box, or company name). */
@@ -20495,7 +20854,8 @@ export interface components {
       username: string;
     };
     api_errors: {
-      /** For card errors, the ID of the failed charge. */ charge?: string;
+      /** For card errors, the ID of the failed charge. */
+      charge?: string;
       /** For some errors that could be handled programmatically, a short string indicating the [error code](https://stripe.com/docs/error-codes) reported. */
       code?: string;
       /** For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://stripe.com/docs/declines#issuer-declines) if they provide one. */
@@ -20535,7 +20895,8 @@ export interface components {
       object: "apple_pay_domain";
     };
     application: {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** The name of the application. */
       name?: string | null;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -20612,13 +20973,15 @@ export interface components {
       pending: components["schemas"]["balance_amount"][];
     };
     balance_amount: {
-      /** Balance amount. */ amount: number;
+      /** Balance amount. */
+      amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       source_types?: components["schemas"]["balance_amount_by_source_type"];
     };
     balance_amount_by_source_type: {
-      /** Amount for bank account. */ bank_account?: number;
+      /** Amount for bank account. */
+      bank_account?: number;
       /** Amount for card. */
       card?: number;
       /** Amount for FPX. */
@@ -20631,7 +20994,8 @@ export interface components {
      * Related guide: [Balance Transaction Types](https://stripe.com/docs/reports/balance-transaction-types).
      */
     balance_transaction: {
-      /** Gross amount of the transaction, in %s. */ amount: number;
+      /** Gross amount of the transaction, in %s. */
+      amount: number;
       /** The date the transaction's net funds will become available in the Stripe balance. */
       available_on: number;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -21240,14 +21604,16 @@ export interface components {
       success_url: string;
     };
     checkout_session_custom_display_item_description: {
-      /** The description of the line item. */ description?: string | null;
+      /** The description of the line item. */
+      description?: string | null;
       /** The images of the line item. */
       images?: string[] | null;
       /** The name of the line item. */
       name: string;
     };
     checkout_session_display_item: {
-      /** Amount for the display item. */ amount?: number;
+      /** Amount for the display item. */
+      amount?: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency?: string;
       custom?: components["schemas"]["checkout_session_custom_display_item_description"];
@@ -21259,7 +21625,8 @@ export interface components {
       type?: string;
     };
     connect_collection_transfer: {
-      /** Amount transferred, in %s. */ amount: number;
+      /** Amount transferred, in %s. */
+      amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** ID of the account that funds are being collected for. */
@@ -21448,7 +21815,8 @@ export interface components {
       unit_amount_decimal?: string | null;
     };
     credit_note_tax_amount: {
-      /** The amount, in %s, of the tax. */ amount: number;
+      /** The amount, in %s, of the tax. */
+      amount: number;
       /** Whether this tax amount is inclusive or exclusive. */
       inclusive: boolean;
       /** The tax rate that was applied to get this tax amount. */
@@ -21611,21 +21979,24 @@ export interface components {
         | "unspent_receiver_credit";
     };
     deleted_account: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "account";
     };
     deleted_alipay_account: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "alipay_account";
     };
     deleted_apple_pay_domain: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -21642,7 +22013,8 @@ export interface components {
       object: "bank_account";
     };
     deleted_bitcoin_receiver: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -21659,21 +22031,24 @@ export interface components {
       object: "card";
     };
     deleted_coupon: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "coupon";
     };
     deleted_customer: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "customer";
     };
     deleted_discount: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "discount";
     };
@@ -21682,14 +22057,16 @@ export interface components {
     > &
       Partial<components["schemas"]["deleted_card"]>;
     deleted_invoice: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "invoice";
     };
     deleted_invoiceitem: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -21702,84 +22079,96 @@ export interface components {
       Partial<components["schemas"]["deleted_bitcoin_receiver"]> &
       Partial<components["schemas"]["deleted_card"]>;
     deleted_person: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "person";
     };
     deleted_plan: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "plan";
     };
     deleted_product: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "product";
     };
     "deleted_radar.value_list": {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "radar.value_list";
     };
     "deleted_radar.value_list_item": {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "radar.value_list_item";
     };
     deleted_recipient: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "recipient";
     };
     deleted_sku: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "sku";
     };
     deleted_subscription_item: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "subscription_item";
     };
     deleted_tax_id: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "tax_id";
     };
     "deleted_terminal.location": {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "terminal.location";
     };
     "deleted_terminal.reader": {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "terminal.reader";
     };
     deleted_webhook_endpoint: {
-      /** Always true for a deleted object */ deleted: true;
+      /** Always true for a deleted object */
+      deleted: true;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -21967,7 +22356,9 @@ export interface components {
       secret?: string;
     };
     /** An error response from the Stripe API */
-    error: { error: components["schemas"]["api_errors"] };
+    error: {
+      error: components["schemas"]["api_errors"];
+    };
     /**
      * Events are our way of letting you know when something interesting happens in
      * your account. When an interesting event occurs, we create a new `Event`
@@ -22000,7 +22391,8 @@ export interface components {
      * guaranteed only for 30 days.
      */
     event: {
-      /** The connected account that originated the event. */ account?: string;
+      /** The connected account that originated the event. */
+      account?: string;
       /** The Stripe API version used to render `data`. *Note: This property is populated only for events on or after October 31, 2014*. */
       api_version?: string | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -22045,7 +22437,8 @@ export interface components {
     external_account: Partial<components["schemas"]["bank_account"]> &
       Partial<components["schemas"]["card"]>;
     fee: {
-      /** Amount of the fee, in cents. */ amount: number;
+      /** Amount of the fee, in cents. */
+      amount: number;
       /** ID of the Connect application that earned the fee. */
       application?: string | null;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -22063,7 +22456,8 @@ export interface components {
      * Related guide: [Refunding Application Fees](https://stripe.com/docs/connect/destination-charges#refunding-app-fee).
      */
     fee_refund: {
-      /** Amount, in %s. */ amount: number;
+      /** Amount, in %s. */
+      amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
         | (Partial<string> &
@@ -22377,12 +22771,14 @@ export interface components {
       usage_gte: number;
     };
     invoice_line_item_period: {
-      /** End of the line item's billing period */ end: number;
+      /** End of the line item's billing period */
+      end: number;
       /** Start of the line item's billing period */
       start: number;
     };
     invoice_setting_custom_field: {
-      /** The name of the custom field. */ name: string;
+      /** The name of the custom field. */
+      name: string;
       /** The value of the custom field. */
       value: string;
     };
@@ -22403,7 +22799,8 @@ export interface components {
       days_until_due?: number | null;
     };
     invoice_tax_amount: {
-      /** The amount, in %s, of the tax. */ amount: number;
+      /** The amount, in %s, of the tax. */
+      amount: number;
       /** Whether this tax amount is inclusive or exclusive. */
       inclusive: boolean;
       /** The tax rate that was applied to get this tax amount. */
@@ -22596,7 +22993,8 @@ export interface components {
     };
     /** You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders. */
     "issuing.card": {
-      /** The brand of the card. */ brand: string;
+      /** The brand of the card. */
+      brand: string;
       /** The reason why the card was canceled. */
       cancellation_reason?: ("lost" | "stolen") | null;
       cardholder: components["schemas"]["issuing.cardholder"];
@@ -22687,7 +23085,8 @@ export interface components {
      * Related guide: [Disputing Transactions](https://stripe.com/docs/issuing/purchases/disputes)
      */
     "issuing.dispute": {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -23465,7 +23864,8 @@ export interface components {
       type: "bulk" | "individual";
     };
     issuing_card_spending_limit: {
-      /** Maximum amount allowed to spend per time interval. */ amount: number;
+      /** Maximum amount allowed to spend per time interval. */
+      amount: number;
       /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges. */
       categories?:
         | (
@@ -23768,7 +24168,9 @@ export interface components {
         | "weekly"
         | "yearly";
     };
-    issuing_cardholder_address: { address: components["schemas"]["address"] };
+    issuing_cardholder_address: {
+      address: components["schemas"]["address"];
+    };
     issuing_cardholder_authorization_controls: {
       /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this cardholder's cards. */
       allowed_categories?:
@@ -24388,7 +24790,8 @@ export interface components {
       > | null;
     };
     issuing_cardholder_individual_dob: {
-      /** The day of birth, between 1 and 31. */ day?: number | null;
+      /** The day of birth, between 1 and 31. */
+      day?: number | null;
       /** The month of birth, between 1 and 12. */
       month?: number | null;
       /** The four-digit year of birth. */
@@ -24411,7 +24814,8 @@ export interface components {
         | null;
     };
     issuing_cardholder_spending_limit: {
-      /** Maximum amount allowed to spend per time interval. */ amount: number;
+      /** Maximum amount allowed to spend per time interval. */
+      amount: number;
       /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges. */
       categories?:
         | (
@@ -24786,14 +25190,16 @@ export interface components {
       front?: (Partial<string> & Partial<components["schemas"]["file"]>) | null;
     };
     legal_entity_dob: {
-      /** The day of birth, between 1 and 31. */ day?: number | null;
+      /** The day of birth, between 1 and 31. */
+      day?: number | null;
       /** The month of birth, between 1 and 12. */
       month?: number | null;
       /** The four-digit year of birth. */
       year?: number | null;
     };
     legal_entity_japan_address: {
-      /** City/Ward. */ city?: string | null;
+      /** City/Ward. */
+      city?: string | null;
       /** Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
       country?: string | null;
       /** Block/Building number. */
@@ -24832,7 +25238,8 @@ export interface components {
     };
     light_account_logout: { [key: string]: any };
     line_item: {
-      /** The amount, in %s. */ amount: number;
+      /** The amount, in %s. */
+      amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
@@ -24908,12 +25315,14 @@ export interface components {
       type: string;
     };
     mandate_sepa_debit: {
-      /** The unique reference of the mandate. */ reference: string;
+      /** The unique reference of the mandate. */
+      reference: string;
       /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
       url: string;
     };
     mandate_single_use: {
-      /** On a single use mandate, the amount of the payment. */ amount: number;
+      /** On a single use mandate, the amount of the payment. */
+      amount: number;
       /** On a single use mandate, the currency of the payment. */
       currency: string;
     };
@@ -25061,7 +25470,8 @@ export interface components {
         | null;
     };
     package_dimensions: {
-      /** Height, in inches. */ height: number;
+      /** Height, in inches. */
+      height: number;
       /** Length, in inches. */
       length: number;
       /** Weight, in ounces. */
@@ -25324,7 +25734,8 @@ export interface components {
       cvc_check?: string | null;
     };
     payment_method_card_generated_card: {
-      /** The charge that created this object. */ charge?: string | null;
+      /** The charge that created this object. */
+      charge?: string | null;
       /** Transaction-specific details of the payment method used in the payment. */
       payment_method_details?: Partial<
         components["schemas"]["payment_method_details"]
@@ -26228,7 +26639,8 @@ export interface components {
      * Related guides: [Set up a subscription](https://stripe.com/docs/billing/subscriptions/set-up-subscription) and more about [products and plans](https://stripe.com/docs/billing/subscriptions/products-and-plans).
      */
     plan: {
-      /** Whether the plan can be used for new purchases. */ active: boolean;
+      /** Whether the plan can be used for new purchases. */
+      active: boolean;
       /** Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`. */
       aggregate_usage?:
         | ("last_during_period" | "last_ever" | "max" | "sum")
@@ -26277,7 +26689,8 @@ export interface components {
       usage_type: "licensed" | "metered";
     };
     plan_tier: {
-      /** Price for the entire tier. */ flat_amount?: number | null;
+      /** Price for the entire tier. */
+      flat_amount?: number | null;
       /** Same as `flat_amount`, but contains a decimal value with at most 12 decimal places. */
       flat_amount_decimal?: string | null;
       /** Per unit price for units relevant to the tier. */
@@ -26288,7 +26701,8 @@ export interface components {
       up_to?: number | null;
     };
     platform_tax_fee: {
-      /** The Connected account that incurred this charge. */ account: string;
+      /** The Connected account that incurred this charge. */
+      account: string;
       /** Unique identifier for the object. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -26378,7 +26792,8 @@ export interface components {
      * Related guide: [Default Stripe Lists](https://stripe.com/docs/radar/lists#managing-list-items).
      */
     "radar.value_list": {
-      /** The name of the value list for use in rules. */ alias: string;
+      /** The name of the value list for use in rules. */
+      alias: string;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** The name or email address of the user who created this value list. */
@@ -26436,7 +26851,8 @@ export interface components {
       value_list: string;
     };
     radar_review_resource_location: {
-      /** The city where the payment originated. */ city?: string | null;
+      /** The city where the payment originated. */
+      city?: string | null;
       /** Two-letter ISO code representing the country where the payment originated. */
       country?: string | null;
       /** The geographic latitude where the payment originated. */
@@ -26517,7 +26933,8 @@ export interface components {
      * Related guide: [Refunds](https://stripe.com/docs/refunds).
      */
     refund: {
-      /** Amount, in %s. */ amount: number;
+      /** Amount, in %s. */
+      amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
         | (Partial<string> &
@@ -26696,7 +27113,8 @@ export interface components {
       > | null;
     };
     rule: {
-      /** The action taken on the payment. */ action: string;
+      /** The action taken on the payment. */
+      action: string;
       /** Unique identifier for the object. */
       id: string;
       /** The predicate to evaluate the payment against. */
@@ -26881,7 +27299,8 @@ export interface components {
       id: string;
     };
     sigma_scheduled_query_run_error: {
-      /** Information about the run failure. */ message: string;
+      /** Information about the run failure. */
+      message: string;
     };
     /**
      * Stores representations of [stock keeping units](http://en.wikipedia.org/wiki/Stock_keeping_unit).
@@ -26894,7 +27313,8 @@ export interface components {
      * Related guide: [Tax, Shipping, and Inventory](https://stripe.com/docs/orders).
      */
     sku: {
-      /** Whether the SKU is available for purchase. */ active: boolean;
+      /** Whether the SKU is available for purchase. */
+      active: boolean;
       /** A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`. */
       attributes: { [key: string]: string };
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -27038,7 +27458,8 @@ export interface components {
       last4?: string;
     };
     source_mandate_notification_sepa_debit_data: {
-      /** SEPA creditor ID. */ creditor_identifier?: string;
+      /** SEPA creditor ID. */
+      creditor_identifier?: string;
       /** Last 4 digits of the account number associated with the debit. */
       last4?: string;
       /** Mandate reference associated with the debit. */
@@ -27056,7 +27477,8 @@ export interface components {
       shipping?: components["schemas"]["shipping"];
     };
     source_order_item: {
-      /** The amount (price) for this order item. */ amount?: number | null;
+      /** The amount (price) for this order item. */
+      amount?: number | null;
       /** This currency of this order item. Required when `amount` is present. */
       currency?: string | null;
       /** Human-readable description for this order item. */
@@ -27156,7 +27578,8 @@ export interface components {
         | "wechat";
     };
     source_transaction_ach_credit_transfer_data: {
-      /** Customer data associated with the transfer. */ customer_data?: string;
+      /** Customer data associated with the transfer. */
+      customer_data?: string;
       /** Bank account fingerprint associated with the transfer. */
       fingerprint?: string;
       /** Last 4 digits of the account number associated with the transfer. */
@@ -27165,7 +27588,8 @@ export interface components {
       routing_number?: string;
     };
     source_transaction_chf_credit_transfer_data: {
-      /** Reference associated with the transfer. */ reference?: string;
+      /** Reference associated with the transfer. */
+      reference?: string;
       /** Sender's country address. */
       sender_address_country?: string;
       /** Sender's line 1 address. */
@@ -27198,7 +27622,8 @@ export interface components {
       invoices?: string;
     };
     source_transaction_sepa_credit_transfer_data: {
-      /** Reference associated with the transfer. */ reference?: string;
+      /** Reference associated with the transfer. */
+      reference?: string;
       /** Sender's bank account IBAN. */
       sender_iban?: string;
       /** Sender's name. */
@@ -27336,7 +27761,9 @@ export interface components {
       refund_account_holder_name?: string | null;
       refund_iban?: string | null;
     };
-    source_type_p24: { reference?: string | null };
+    source_type_p24: {
+      reference?: string | null;
+    };
     source_type_sepa_debit: {
       bank_code?: string | null;
       branch_code?: string | null;
@@ -27380,7 +27807,8 @@ export interface components {
       statement_descriptor?: string;
     };
     status_transitions: {
-      /** The time that the order was canceled. */ canceled?: number | null;
+      /** The time that the order was canceled. */
+      canceled?: number | null;
       /** The time that the order was fulfilled. */
       fulfiled?: number | null;
       /** The time that the order was paid. */
@@ -27709,7 +28137,8 @@ export interface components {
       trial_from_plan?: boolean | null;
     };
     tax_deducted_at_source: {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "tax_deducted_at_source";
       /** The end of the invoicing period. This TDS applies to Stripe fees collected during this invoicing period. */
@@ -27900,7 +28329,8 @@ export interface components {
       version: string;
     };
     three_d_secure_usage: {
-      /** Whether 3D Secure is supported on this card. */ supported: boolean;
+      /** Whether 3D Secure is supported on this card. */
+      supported: boolean;
     };
     /**
      * Tokenization is the process Stripe uses to collect sensitive card or bank
@@ -27952,7 +28382,8 @@ export interface components {
      * Related guide: [Topping Up your Platform Account](https://stripe.com/docs/connect/top-ups).
      */
     topup: {
-      /** Amount transferred. */ amount: number;
+      /** Amount transferred. */
+      amount: number;
       /** ID of the balance transaction that describes the impact of this top-up on your account balance. May not be specified depending on status of top-up. */
       balance_transaction?:
         | (Partial<string> &
@@ -27999,7 +28430,8 @@ export interface components {
      * Related guide: [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers).
      */
     transfer: {
-      /** Amount in %s to be transferred. */ amount: number;
+      /** Amount in %s to be transferred. */
+      amount: number;
       /** Amount in %s reversed (can be less than the amount attribute on the transfer if a partial reversal was issued). */
       amount_reversed: number;
       /** Balance transaction that describes the impact of this transfer on your account balance. */
@@ -28076,7 +28508,8 @@ export interface components {
      * Related guide: [Reversing Transfers](https://stripe.com/docs/connect/charges-transfers#reversing-transfers).
      */
     transfer_reversal: {
-      /** Amount, in %s. */ amount: number;
+      /** Amount, in %s. */
+      amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
         | (Partial<string> &
@@ -28114,7 +28547,8 @@ export interface components {
       weekly_anchor?: string;
     };
     transform_usage: {
-      /** Divide usage by this number. */ divide_by: number;
+      /** Divide usage by this number. */
+      divide_by: number;
       /** After division, either round the result `up` or `down`. */
       round: "down" | "up";
     };
@@ -28125,7 +28559,8 @@ export interface components {
      * Related guide: [Metered Billing](https://stripe.com/docs/billing/subscriptions/metered-billing).
      */
     usage_record: {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -28138,7 +28573,8 @@ export interface components {
       timestamp: number;
     };
     usage_record_summary: {
-      /** Unique identifier for the object. */ id: string;
+      /** Unique identifier for the object. */
+      id: string;
       /** The invoice in which this usage period has been billed for. */
       invoice?: string | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -63,7 +63,9 @@ describe("types", () => {
 
       export interface components {
         schemas: {
-          object: { string?: string };
+          object: {
+            string?: string;
+          };
           string: string;
           string_ref: components['schemas']['string'];
           nullable: string | null;
@@ -99,7 +101,10 @@ describe("types", () => {
 
       export interface components {
         schemas: {
-          object: { integer?: number; number?: number }
+          object: {
+            integer?: number;
+            number?: number;
+          }
           number: number;
           number_ref: components['schemas']['number'];
           nullable: number | null;
@@ -129,7 +134,9 @@ describe("types", () => {
 
       export interface components {
         schemas: {
-          object: { boolean?: boolean };
+          object: {
+            boolean?: boolean;
+          };
           boolean: boolean;
           boolean_ref: components['schemas']['boolean'];
           nullable: boolean | null;
@@ -184,13 +191,20 @@ describe("types", () => {
         schemas: {
           object: {
             object?: {
-              object?: { string?: string; number?: components['schemas']['object_ref'] };
+              object?: {
+                string?: string;
+                number?: components['schemas']['object_ref'];
+              };
             };
           };
-          object_ref: { number?: number };
+          object_ref: {
+            number?: number
+          };
           object_unknown: { [key: string]: any };
           object_empty: { [key: string]: any };
-          nullable: { string?: string } | null;
+          nullable: {
+            string?: string
+          } | null;
         }
       }`)
     );
@@ -280,7 +294,9 @@ describe("types", () => {
 
       export interface components {
         schemas: {
-          union: { string?: 'Totoro' | 'Sats\\'uki' | 'Mei' }
+          union: {
+            string?: 'Totoro' | 'Sats\\'uki' | 'Mei';
+          }
         }
       }`)
     );
@@ -336,8 +352,12 @@ describe("OpenAPI3 features", () => {
 
       export interface components {
         schemas: {
-          additional_properties: { number?: number; } & { [key: string]: any };
-          additional_properties_string: { string?: string } & { [key: string]: string };
+          additional_properties: {
+            number?: number;
+          } & { [key: string]: any };
+          additional_properties_string: {
+            string?: string;
+          } & { [key: string]: string };
         }
       }`)
     );
@@ -372,8 +392,15 @@ describe("OpenAPI3 features", () => {
 
       export interface components {
         schemas: {
-          base: { boolean?: boolean; number?: number };
-          all_of: components['schemas']['base'] & { string?: string } & { password?: string };
+          base: {
+            boolean?: boolean;
+            number?: number;
+          };
+          all_of: components['schemas']['base'] & {
+            string?: string;
+          } & {
+            password?: string;
+          };
         }
       }`)
     );
@@ -419,9 +446,15 @@ describe("OpenAPI3 features", () => {
       export interface components {
         schemas: {
           any_of: Partial<components['schemas']['string']> & Partial<components['schemas']['number']> & Partial<components['schemas']['boolean']>;
-          string: {string?: string };
-          number: {number?: number };
-          boolean: {boolean?: boolean };
+          string: {
+            string?: string;
+          };
+          number: {
+            number?: number;
+          };
+          boolean: {
+            boolean?: boolean;
+          };
         }
       }`)
     );
@@ -449,7 +482,10 @@ describe("OpenAPI3 features", () => {
 
       export interface components {
         schemas: {
-          required: { required: string; optional?: boolean  }
+          required: {
+            required: string;
+            optional?: boolean;
+          }
         }
       }`)
     );
@@ -510,11 +546,23 @@ describe("OpenAPI3 features", () => {
 
         export interface components {
           schemas: {
-            one_of: { options?: string | number | components['schemas']['one_of_ref'] };
-            one_of_ref: { boolean?: boolean };
+            one_of: {
+              options?: string | number | components['schemas']['one_of_ref'];
+            };
+            one_of_ref: {
+              boolean?: boolean;
+            };
             one_of_inferred:
-              | { kibana?: { versions?: string } }
-              | { elasticsearch?: { versions?: string } }
+              | {
+                kibana?: {
+                  versions?: string;
+                }
+              }
+              | {
+                elasticsearch?: {
+                  versions?: string;
+                }
+              }
             one_of_addl_props: { [key: string]: string | number | boolean }
           }
         }
@@ -537,7 +585,10 @@ describe("OpenAPI3 features", () => {
     expect(swaggerToTS(schema, { version: 3, rawSchema: true })).toBe(
       format(`
       export interface schemas {
-        User: { name: string; email: string }
+        User: {
+          name: string;
+          email: string;
+        }
       }`)
     );
   });
@@ -646,16 +697,19 @@ describe("responses", () => {
     expect(swaggerToTS(schema)).toBe(
       format(`
       export interface paths {
-        '/': {
+        "/": {
           get: {
             responses: {
               200: {
-                'application/json': { title: string; body: string }
+                "application/json": {
+                  title: string;
+                  body: string;
+                }
               }
             }
           }
         };
-        '/search': {
+        "/search": {
           post: {
             parameters: {
               query: {
@@ -665,13 +719,13 @@ describe("responses", () => {
             };
             responses: {
               200: {
-                'application/json': {
-                  results?: components['schemas']['SearchResult'][];
+                "application/json": {
+                  results?: components["schemas"]["SearchResult"][];
                   total: number;
                 }
               }
               404: {
-                'application/json': components['schemas']['ErrorResponse']
+                "application/json": components["schemas"]["ErrorResponse"]
               }
             }
           }
@@ -682,8 +736,14 @@ describe("responses", () => {
 
       export interface components {
         schemas: {
-          ErrorResponse: { error: string; message: string };
-          SearchResponse: { title: string; date: string }
+          ErrorResponse: {
+            error: string;
+            message: string;
+          };
+          SearchResponse: {
+            title: string;
+            date: string;
+          }
         }
         responses: {
           NotFound: {
@@ -812,11 +872,16 @@ describe("responses", () => {
         "/tests": {
           post: {
             requestBody: {
-              'application/json': { title: string }
+              'application/json': {
+                title: string;
+              }
             }
             responses: {
               201: {
-                'application/json': { id: string; title: string}
+                'application/json': {
+                  id: string;
+                  title: string;
+                }
               };
             };
           };


### PR DESCRIPTION
Followup to #443. Apparently when you have:

```js
{ /** comment */ property: … }
```

Prettier will keep the comment and property on the same line. This PR enforces a newline after `{`, resulting in:

```diff
  address: {
-   /** City, district, suburb, town, or village. */ city?: string;
+  /** City, district, suburb, town, or village. */
+  city?: string;
```

Unfortunately in the process, it does enforce that every object’s properties are on their own lines. Overall, though, I think it’s a good tradeoff.