### PR TITLE
Escapes markdown descriptions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { OpenAPI2, OpenAPI3, ReferenceObject } from "./types";
 
 export function comment(text: string): string {
-  const commentText = text.trim();
+  const commentText = text.trim().replace(/\*\//g, "*\\/");
 
   // if single-line comment
   if (commentText.indexOf("\n") === -1) {

--- a/tests/utils/index.test.ts
+++ b/tests/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { swaggerVersion } from "../../src/utils";
+import { swaggerVersion, comment } from "../../src/utils";
 
 describe("swaggerVersion", () => {
   it("v2", () => {
@@ -9,5 +9,20 @@ describe("swaggerVersion", () => {
   });
   it("errs", () => {
     expect(() => swaggerVersion({} as any)).toThrow();
+  });
+});
+
+describe("comment", () => {
+  it("escapes markdown in comments", () => {
+    const text = `Example markdown
+**/some/url/path**`;
+
+    expect(comment(text)).toBe(
+      `/**
+  * Example markdown
+  * **\\/some/url/path**
+  */
+`
+    );
   });
 });


### PR DESCRIPTION
This avoids accidental closing of comment tags.

Fixes #547