### PR TITLE
Fix requestBodies that use hypenated naming

### DIFF
--- a/src/transform/responses.ts
+++ b/src/transform/responses.ts
@@ -68,7 +68,7 @@ export function transformRequestBodies(requestBodies: Record<string, RequestBody
 
   Object.entries(requestBodies).forEach(([bodyName, requestBody]) => {
     if (requestBody && requestBody.description) output += `  ${comment(requestBody.description)}`;
-    output += `  ${bodyName}: {`;
+    output += `  "${bodyName}": {`;
     output += `  ${transformRequestBodyObj(requestBody, options)}`;
     output += `  }\n`;
   });

--- a/tests/operation.test.ts
+++ b/tests/operation.test.ts
@@ -117,6 +117,58 @@ describe("requestBodies", () => {
         };`)
     );
   });
+
+  it("hypenated", () => {
+    const schema = {
+      "Pet-example": {
+        description: "Pet-example request body",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                test: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const output = transformRequestBodies(schema, {
+      immutableTypes: false,
+    }).trim();
+
+    expect(format(`type requestBodies = {${output}}`)).toBe(
+      format(`type requestBodies = {
+          /** Pet-example request body */
+          "Pet-example": {
+            content: {
+              "application/json": {
+                test?: string;
+              };
+            };
+          };
+        };`)
+    );
+
+    const outputImmutable = transformRequestBodies(schema, {
+      immutableTypes: true,
+    }).trim();
+
+    expect(format(`type requestBodies = {${outputImmutable}}`)).toBe(
+      format(`type requestBodies = {
+          /** Pet-example request body */
+          "Pet-example": {
+            readonly content: {
+              readonly "application/json": {
+                readonly test?: string;
+              };
+            };
+          };
+        };`)
+    );
+  });
 });
 
 describe("parameters", () => {


### PR DESCRIPTION
If a request body's name is hypenated it breaks when prettier formats the code as it is an invalid object.

Wrapping the request body's name in quotes resolves the issue, and prettier will strip the quotes when they're not required.

### Example for reproducing:

```
npx openapi-typescript https://raw.githubusercontent.com/ashsmith/api-specs/fix-invalid-examples/reference/channels.v3.yml --output channels.v3.ts
```

#### Current result:
```
SyntaxError: Property or signature expected. (505:7)
  503 |   }
  504 |   requestBodies: {
> 505 |       post-channels-channel_id-currency-assignmentsBody: {    content: {
      |       ^
  506 |       "application/json": {
  507 | /** Currencies that are enabled for the given channel, in ISO 4217 3 character alphabetic */
  508 | "enabled_currencies": (string)[];
    at e (/Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/prettier/parser-typescript.js:1:322)
    at Object.parse (/Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/prettier/parser-typescript.js:1:3072720)
    at Object.parse (/Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/prettier/index.js:13625:19)
    at coreFormat (/Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/prettier/index.js:14899:14)
    at format (/Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/prettier/index.js:15131:14)
    at /Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/prettier/index.js:57542:12
    at Object.format (/Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/prettier/index.js:57562:12)
    at swaggerToTS (/Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/openapi-typescript/dist/cjs/index.js:51:31)
    at main (/Users/ash/.npm/_npx/21d31b7563e6adbc/node_modules/openapi-typescript/bin/cli.js:75:18)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```