### PR TITLE
504 - Fix additionalProperties on object type

### DIFF
--- a/src/transform/schema.ts
+++ b/src/transform/schema.ts
@@ -94,7 +94,7 @@ export function transformSchemaObj(node: any): string {
       // if additional properties, add an intersection with a generic map type
       let additionalProperties: string | undefined;
       if (node.additionalProperties) {
-        if (node.additionalProperties === true) {
+        if (node.additionalProperties === true || Object.keys(node.additionalProperties).length === 0) {
           additionalProperties = `{ [key: string]: any }`;
         } else if (typeof node.additionalProperties === "object") {
           const oneOf: any[] | undefined = (node.additionalProperties as any).oneOf || undefined; // TypeScript does a really bad job at inference here, so we enforce a type

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -163,6 +163,9 @@ describe("SchemaObject", () => {
       // boolean
       expect(transform({ additionalProperties: true })).toBe(`{ [key: string]: any }`);
 
+      // empty object
+      expect(transform({ additionalProperties: {} })).toBe(`{ [key: string]: any }`);
+
       // type
       expect(transform({ additionalProperties: { type: "string" } })).toBe(`{ [key: string]: string; }`);
 


### PR DESCRIPTION
Fixes #504 
As stated in the [documentation ](https://swagger.io/docs/specification/data-models/dictionaries/) Freeform objects (objects with any value) can be defined by setting additionalProperties either to true or {}. 

Previously:
```
foo?: { [key: string]: { [key: string]: any } }
```
was the output instead of:
```
foo?: { [key: string]: any }
```

This is fixed and tested with this PR.