### PR TITLE
Inherit parameters from path item to its operations.

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -1,4 +1,4 @@
-import { OperationObject } from "../types";
+import { OperationObject, PathItemObject } from "../types";
 import { comment, tsReadonly } from "../utils";
 import { transformHeaderObjMap } from "./headers";
 import { transformOperationObj } from "./operation";
@@ -17,7 +17,7 @@ export function transformAll(schema: any, { immutableTypes, rawSchema, version }
 
   let output = "";
 
-  let operations: Record<string, OperationObject> = {};
+  let operations: Record<string, { operation: OperationObject; pathItem: PathItemObject }> = {};
 
   // --raw-schema mode
   if (rawSchema) {
@@ -128,9 +128,10 @@ export function transformAll(schema: any, { immutableTypes, rawSchema, version }
 
   output += `export interface operations {\n`; // open operations
   if (Object.keys(operations).length) {
-    Object.entries(operations).forEach(([operationId, operation]) => {
+    Object.entries(operations).forEach(([operationId, { operation, pathItem }]) => {
       if (operation.description) output += comment(operation.description); // handle comment
       output += `  ${readonly}"${operationId}": {\n    ${transformOperationObj(operation, {
+        pathItem,
         globalParameters: (schema.components && schema.components.parameters) || schema.parameters,
         immutableTypes,
         version,

--- a/src/transform/operation.ts
+++ b/src/transform/operation.ts
@@ -1,4 +1,4 @@
-import { OperationObject, ParameterObject, RequestBody } from "../types";
+import { OperationObject, ParameterObject, PathItemObject, RequestBody } from "../types";
 import { comment, isRef, transformRef, tsReadonly } from "../utils";
 import { transformParametersArray } from "./parameters";
 import { transformResponsesObj } from "./responses";
@@ -9,8 +9,10 @@ export function transformOperationObj(
   {
     globalParameters,
     immutableTypes,
+    pathItem,
     version,
   }: {
+    pathItem?: PathItemObject;
     globalParameters?: Record<string, ParameterObject>;
     immutableTypes: boolean;
     version: number;
@@ -20,8 +22,9 @@ export function transformOperationObj(
 
   let output = "";
 
-  if (operation.parameters) {
-    output += `  ${readonly}parameters: {\n    ${transformParametersArray(operation.parameters, {
+  if (operation.parameters || pathItem?.parameters) {
+    const parameters = (pathItem?.parameters || []).concat(operation.parameters || []);
+    output += `  ${readonly}parameters: {\n    ${transformParametersArray(parameters, {
       globalParameters,
       immutableTypes,
       version,

--- a/src/transform/operation.ts
+++ b/src/transform/operation.ts
@@ -9,7 +9,7 @@ export function transformOperationObj(
   {
     globalParameters,
     immutableTypes,
-    pathItem,
+    pathItem = {},
     version,
   }: {
     pathItem?: PathItemObject;
@@ -22,8 +22,8 @@ export function transformOperationObj(
 
   let output = "";
 
-  if (operation.parameters || pathItem?.parameters) {
-    const parameters = (pathItem?.parameters || []).concat(operation.parameters || []);
+  if (operation.parameters || pathItem.parameters) {
+    const parameters = (pathItem.parameters || []).concat(operation.parameters || []);
     output += `  ${readonly}parameters: {\n    ${transformParametersArray(parameters, {
       globalParameters,
       immutableTypes,

--- a/src/transform/paths.ts
+++ b/src/transform/paths.ts
@@ -39,9 +39,8 @@ export function transformPathsObj(
 
       // if operation has operationId, abstract into top-level operations object
       if (operation.operationId) {
-        output += `   ${readonly}"${method}": operations["${operation.operationId}"];\n`;
         operations[operation.operationId] = { operation, pathItem };
-        output += `    "${method}": operations["${operation.operationId}"];\n`;
+        output += `    ${readonly}"${method}": operations["${operation.operationId}"];\n`;
         return;
       }
       // otherwise, inline operation

--- a/src/transform/paths.ts
+++ b/src/transform/paths.ts
@@ -6,7 +6,7 @@ import { transformParametersArray } from "./parameters";
 interface TransformPathsObjOption {
   globalParameters: Record<string, ParameterObject>;
   immutableTypes: boolean;
-  operations: Record<string, OperationObject>;
+  operations: Record<string, { operation: OperationObject; pathItem: PathItemObject }>;
   version: number;
 }
 
@@ -40,14 +40,15 @@ export function transformPathsObj(
       // if operation has operationId, abstract into top-level operations object
       if (operation.operationId) {
         output += `   ${readonly}"${method}": operations["${operation.operationId}"];\n`;
-        operations[operation.operationId] = operation;
+        operations[operation.operationId] = { operation, pathItem };
+        output += `    "${method}": operations["${operation.operationId}"];\n`;
         return;
       }
-
       // otherwise, inline operation
       output += `    ${readonly}"${method}": {\n      ${transformOperationObj(operation, {
         globalParameters,
         immutableTypes,
+        pathItem,
         version,
       })}\n    }\n`;
     });

--- a/tests/operation.test.ts
+++ b/tests/operation.test.ts
@@ -118,3 +118,112 @@ describe("requestBodies", () => {
     );
   });
 });
+
+describe.only("parameters", () => {
+  it("operation parameters only", () => {
+    expect(
+      transformOperationObj(
+        {
+          parameters: [
+            {
+              in: "path",
+              name: "p1",
+              schema: {
+                type: "string",
+              },
+            },
+          ],
+        },
+        {
+          version: 3,
+          pathItem: {},
+        }
+      ).trim()
+    ).toBe(`parameters: {
+      path: {
+    "p1"?: string;
+  }
+
+  }`);
+  });
+
+  it("inherited path parameters only", () => {
+    expect(
+      transformOperationObj(
+        {},
+        {
+          version: 3,
+          pathItem: {
+            parameters: [
+              {
+                in: "path",
+                name: "p1",
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+          },
+        }
+      ).trim()
+    ).toBe(`parameters: {
+      path: {
+    "p1"?: string;
+  }
+
+  }`);
+  });
+
+  it("inherited path parameters and operation parameters", () => {
+    expect(
+      transformOperationObj(
+        {
+          parameters: [
+            {
+              in: "path",
+              name: "p1",
+              schema: {
+                type: "string",
+              },
+            },
+            {
+              in: "path",
+              name: "p2",
+              schema: {
+                type: "number",
+              },
+            },
+          ],
+        },
+        {
+          version: 3,
+          pathItem: {
+            parameters: [
+              {
+                in: "path",
+                name: "p2",
+                schema: {
+                  type: "string",
+                },
+              },
+              {
+                in: "path",
+                name: "p3",
+                schema: {
+                  type: "string",
+                },
+              },
+            ],
+          },
+        }
+      ).trim()
+    ).toBe(`parameters: {
+      path: {
+    "p2"?: number;
+    "p3"?: string;
+    "p1"?: string;
+  }
+
+  }`);
+  });
+});

--- a/tests/operation.test.ts
+++ b/tests/operation.test.ts
@@ -119,7 +119,7 @@ describe("requestBodies", () => {
   });
 });
 
-describe.only("parameters", () => {
+describe("parameters", () => {
   it("operation parameters only", () => {
     expect(
       transformOperationObj(

--- a/tests/operation.test.ts
+++ b/tests/operation.test.ts
@@ -136,6 +136,7 @@ describe("parameters", () => {
         },
         {
           version: 3,
+          immutableTypes: false,
           pathItem: {},
         }
       ).trim()
@@ -153,6 +154,7 @@ describe("parameters", () => {
         {},
         {
           version: 3,
+          immutableTypes: false,
           pathItem: {
             parameters: [
               {
@@ -197,6 +199,7 @@ describe("parameters", () => {
         },
         {
           version: 3,
+          immutableTypes: false,
           pathItem: {
             parameters: [
               {

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -460,6 +460,11 @@ describe("transformPathsObj", () => {
     expect(transform(parametersSchema, { immutableTypes: true })).toBe(`export interface paths {
   readonly "/{example}": {
     readonly get: {
+      readonly parameters: {
+        readonly path: {
+          readonly example: string;
+        };
+      };
       readonly responses: {};
     };
     readonly parameters: {

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -442,6 +442,11 @@ describe("transformPathsObj", () => {
     expect(transform(parametersSchema)).toBe(`export interface paths {
   "/{example}": {
     get: {
+      parameters: {
+        path: {
+          example: string;
+        };
+      };
       responses: {};
     };
     parameters: {


### PR DESCRIPTION
A path item may declare common parameters to all operations outside of the operation map.
If this is the case, all operations should inherit those parameters and merge them with
any operation specific parameters.
In case of conflicting parameters, the one defined in the operation has precedence over
path item parameters.

To fix this, operations need a reference to their path item, so modifying the record of operations built during path item parsing to hold { operation, pathItem } objects.