### PR TITLE
Request body refs

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export interface OpenAPI3 {
   paths?: Record<string, PathItemObject>; // required
   components?: {
     schemas?: Record<string, ReferenceObject | SchemaObject>;
+    requestBodies?: Record<string, ReferenceObject | RequestBody>;
     responses?: Record<string, ReferenceObject | ResponseObject>;
     parameters?: Record<string, ReferenceObject | ParameterObject>;
     headers?: Record<string, ReferenceObject | HeaderObject>;
@@ -56,7 +57,7 @@ export interface OperationObject {
   operationId?: string;
   parameters?: (ReferenceObject | ParameterObject)[];
   responses?: Record<string, ReferenceObject | ResponseObject>; // required
-  requestBody?: RequestBody;
+  requestBody?: ReferenceObject | RequestBody;
 }
 
 export interface ParameterObject {


### PR DESCRIPTION
Adding support for refs in operation `requestBody` to support the `components.requestBodies` objects.

I looked through tests and didn't see where would be most appropriate to test this - it didn't look like anything besides schemas and parameters were tested in the example files, and many tests were GH issue-based. Let me know, happy to add testing.