### PR TITLE
ci: use node.js version from matrix

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run test:coverage
   typecheck:


### PR DESCRIPTION
fixes: https://github.com/drwpow/openapi-typescript/pull/530#discussion_r599828545

also included node.js v15

v10 can probably dropped end-of-April: https://nodejs.org/en/about/releases/ and replaced with v16 (while v15 to be removed)