### PR TITLE
WIP: Adding requestBodies transform support

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -3,7 +3,7 @@ import { comment } from "../utils";
 import { transformHeaderObjMap } from "./headers";
 import { transformOperationObj } from "./operation";
 import { transformPathsObj } from "./paths";
-import { transformResponsesObj } from "./responses";
+import { transformResponsesObj, transformRequestBodies } from "./responses";
 import { transformSchemaObjMap } from "./schema";
 
 interface TransformOptions {
@@ -89,10 +89,7 @@ export function transformAll(schema: any, { version, rawSchema }: TransformOptio
 
         // #/components/requestBodies
         if (schema.components.requestBodies) {
-          const required = Object.keys(schema.components.requestBodies);
-          output += `  requestBodies: {\n    ${transformSchemaObjMap(schema.components.requestBodies, {
-            required,
-          })}\n  }\n`;
+          output += `  requestBodies: {\n    ${transformRequestBodies(schema.components.requestBodies)}\n  }\n`;
         }
 
         // #/components/headers

--- a/src/transform/operation.ts
+++ b/src/transform/operation.ts
@@ -1,4 +1,4 @@
-import { OperationObject, ParameterObject } from "../types";
+import { OperationObject, ParameterObject, RequestBody } from "../types";
 import { comment, isRef, transformRef } from "../utils";
 import { transformParametersArray } from "./parameters";
 import { transformResponsesObj } from "./responses";
@@ -22,21 +22,31 @@ export function transformOperationObj(
     if (isRef(operation.requestBody)) {
       output += `  requestBody: ${transformRef(operation.requestBody.$ref)};\n`;
     } else {
-      const { description, content } = operation.requestBody;
+      if (operation.requestBody.description) output += comment(operation.requestBody.description);
 
-      if (description) output += comment(description);
-
-      if (content && Object.keys(content).length) {
-        output += `  requestBody: {\n    content: {\n`; // open requestBody
-
-        Object.entries(content).forEach(([k, v]) => {
-          output += `      "${k}": ${transformSchemaObj(v.schema)};\n`;
-        });
-        output += `    }\n  }\n`; // close requestBody
-      } else {
-        output += `  requestBody: unknown;\n`;
-      }
+      output += `  requestBody: {\n`; // open requestBody
+      output += `  ${transformRequestBodyObj(operation.requestBody)}`;
+      output += `  }\n`; // close requestBody
     }
+  }
+
+  return output;
+}
+
+export function transformRequestBodyObj(requestBody: RequestBody) {
+  let output = "";
+
+  const { content } = requestBody;
+
+  if (content && Object.keys(content).length) {
+    output += `  content: {\n`; // open content
+
+    Object.entries(content).forEach(([k, v]) => {
+      output += `      "${k}": ${transformSchemaObj(v.schema)};\n`;
+    });
+    output += `    }\n`; // close content
+  } else {
+    output += `  unknown;\n`;
   }
 
   return output;

--- a/src/transform/responses.ts
+++ b/src/transform/responses.ts
@@ -1,6 +1,8 @@
 import { comment, transformRef } from "../utils";
 import { transformHeaderObjMap } from "./headers";
 import { transformSchemaObj } from "./schema";
+import { transformRequestBodyObj } from "./operation";
+import { RequestBody } from "../types";
 
 const resType = (res: string | number) => (res === 204 || (res >= 300 && res < 400) ? "never" : "unknown");
 
@@ -47,5 +49,18 @@ export function transformResponsesObj(responsesObj: Record<string, any>): string
 
     output += `  }\n`; // close response
   });
+  return output;
+}
+
+export function transformRequestBodies(requestBodies: Record<string, RequestBody>) {
+  let output = "";
+
+  Object.entries(requestBodies).forEach(([bodyName, requestBody]) => {
+    if (requestBody && requestBody.description) output += `  ${comment(requestBody.description)}`;
+    output += `  ${bodyName}: {`;
+    output += `  ${transformRequestBodyObj(requestBody)}`;
+    output += `  }\n`;
+  });
+
   return output;
 }

--- a/tests/operation.test.ts
+++ b/tests/operation.test.ts
@@ -1,4 +1,6 @@
+import prettier from "prettier";
 import { transformOperationObj } from "../src/transform/operation";
+import { transformRequestBodies } from "../src/transform/responses";
 
 describe("requestBody", () => {
   it("basic", () => {
@@ -29,5 +31,40 @@ describe("requestBody", () => {
         requestBody: { $ref: "#/components/requestBodies/Request" },
       }).trim()
     ).toBe(`requestBody: components["requestBodies"]["Request"];`);
+  });
+});
+
+describe("requestBodies", () => {
+  const format = (source: string) => prettier.format(source, { parser: "typescript" });
+
+  it("basic", () => {
+    const output = transformRequestBodies({
+      Pet: {
+        description: "Pet request body",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                test: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    }).trim();
+
+    expect(format(`type requestBodies = {${output}}`)).toBe(
+      format(`type requestBodies = {
+          /** Pet request body */
+          Pet: {
+            content: {
+              "application/json": {
+                test?: string;
+              };
+            };
+          };
+        };`)
+    );
   });
 });

--- a/tests/v3/expected/petstore-openapitools.ts
+++ b/tests/v3/expected/petstore-openapitools.ts
@@ -115,11 +115,13 @@ export interface components {
     };
   };
   requestBodies: {
+    /** List of user object */
     UserArray: {
       content: {
         "application/json": components["schemas"]["User"][];
       };
     };
+    /** Pet object that needs to be added to the store */
     Pet: {
       content: {
         "application/json": components["schemas"]["Pet"];

--- a/tests/v3/expected/petstore-openapitools.ts
+++ b/tests/v3/expected/petstore-openapitools.ts
@@ -115,10 +115,17 @@ export interface components {
     };
   };
   requestBodies: {
-    /** List of user object */
-    UserArray: { [key: string]: any };
-    /** Pet object that needs to be added to the store */
-    Pet: { [key: string]: any };
+    UserArray: {
+      content: {
+        "application/json": components["schemas"]["User"][];
+      };
+    };
+    Pet: {
+      content: {
+        "application/json": components["schemas"]["Pet"];
+        "application/xml": components["schemas"]["Pet"];
+      };
+    };
   };
 }
 


### PR DESCRIPTION
According to [OpenAPI 3.0](https://swagger.io/docs/specification/describing-request-body/#Reusable%20Bodies) `components.requestBodies` have a specific schema:

```yaml
components:
  requestBodies:
    PetBody:
      description: A JSON object containing pet information
      required: true
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/Pet'
```

Currently `components.requestBodies` is transformed as normal schema with the wrong output code:

```typescript
  requestBodies: {
    /** List of user object */
    UserArray: { [key: string]: any };
    /** Pet object that needs to be added to the store */
    Pet: { [key: string]: any };
  };
```

This PR fix wrong transformation, and makes ability to have a valid output code:

```typescript
  requestBodies: {
    /** List of user object */
    UserArray: {
      content: {
        "application/json": components["schemas"]["User"][];
      };
    };
    /** Pet object that needs to be added to the store */
    Pet: {
      content: {
        "application/json": components["schemas"]["Pet"];
        "application/xml": components["schemas"]["Pet"];
      };
    };
  };
```