### PR TITLE
Mark schema objects with default values as non-nullable

### DIFF
--- a/src/transform/schema.ts
+++ b/src/transform/schema.ts
@@ -15,10 +15,14 @@ interface TransformSchemaObjOptions extends GlobalContext {
   required: Set<string>;
 }
 
+function hasDefaultValue(node: any): boolean {
+  if (node.hasOwnProperty("default")) return true;
+  // if (node.hasOwnProperty("$ref")) return true; // TODO: resolve remote $refs?
+  return false;
+}
+
 /** Take object keys and convert to TypeScript interface */
 export function transformSchemaObjMap(obj: Record<string, any>, options: TransformSchemaObjOptions): string {
-  const readonly = tsReadonly(options.immutableTypes);
-
   let output = "";
 
   for (const k of Object.keys(obj)) {
@@ -27,7 +31,9 @@ export function transformSchemaObjMap(obj: Record<string, any>, options: Transfo
     if (v.description) output += comment(v.description);
 
     // 2. name (with “?” if optional property)
-    output += `${readonly}"${k}"${options.required.has(k) ? "" : "?"}: `;
+    const readonly = tsReadonly(options.immutableTypes);
+    const required = options.required.has(k) || hasDefaultValue(v.schema || v) ? "" : "?";
+    output += `${readonly}"${k}"${required}: `;
 
     // 3. transform
     output += transformSchemaObj(v.schema || v, options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,7 @@ export interface SchemaObject {
   items?: ReferenceObject | SchemaObject;
   allOf?: SchemaObject;
   properties?: Record<string, ReferenceObject | SchemaObject>;
+  default?: any;
   additionalProperties?: boolean | ReferenceObject | SchemaObject;
   nullable?: boolean; // V3 ONLY
   oneOf?: (ReferenceObject | SchemaObject)[]; // V3 ONLY

--- a/tests/bin/expected/prettier-js.ts
+++ b/tests/bin/expected/prettier-js.ts
@@ -72,7 +72,7 @@ export interface components {
       shipDate?: string
       /** Order Status */
       status?: 'placed' | 'approved' | 'delivered'
-      complete?: boolean
+      complete: boolean
     }
     Category: {
       id?: number

--- a/tests/bin/expected/prettier-json.ts
+++ b/tests/bin/expected/prettier-json.ts
@@ -72,7 +72,7 @@ export interface components {
       shipDate?: string
       /** Order Status */
       status?: 'placed' | 'approved' | 'delivered'
-      complete?: boolean
+      complete: boolean
     }
     Category: {
       id?: number

--- a/tests/bin/expected/stdout.ts
+++ b/tests/bin/expected/stdout.ts
@@ -72,7 +72,7 @@ export interface components {
       shipDate?: string;
       /** Order Status */
       status?: "placed" | "approved" | "delivered";
-      complete?: boolean;
+      complete: boolean;
     };
     Category: {
       id?: number;

--- a/tests/v2/expected/http.ts
+++ b/tests/v2/expected/http.ts
@@ -618,11 +618,11 @@ export interface definitions {
       base_url?: string;
       sso_url?: string;
       version?: "v1";
-      features?: {
+      features: {
         access_code?: boolean;
         sso?: boolean;
         plan_change?: boolean;
-        credential?: "none" | "single" | "multiple" | "unknown";
+        credential: "none" | "single" | "multiple" | "unknown";
       };
     };
     /** An array of platform ids to restrict this product for. */
@@ -662,24 +662,24 @@ export interface definitions {
     name: definitions["Name"];
     type: "boolean" | "string" | "number";
     /** This sets whether or not the feature can be customized by a consumer. */
-    customizable?: boolean;
+    customizable: boolean;
     /**
      * This sets whether or not the feature can be upgraded by the consumer after the
      * resource has provisioned. Upgrading means setting a higher value or selecting a
      * higher element in the list.
      */
-    upgradable?: boolean;
+    upgradable: boolean;
     /**
      * This sets whether or not the feature can be downgraded by the consumer after the
      * resource has provisioned. Downgrading means setting a lower value or selecting a
      * lower element in the list.
      */
-    downgradable?: boolean;
+    downgradable: boolean;
     /**
      * Sets if this feature’s value is trackable from the provider,
      * this only really affects numeric constraints.
      */
-    measurable?: boolean;
+    measurable: boolean;
     values?: definitions["FeatureValuesList"];
   };
   /**
@@ -699,7 +699,7 @@ export interface definitions {
      * is selected or is default for the plan.
      * Cost is deprecated in favor of the `price.cost` field.
      */
-    cost?: number;
+    cost: number;
     /**
      * Price describes the cost of a feature. It should be preferred over
      * the `cost` property.
@@ -710,13 +710,13 @@ export interface definitions {
        * when this value is selected or is default for the plan.
        * Number features should use the cost range instead.
        */
-      cost?: number;
+      cost: number;
       /**
        * When a feature is used to multiply the cost of the plan or of
        * another feature, multiply factor is used for calculation.
        * A feature cannot have both a cost and a multiply factor.
        */
-      multiply_factor?: number;
+      multiply_factor: number;
       /** Price describes how the feature cost should be calculated. */
       formula?: definitions["PriceFormula"];
       /** Description explains how a feature is calculated to the user. */
@@ -737,9 +737,9 @@ export interface definitions {
      * means this numeric details has no scale, and will not be or customizable.
      * Some plans may not have a measureable or customizable feature.
      */
-    increment?: number;
+    increment: number;
     /** Minimum value that can be set by a user if customizable */
-    min?: number;
+    min: number;
     /** Maximum value that can be set by a user if customizable */
     max?: number;
     /** Applied to the end of the number for display, for example the ‘GB’ in ‘20 GB’. */
@@ -758,7 +758,7 @@ export interface definitions {
      * An integer in 10,000,000ths of cents, will be multiplied by the
      * numeric value set in the feature to determine the cost.
      */
-    cost_multiple?: number;
+    cost_multiple: number;
   };
   FeatureValue: {
     feature: definitions["Label"];
@@ -784,7 +784,7 @@ export interface definitions {
      * When true, everyone can see the product when requested. When false it will
      * not be visible to anyone except those on the provider team.
      */
-    public?: boolean;
+    public: boolean;
     /**
      * When true, the product will be displayed in product listings alongside
      * other products. When false the product will be excluded from listings,
@@ -792,32 +792,32 @@ export interface definitions {
      * Any pages that display information about the product when not listed,
      * should indicate to webcrawlers that the content should not be indexed.
      */
-    listed?: boolean;
+    listed: boolean;
     /**
      * Object to hold various flags for marketing purposes only. These are values
      * that need to be stored, but should not affect decision making in code. If
      * we find ourselves in a position where we think they should, we should
      * consider refactoring our listing definition.
      */
-    marketing?: {
+    marketing: {
       /**
        * Indicates whether or not the product is in `Beta` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      beta?: boolean;
+      beta: boolean;
       /**
        * Indicates whether or not the product is in `New` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      new?: boolean;
+      new: boolean;
       /**
        * Indicates whether or not the product is in `New` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      featured?: boolean;
+      featured: boolean;
     };
   };
   /**
@@ -858,7 +858,7 @@ export interface definitions {
      * * `multiple`: Multiple credentials are supported at the same time.
      * * `unknown`: The credential type is unknown.
      */
-    credential?: "none" | "single" | "multiple" | "unknown";
+    credential: "none" | "single" | "multiple" | "unknown";
   };
   ProductBody: {
     provider_id: definitions["ID"];

--- a/tests/v2/expected/manifold.immutable.ts
+++ b/tests/v2/expected/manifold.immutable.ts
@@ -618,11 +618,11 @@ export interface definitions {
       readonly base_url?: string;
       readonly sso_url?: string;
       readonly version?: "v1";
-      readonly features?: {
+      readonly features: {
         readonly access_code?: boolean;
         readonly sso?: boolean;
         readonly plan_change?: boolean;
-        readonly credential?: "none" | "single" | "multiple" | "unknown";
+        readonly credential: "none" | "single" | "multiple" | "unknown";
       };
     };
     /** An array of platform ids to restrict this product for. */
@@ -662,24 +662,24 @@ export interface definitions {
     readonly name: definitions["Name"];
     readonly type: "boolean" | "string" | "number";
     /** This sets whether or not the feature can be customized by a consumer. */
-    readonly customizable?: boolean;
+    readonly customizable: boolean;
     /**
      * This sets whether or not the feature can be upgraded by the consumer after the
      * resource has provisioned. Upgrading means setting a higher value or selecting a
      * higher element in the list.
      */
-    readonly upgradable?: boolean;
+    readonly upgradable: boolean;
     /**
      * This sets whether or not the feature can be downgraded by the consumer after the
      * resource has provisioned. Downgrading means setting a lower value or selecting a
      * lower element in the list.
      */
-    readonly downgradable?: boolean;
+    readonly downgradable: boolean;
     /**
      * Sets if this feature’s value is trackable from the provider,
      * this only really affects numeric constraints.
      */
-    readonly measurable?: boolean;
+    readonly measurable: boolean;
     readonly values?: definitions["FeatureValuesList"];
   };
   /**
@@ -699,7 +699,7 @@ export interface definitions {
      * is selected or is default for the plan.
      * Cost is deprecated in favor of the `price.cost` field.
      */
-    readonly cost?: number;
+    readonly cost: number;
     /**
      * Price describes the cost of a feature. It should be preferred over
      * the `cost` property.
@@ -710,13 +710,13 @@ export interface definitions {
        * when this value is selected or is default for the plan.
        * Number features should use the cost range instead.
        */
-      readonly cost?: number;
+      readonly cost: number;
       /**
        * When a feature is used to multiply the cost of the plan or of
        * another feature, multiply factor is used for calculation.
        * A feature cannot have both a cost and a multiply factor.
        */
-      readonly multiply_factor?: number;
+      readonly multiply_factor: number;
       /** Price describes how the feature cost should be calculated. */
       readonly formula?: definitions["PriceFormula"];
       /** Description explains how a feature is calculated to the user. */
@@ -737,9 +737,9 @@ export interface definitions {
      * means this numeric details has no scale, and will not be or customizable.
      * Some plans may not have a measureable or customizable feature.
      */
-    readonly increment?: number;
+    readonly increment: number;
     /** Minimum value that can be set by a user if customizable */
-    readonly min?: number;
+    readonly min: number;
     /** Maximum value that can be set by a user if customizable */
     readonly max?: number;
     /** Applied to the end of the number for display, for example the ‘GB’ in ‘20 GB’. */
@@ -758,7 +758,7 @@ export interface definitions {
      * An integer in 10,000,000ths of cents, will be multiplied by the
      * numeric value set in the feature to determine the cost.
      */
-    readonly cost_multiple?: number;
+    readonly cost_multiple: number;
   };
   readonly FeatureValue: {
     readonly feature: definitions["Label"];
@@ -784,7 +784,7 @@ export interface definitions {
      * When true, everyone can see the product when requested. When false it will
      * not be visible to anyone except those on the provider team.
      */
-    readonly public?: boolean;
+    readonly public: boolean;
     /**
      * When true, the product will be displayed in product listings alongside
      * other products. When false the product will be excluded from listings,
@@ -792,32 +792,32 @@ export interface definitions {
      * Any pages that display information about the product when not listed,
      * should indicate to webcrawlers that the content should not be indexed.
      */
-    readonly listed?: boolean;
+    readonly listed: boolean;
     /**
      * Object to hold various flags for marketing purposes only. These are values
      * that need to be stored, but should not affect decision making in code. If
      * we find ourselves in a position where we think they should, we should
      * consider refactoring our listing definition.
      */
-    readonly marketing?: {
+    readonly marketing: {
       /**
        * Indicates whether or not the product is in `Beta` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      readonly beta?: boolean;
+      readonly beta: boolean;
       /**
        * Indicates whether or not the product is in `New` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      readonly new?: boolean;
+      readonly new: boolean;
       /**
        * Indicates whether or not the product is in `New` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      readonly featured?: boolean;
+      readonly featured: boolean;
     };
   };
   /**
@@ -858,7 +858,7 @@ export interface definitions {
      * * `multiple`: Multiple credentials are supported at the same time.
      * * `unknown`: The credential type is unknown.
      */
-    readonly credential?: "none" | "single" | "multiple" | "unknown";
+    readonly credential: "none" | "single" | "multiple" | "unknown";
   };
   readonly ProductBody: {
     readonly provider_id: definitions["ID"];

--- a/tests/v2/expected/manifold.ts
+++ b/tests/v2/expected/manifold.ts
@@ -618,11 +618,11 @@ export interface definitions {
       base_url?: string;
       sso_url?: string;
       version?: "v1";
-      features?: {
+      features: {
         access_code?: boolean;
         sso?: boolean;
         plan_change?: boolean;
-        credential?: "none" | "single" | "multiple" | "unknown";
+        credential: "none" | "single" | "multiple" | "unknown";
       };
     };
     /** An array of platform ids to restrict this product for. */
@@ -662,24 +662,24 @@ export interface definitions {
     name: definitions["Name"];
     type: "boolean" | "string" | "number";
     /** This sets whether or not the feature can be customized by a consumer. */
-    customizable?: boolean;
+    customizable: boolean;
     /**
      * This sets whether or not the feature can be upgraded by the consumer after the
      * resource has provisioned. Upgrading means setting a higher value or selecting a
      * higher element in the list.
      */
-    upgradable?: boolean;
+    upgradable: boolean;
     /**
      * This sets whether or not the feature can be downgraded by the consumer after the
      * resource has provisioned. Downgrading means setting a lower value or selecting a
      * lower element in the list.
      */
-    downgradable?: boolean;
+    downgradable: boolean;
     /**
      * Sets if this feature’s value is trackable from the provider,
      * this only really affects numeric constraints.
      */
-    measurable?: boolean;
+    measurable: boolean;
     values?: definitions["FeatureValuesList"];
   };
   /**
@@ -699,7 +699,7 @@ export interface definitions {
      * is selected or is default for the plan.
      * Cost is deprecated in favor of the `price.cost` field.
      */
-    cost?: number;
+    cost: number;
     /**
      * Price describes the cost of a feature. It should be preferred over
      * the `cost` property.
@@ -710,13 +710,13 @@ export interface definitions {
        * when this value is selected or is default for the plan.
        * Number features should use the cost range instead.
        */
-      cost?: number;
+      cost: number;
       /**
        * When a feature is used to multiply the cost of the plan or of
        * another feature, multiply factor is used for calculation.
        * A feature cannot have both a cost and a multiply factor.
        */
-      multiply_factor?: number;
+      multiply_factor: number;
       /** Price describes how the feature cost should be calculated. */
       formula?: definitions["PriceFormula"];
       /** Description explains how a feature is calculated to the user. */
@@ -737,9 +737,9 @@ export interface definitions {
      * means this numeric details has no scale, and will not be or customizable.
      * Some plans may not have a measureable or customizable feature.
      */
-    increment?: number;
+    increment: number;
     /** Minimum value that can be set by a user if customizable */
-    min?: number;
+    min: number;
     /** Maximum value that can be set by a user if customizable */
     max?: number;
     /** Applied to the end of the number for display, for example the ‘GB’ in ‘20 GB’. */
@@ -758,7 +758,7 @@ export interface definitions {
      * An integer in 10,000,000ths of cents, will be multiplied by the
      * numeric value set in the feature to determine the cost.
      */
-    cost_multiple?: number;
+    cost_multiple: number;
   };
   FeatureValue: {
     feature: definitions["Label"];
@@ -784,7 +784,7 @@ export interface definitions {
      * When true, everyone can see the product when requested. When false it will
      * not be visible to anyone except those on the provider team.
      */
-    public?: boolean;
+    public: boolean;
     /**
      * When true, the product will be displayed in product listings alongside
      * other products. When false the product will be excluded from listings,
@@ -792,32 +792,32 @@ export interface definitions {
      * Any pages that display information about the product when not listed,
      * should indicate to webcrawlers that the content should not be indexed.
      */
-    listed?: boolean;
+    listed: boolean;
     /**
      * Object to hold various flags for marketing purposes only. These are values
      * that need to be stored, but should not affect decision making in code. If
      * we find ourselves in a position where we think they should, we should
      * consider refactoring our listing definition.
      */
-    marketing?: {
+    marketing: {
       /**
        * Indicates whether or not the product is in `Beta` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      beta?: boolean;
+      beta: boolean;
       /**
        * Indicates whether or not the product is in `New` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      new?: boolean;
+      new: boolean;
       /**
        * Indicates whether or not the product is in `New` and should be
        * advertised as such. This does not have any impact on who can access the
        * product, it is just used to inform consumers through our clients.
        */
-      featured?: boolean;
+      featured: boolean;
     };
   };
   /**
@@ -858,7 +858,7 @@ export interface definitions {
      * * `multiple`: Multiple credentials are supported at the same time.
      * * `unknown`: The credential type is unknown.
      */
-    credential?: "none" | "single" | "multiple" | "unknown";
+    credential: "none" | "single" | "multiple" | "unknown";
   };
   ProductBody: {
     provider_id: definitions["ID"];

--- a/tests/v2/expected/petstore.immutable.ts
+++ b/tests/v2/expected/petstore.immutable.ts
@@ -71,7 +71,7 @@ export interface definitions {
     readonly shipDate?: string;
     /** Order Status */
     readonly status?: "placed" | "approved" | "delivered";
-    readonly complete?: boolean;
+    readonly complete: boolean;
   };
   readonly Category: {
     readonly id?: number;

--- a/tests/v2/expected/petstore.ts
+++ b/tests/v2/expected/petstore.ts
@@ -71,7 +71,7 @@ export interface definitions {
     shipDate?: string;
     /** Order Status */
     status?: "placed" | "approved" | "delivered";
-    complete?: boolean;
+    complete: boolean;
   };
   Category: {
     id?: number;

--- a/tests/v3/expected/github.additional.ts
+++ b/tests/v3/expected/github.additional.ts
@@ -5417,7 +5417,7 @@ export interface components {
       default_branch: string;
       open_issues_count: number;
       /** Whether this repository acts as a template that can be used to generate new repositories. */
-      is_template?: boolean;
+      is_template: boolean;
       topics?: string[];
       /** Whether issues are enabled. */
       has_issues: boolean;
@@ -5433,12 +5433,12 @@ export interface components {
       /** Returns whether or not this repository disabled. */
       disabled: boolean;
       /** The repository visibility: public, private, or internal. */
-      visibility?: string;
+      visibility: string;
       pushed_at: string | null;
       created_at: string | null;
       updated_at: string | null;
       /** Whether to allow rebase merges for pull requests. */
-      allow_rebase_merge?: boolean;
+      allow_rebase_merge: boolean;
       template_repository?:
         | ({
             id?: number;
@@ -5548,11 +5548,11 @@ export interface components {
         | null;
       temp_clone_token?: string;
       /** Whether to allow squash merges for pull requests. */
-      allow_squash_merge?: boolean;
+      allow_squash_merge: boolean;
       /** Whether to delete head branches when pull requests are merged */
-      delete_branch_on_merge?: boolean;
+      delete_branch_on_merge: boolean;
       /** Whether to allow merge commits for pull requests. */
-      allow_merge_commit?: boolean;
+      allow_merge_commit: boolean;
       subscribers_count?: number;
       network_count?: number;
       open_issues: number;
@@ -6849,7 +6849,7 @@ export interface components {
       default_branch: string;
       open_issues_count: number;
       /** Whether this repository acts as a template that can be used to generate new repositories. */
-      is_template?: boolean;
+      is_template: boolean;
       topics?: string[];
       /** Whether issues are enabled. */
       has_issues: boolean;
@@ -6865,20 +6865,20 @@ export interface components {
       /** Returns whether or not this repository disabled. */
       disabled: boolean;
       /** The repository visibility: public, private, or internal. */
-      visibility?: string;
+      visibility: string;
       pushed_at: string | null;
       created_at: string | null;
       updated_at: string | null;
       /** Whether to allow rebase merges for pull requests. */
-      allow_rebase_merge?: boolean;
+      allow_rebase_merge: boolean;
       template_repository?: (components["schemas"]["repository"] & { [key: string]: any }) | null;
       temp_clone_token?: string;
       /** Whether to allow squash merges for pull requests. */
-      allow_squash_merge?: boolean;
+      allow_squash_merge: boolean;
       /** Whether to delete head branches when pull requests are merged */
-      delete_branch_on_merge?: boolean;
+      delete_branch_on_merge: boolean;
       /** Whether to allow merge commits for pull requests. */
-      allow_merge_commit?: boolean;
+      allow_merge_commit: boolean;
       subscribers_count?: number;
       network_count?: number;
       open_issues: number;
@@ -7041,7 +7041,7 @@ export interface components {
       open_issues: number;
       watchers: number;
       /** Whether anonymous git access is allowed. */
-      anonymous_access_enabled?: boolean;
+      anonymous_access_enabled: boolean;
       code_of_conduct?: components["schemas"]["code-of-conduct-simple"];
     } & { [key: string]: any };
     /** An artifact */
@@ -8287,7 +8287,7 @@ export interface components {
       /** A short description of the status. */
       description: string;
       /** The environment of the deployment that the status is for. */
-      environment?: string;
+      environment: string;
       /** Deprecated: the URL to associate with this status. */
       target_url: string;
       created_at: string;
@@ -8295,9 +8295,9 @@ export interface components {
       deployment_url: string;
       repository_url: string;
       /** The URL for accessing your environment. */
-      environment_url?: string;
+      environment_url: string;
       /** The URL to associate with this status. */
-      log_url?: string;
+      log_url: string;
       performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: any }) | null;
     } & { [key: string]: any };
     /** The amount of time to delay a job after the job is initially triggered. The time (in minutes) must be an integer between 0 and 43,200 (30 days). */
@@ -9098,13 +9098,13 @@ export interface components {
       /** The first line of the range for a multi-line comment. */
       original_start_line?: number | null;
       /** The side of the first line of the range for a multi-line comment. */
-      start_side?: ("LEFT" | "RIGHT") | null;
+      start_side: ("LEFT" | "RIGHT") | null;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       line?: number;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       original_line?: number;
       /** The side of the diff to which the comment applies. The side of the last line of the range for a multi-line comment */
-      side?: "LEFT" | "RIGHT";
+      side: "LEFT" | "RIGHT";
       reactions?: components["schemas"]["reaction-rollup"];
       body_html?: string;
       body_text?: string;
@@ -9174,9 +9174,9 @@ export interface components {
       body_text?: string;
       body_html?: string;
       /** The side of the first line of the range for a multi-line comment. */
-      side?: "LEFT" | "RIGHT";
+      side: "LEFT" | "RIGHT";
       /** The side of the first line of the range for a multi-line comment. */
-      start_side?: ("LEFT" | "RIGHT") | null;
+      start_side: ("LEFT" | "RIGHT") | null;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       line?: number;
       /** The original line of the blob to which the comment applies. The last line of the range for a multi-line comment */
@@ -11539,7 +11539,7 @@ export interface operations {
           /** Name of the runner group. */
           name?: string;
           /** Visibility of a runner group. You can select all organizations or select individual organizations. Can be one of: `all` or `selected` */
-          visibility?: "selected" | "all";
+          visibility: "selected" | "all";
         } & { [key: string]: any };
       };
     };
@@ -12709,7 +12709,7 @@ export interface operations {
           /** The Markdown text to render in HTML. */
           text: string;
           /** The rendering mode. */
-          mode?: "markdown" | "gfm";
+          mode: "markdown" | "gfm";
           /** The repository context to use when creating references in `gfm` mode. */
           context?: string;
         } & { [key: string]: any };
@@ -13097,7 +13097,7 @@ export interface operations {
       content: {
         "application/json": {
           /** Whether to block all notifications from a thread. */
-          ignored?: boolean;
+          ignored: boolean;
         } & { [key: string]: any };
       };
     };
@@ -13241,7 +13241,7 @@ export interface operations {
            * \* `admin` - can pull, push, and administer this repository.
            * \* `none` - no permissions granted by default.
            */
-          default_repository_permission?: "read" | "write" | "admin" | "none";
+          default_repository_permission: "read" | "write" | "admin" | "none";
           /**
            * Toggles the ability of non-admin organization members to create repositories. Can be one of:
            * \* `true` - all organization members can create repositories.
@@ -13249,7 +13249,7 @@ export interface operations {
            * Default: `true`
            * **Note:** A parameter can override this parameter. See `members_allowed_repository_creation_type` in this table for details. **Note:** A parameter can override this parameter. See `members_allowed_repository_creation_type` in this table for details.
            */
-          members_can_create_repositories?: boolean;
+          members_can_create_repositories: boolean;
           /**
            * Toggles whether organization members can create internal repositories, which are visible to all enterprise members. You can only allow members to create internal repositories if your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. Can be one of:
            * \* `true` - all organization members can create internal repositories.
@@ -13284,19 +13284,19 @@ export interface operations {
            * \* `true` - all organization members can create GitHub Pages sites.
            * \* `false` - no organization members can create GitHub Pages sites. Existing published sites will not be impacted.
            */
-          members_can_create_pages?: boolean;
+          members_can_create_pages: boolean;
           /**
            * Toggles whether organization members can create public GitHub Pages sites. Can be one of:
            * \* `true` - all organization members can create public GitHub Pages sites.
            * \* `false` - no organization members can create public GitHub Pages sites. Existing published sites will not be impacted.
            */
-          members_can_create_public_pages?: boolean;
+          members_can_create_public_pages: boolean;
           /**
            * Toggles whether organization members can create private GitHub Pages sites. Can be one of:
            * \* `true` - all organization members can create private GitHub Pages sites.
            * \* `false` - no organization members can create private GitHub Pages sites. Existing published sites will not be impacted.
            */
-          members_can_create_private_pages?: boolean;
+          members_can_create_private_pages: boolean;
           blog?: string;
         } & { [key: string]: any };
       };
@@ -13538,7 +13538,7 @@ export interface operations {
           /** Name of the runner group. */
           name: string;
           /** Visibility of a runner group. You can select all repositories, select individual repositories, or limit access to private repositories. Can be one of: `all`, `selected`, or `private`. */
-          visibility?: "selected" | "all" | "private";
+          visibility: "selected" | "all" | "private";
           /** List of repository IDs that can access the runner group. */
           selected_repository_ids?: number[];
           /** List of runner IDs to add to the runner group. */
@@ -14492,9 +14492,9 @@ export interface operations {
             password?: string;
           } & { [key: string]: any };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          events?: string[];
+          events: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          active?: boolean;
+          active: boolean;
         } & { [key: string]: any };
       };
     };
@@ -14559,9 +14559,9 @@ export interface operations {
             insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
           } & { [key: string]: any };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          events?: string[];
+          events: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          active?: boolean;
+          active: boolean;
           name?: string;
         } & { [key: string]: any };
       };
@@ -14787,7 +14787,7 @@ export interface operations {
            * \* `direct_member` - Non-owner organization members with ability to see other members and join teams by invitation.
            * \* `billing_manager` - Non-owner organization members with ability to manage the billing settings of your organization.
            */
-          role?: "admin" | "direct_member" | "billing_manager";
+          role: "admin" | "direct_member" | "billing_manager";
           /** Specify IDs for the teams you want to invite new members to. */
           team_ids?: number[];
         } & { [key: string]: any };
@@ -15015,7 +15015,7 @@ export interface operations {
            * \* `admin` - The user will become an owner of the organization.
            * \* `member` - The user will become a non-owner member of the organization.
            */
-          role?: "admin" | "member";
+          role: "admin" | "member";
         } & { [key: string]: any };
       };
     };
@@ -15085,9 +15085,9 @@ export interface operations {
           /** A list of arrays indicating which repositories should be migrated. */
           repositories: string[];
           /** Indicates whether repositories should be locked (to prevent manipulation) while migrating data. */
-          lock_repositories?: boolean;
+          lock_repositories: boolean;
           /** Indicates whether attachments should be excluded from the migration (to reduce migration archive file size). */
-          exclude_attachments?: boolean;
+          exclude_attachments: boolean;
           exclude?: string[];
         } & { [key: string]: any };
       };
@@ -15659,36 +15659,36 @@ export interface operations {
           /** A URL with more information about the repository. */
           homepage?: string;
           /** Either `true` to create a private repository or `false` to create a public one. */
-          private?: boolean;
+          private: boolean;
           /**
            * Can be `public` or `private`. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, `visibility` can also be `internal`. For more information, see "[Creating an internal repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-repository-visibility#about-internal-repositories)" in the GitHub Help documentation.
            * The `visibility` parameter overrides the `private` parameter when you use both parameters with the `nebula-preview` preview header.
            */
           visibility?: "public" | "private" | "visibility" | "internal";
           /** Either `true` to enable issues for this repository or `false` to disable them. */
-          has_issues?: boolean;
+          has_issues: boolean;
           /** Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error. */
-          has_projects?: boolean;
+          has_projects: boolean;
           /** Either `true` to enable the wiki for this repository or `false` to disable it. */
-          has_wiki?: boolean;
+          has_wiki: boolean;
           /** Either `true` to make this repo available as a template repository or `false` to prevent it. */
-          is_template?: boolean;
+          is_template: boolean;
           /** The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization. */
           team_id?: number;
           /** Pass `true` to create an initial commit with empty README. */
-          auto_init?: boolean;
+          auto_init: boolean;
           /** Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, "Haskell". */
           gitignore_template?: string;
           /** Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, "mit" or "mpl-2.0". */
           license_template?: string;
           /** Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging. */
-          allow_squash_merge?: boolean;
+          allow_squash_merge: boolean;
           /** Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits. */
-          allow_merge_commit?: boolean;
+          allow_merge_commit: boolean;
           /** Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging. */
-          allow_rebase_merge?: boolean;
+          allow_rebase_merge: boolean;
           /** Either `true` to allow automatically deleting head branches when pull requests are merged, or `false` to prevent automatic deletion. */
-          delete_branch_on_merge?: boolean;
+          delete_branch_on_merge: boolean;
         } & { [key: string]: any };
       };
     };
@@ -15863,7 +15863,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          permission?: "pull" | "push" | "admin";
+          permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number;
         } & { [key: string]: any };
@@ -15956,7 +15956,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          permission?: "pull" | "push" | "admin";
+          permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number | null;
         } & { [key: string]: any };
@@ -16025,7 +16025,7 @@ export interface operations {
           /** The discussion post's body text. */
           body: string;
           /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
-          private?: boolean;
+          private: boolean;
         } & { [key: string]: any };
       };
     };
@@ -16562,7 +16562,7 @@ export interface operations {
            * \* `member` - a normal member of the team.
            * \* `maintainer` - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
            */
-          role?: "member" | "maintainer";
+          role: "member" | "maintainer";
         } & { [key: string]: any };
       };
     };
@@ -17387,7 +17387,7 @@ export interface operations {
       content: {
         "application/json": {
           /** The permission to grant the collaborator. */
-          permission?: "read" | "write" | "admin";
+          permission: "read" | "write" | "admin";
         } & { [key: string]: any };
       };
     };
@@ -17610,29 +17610,29 @@ export interface operations {
            * Either `true` to make the repository private or `false` to make it public. Default: `false`.
            * **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private. **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private.
            */
-          private?: boolean;
+          private: boolean;
           /** Can be `public` or `private`. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, `visibility` can also be `internal`. The `visibility` parameter overrides the `private` parameter when you use both along with the `nebula-preview` preview header. */
           visibility?: "public" | "private" | "visibility" | "internal";
           /** Either `true` to enable issues for this repository or `false` to disable them. */
-          has_issues?: boolean;
+          has_issues: boolean;
           /** Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error. */
-          has_projects?: boolean;
+          has_projects: boolean;
           /** Either `true` to enable the wiki for this repository or `false` to disable it. */
-          has_wiki?: boolean;
+          has_wiki: boolean;
           /** Either `true` to make this repo available as a template repository or `false` to prevent it. */
-          is_template?: boolean;
+          is_template: boolean;
           /** Updates the default branch for this repository. */
           default_branch?: string;
           /** Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging. */
-          allow_squash_merge?: boolean;
+          allow_squash_merge: boolean;
           /** Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits. */
-          allow_merge_commit?: boolean;
+          allow_merge_commit: boolean;
           /** Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging. */
-          allow_rebase_merge?: boolean;
+          allow_rebase_merge: boolean;
           /** Either `true` to allow automatically deleting head branches when pull requests are merged, or `false` to prevent automatic deletion. */
-          delete_branch_on_merge?: boolean;
+          delete_branch_on_merge: boolean;
           /** `true` to archive this repository. **Note**: You cannot unarchive repositories through the API. */
-          archived?: boolean;
+          archived: boolean;
         } & { [key: string]: any };
       };
     };
@@ -19830,7 +19830,7 @@ export interface operations {
           /** A reference for the run on the integrator's system. */
           external_id?: string;
           /** The current status. Can be one of `queued`, `in_progress`, or `completed`. */
-          status?: "queued" | "in_progress" | "completed";
+          status: "queued" | "in_progress" | "completed";
           /** The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
           started_at?: string;
           /**
@@ -20698,7 +20698,7 @@ export interface operations {
            * \* `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
            * \* `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
            */
-          permission?: "pull" | "push" | "admin" | "maintain" | "triage";
+          permission: "pull" | "push" | "admin" | "maintain" | "triage";
           permissions?: string;
         } & { [key: string]: any };
       };
@@ -21739,21 +21739,21 @@ export interface operations {
           /** The ref to deploy. This can be a branch, tag, or SHA. */
           ref: string;
           /** Specifies a task to execute (e.g., `deploy` or `deploy:migrations`). */
-          task?: string;
+          task: string;
           /** Attempts to automatically merge the default branch into the requested ref, if it's behind the default branch. */
-          auto_merge?: boolean;
+          auto_merge: boolean;
           /** The [status](https://docs.github.com/rest/reference/repos#statuses) contexts to verify against commit status checks. If you omit this parameter, GitHub verifies all unique contexts before creating a deployment. To bypass checking entirely, pass an empty array. Defaults to all unique contexts. */
           required_contexts?: string[];
           payload?: ({ [key: string]: any } | string) & { [key: string]: any };
           /** Name for the target deployment environment (e.g., `production`, `staging`, `qa`). */
-          environment?: string;
+          environment: string;
           /** Short description of the deployment. */
-          description?: string | null;
+          description: string | null;
           /**
            * Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. Default: `false`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          transient_environment?: boolean;
+          transient_environment: boolean;
           /**
            * Specifies if the given environment is one that end-users directly interact with. Default: `true` when `environment` is `production` and `false` otherwise.
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
@@ -21868,21 +21868,21 @@ export interface operations {
           /** The state of the status. Can be one of `error`, `failure`, `inactive`, `in_progress`, `queued` `pending`, or `success`. **Note:** To use the `inactive` state, you must provide the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. To use the `in_progress` and `queued` states, you must provide the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type. When you set a transient deployment to `inactive`, the deployment will be shown as `destroyed` in GitHub. */
           state: "error" | "failure" | "inactive" | "in_progress" | "queued" | "pending" | "success";
           /** The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. **Note:** It's recommended to use the `log_url` parameter, which replaces `target_url`. */
-          target_url?: string;
+          target_url: string;
           /**
            * The full URL of the deployment's output. This parameter replaces `target_url`. We will continue to accept `target_url` to support legacy uses, but we recommend replacing `target_url` with `log_url`. Setting `log_url` will automatically set `target_url` to the same value. Default: `""`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          log_url?: string;
+          log_url: string;
           /** A short description of the status. The maximum description length is 140 characters. */
-          description?: string;
+          description: string;
           /** Name for the target deployment environment, which can be changed when setting a deploy status. For example, `production`, `staging`, or `qa`. **Note:** This parameter requires you to use the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type. */
           environment?: "production" | "staging" | "qa";
           /**
            * Sets the URL for accessing your environment. Default: `""`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          environment_url?: string;
+          environment_url: string;
           /**
            * Adds a new `inactive` status to all prior non-transient, non-production environment deployments with the same repository and `environment` name as the created status's deployment. An `inactive` status is only added to deployments that had a `success` state. Default: `true`
            * **Note:** To add an `inactive` status to `production` environments, you must use the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type.
@@ -22165,7 +22165,7 @@ export interface operations {
           /** The new blob's content. */
           content: string;
           /** The encoding used for `content`. Currently, `"utf-8"` and `"base64"` are supported. */
-          encoding?: string;
+          encoding: string;
         } & { [key: string]: any };
       };
     };
@@ -22460,7 +22460,7 @@ export interface operations {
           /** The SHA1 value to set this reference to */
           sha: string;
           /** Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to `false` will make sure you're not overwriting work. */
-          force?: boolean;
+          force: boolean;
         } & { [key: string]: any };
       };
     };
@@ -22739,9 +22739,9 @@ export interface operations {
             digest?: string;
           } & { [key: string]: any };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          events?: string[];
+          events: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          active?: boolean;
+          active: boolean;
         } & { [key: string]: any };
       };
     };
@@ -22811,13 +22811,13 @@ export interface operations {
             room?: string;
           } & { [key: string]: any };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events. */
-          events?: string[];
+          events: string[];
           /** Determines a list of events to be added to the list of events that the Hook triggers for. */
           add_events?: string[];
           /** Determines a list of events to be removed from the list of events that the Hook triggers for. */
           remove_events?: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          active?: boolean;
+          active: boolean;
         } & { [key: string]: any };
       };
     };
@@ -24484,7 +24484,7 @@ export interface operations {
           /** The title of the milestone. */
           title: string;
           /** The state of the milestone. Either `open` or `closed`. */
-          state?: "open" | "closed";
+          state: "open" | "closed";
           /** A description of the milestone. */
           description?: string;
           /** The milestone due date. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
@@ -24550,7 +24550,7 @@ export interface operations {
           /** The title of the milestone. */
           title?: string;
           /** The state of the milestone. Either `open` or `closed`. */
-          state?: "open" | "closed";
+          state: "open" | "closed";
           /** A description of the milestone. */
           description?: string;
           /** The milestone due date. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
@@ -24715,7 +24715,7 @@ export interface operations {
             /** The repository branch used to publish your site's source files. */
             branch: string;
             /** The repository directory that includes the source files for the Pages site. Allowed paths are `/` or `/docs`. Default: `/` */
-            path?: "/" | "/docs";
+            path: "/" | "/docs";
           } & { [key: string]: any };
         } & { [key: string]: any };
       };
@@ -25903,9 +25903,9 @@ export interface operations {
           /** Text describing the contents of the tag. */
           body?: string;
           /** `true` to create a draft (unpublished) release, `false` to create a published one. */
-          draft?: boolean;
+          draft: boolean;
           /** `true` to identify the release as a prerelease. `false` to identify the release as a full release. */
-          prerelease?: boolean;
+          prerelease: boolean;
         } & { [key: string]: any };
       };
     };
@@ -26433,7 +26433,7 @@ export interface operations {
           /** A short description of the status. */
           description?: string;
           /** A string label to differentiate this status from the status of other systems. This field is case-insensitive. */
-          context?: string;
+          context: string;
         } & { [key: string]: any };
       };
     };
@@ -26836,9 +26836,9 @@ export interface operations {
           /** A short description of the new repository. */
           description?: string;
           /** Set to `true` to include the directory structure and files from all branches in the template repository, and not just the default branch. Default: `false`. */
-          include_all_branches?: boolean;
+          include_all_branches: boolean;
           /** Either `true` to create a new private repository or `false` to create a new public one. */
-          private?: boolean;
+          private: boolean;
         } & { [key: string]: any };
       };
     };
@@ -28102,7 +28102,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          permission?: "pull" | "push" | "admin";
+          permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number | null;
         } & { [key: string]: any };
@@ -28167,7 +28167,7 @@ export interface operations {
           /** The discussion post's body text. */
           body: string;
           /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
-          private?: boolean;
+          private: boolean;
         } & { [key: string]: any };
       };
     };
@@ -28721,7 +28721,7 @@ export interface operations {
            * \* `member` - a normal member of the team.
            * \* `maintainer` - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
            */
-          role?: "member" | "maintainer";
+          role: "member" | "maintainer";
         } & { [key: string]: any };
       };
     };
@@ -30420,33 +30420,33 @@ export interface operations {
           /** A URL with more information about the repository. */
           homepage?: string;
           /** Whether the repository is private or public. */
-          private?: boolean;
+          private: boolean;
           /** Whether issues are enabled. */
-          has_issues?: boolean;
+          has_issues: boolean;
           /** Whether projects are enabled. */
-          has_projects?: boolean;
+          has_projects: boolean;
           /** Whether the wiki is enabled. */
-          has_wiki?: boolean;
+          has_wiki: boolean;
           /** The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization. */
           team_id?: number;
           /** Whether the repository is initialized with a minimal README. */
-          auto_init?: boolean;
+          auto_init: boolean;
           /** The desired language or platform to apply to the .gitignore. */
           gitignore_template?: string;
           /** The license keyword of the open source license for this repository. */
           license_template?: string;
           /** Whether to allow squash merges for pull requests. */
-          allow_squash_merge?: boolean;
+          allow_squash_merge: boolean;
           /** Whether to allow merge commits for pull requests. */
-          allow_merge_commit?: boolean;
+          allow_merge_commit: boolean;
           /** Whether to allow rebase merges for pull requests. */
-          allow_rebase_merge?: boolean;
+          allow_rebase_merge: boolean;
           /** Whether to delete head branches when pull requests are merged */
-          delete_branch_on_merge?: boolean;
+          delete_branch_on_merge: boolean;
           /** Whether downloads are enabled. */
-          has_downloads?: boolean;
+          has_downloads: boolean;
           /** Whether this repository acts as a template that can be used to generate new repositories. */
-          is_template?: boolean;
+          is_template: boolean;
         } & { [key: string]: any };
       };
     };

--- a/tests/v3/expected/github.immutable.ts
+++ b/tests/v3/expected/github.immutable.ts
@@ -5413,7 +5413,7 @@ export interface components {
       readonly default_branch: string;
       readonly open_issues_count: number;
       /** Whether this repository acts as a template that can be used to generate new repositories. */
-      readonly is_template?: boolean;
+      readonly is_template: boolean;
       readonly topics?: readonly string[];
       /** Whether issues are enabled. */
       readonly has_issues: boolean;
@@ -5429,12 +5429,12 @@ export interface components {
       /** Returns whether or not this repository disabled. */
       readonly disabled: boolean;
       /** The repository visibility: public, private, or internal. */
-      readonly visibility?: string;
+      readonly visibility: string;
       readonly pushed_at: string | null;
       readonly created_at: string | null;
       readonly updated_at: string | null;
       /** Whether to allow rebase merges for pull requests. */
-      readonly allow_rebase_merge?: boolean;
+      readonly allow_rebase_merge: boolean;
       readonly template_repository?: {
         readonly id?: number;
         readonly node_id?: string;
@@ -5542,11 +5542,11 @@ export interface components {
       } | null;
       readonly temp_clone_token?: string;
       /** Whether to allow squash merges for pull requests. */
-      readonly allow_squash_merge?: boolean;
+      readonly allow_squash_merge: boolean;
       /** Whether to delete head branches when pull requests are merged */
-      readonly delete_branch_on_merge?: boolean;
+      readonly delete_branch_on_merge: boolean;
       /** Whether to allow merge commits for pull requests. */
-      readonly allow_merge_commit?: boolean;
+      readonly allow_merge_commit: boolean;
       readonly subscribers_count?: number;
       readonly network_count?: number;
       readonly open_issues: number;
@@ -6835,7 +6835,7 @@ export interface components {
       readonly default_branch: string;
       readonly open_issues_count: number;
       /** Whether this repository acts as a template that can be used to generate new repositories. */
-      readonly is_template?: boolean;
+      readonly is_template: boolean;
       readonly topics?: readonly string[];
       /** Whether issues are enabled. */
       readonly has_issues: boolean;
@@ -6851,20 +6851,20 @@ export interface components {
       /** Returns whether or not this repository disabled. */
       readonly disabled: boolean;
       /** The repository visibility: public, private, or internal. */
-      readonly visibility?: string;
+      readonly visibility: string;
       readonly pushed_at: string | null;
       readonly created_at: string | null;
       readonly updated_at: string | null;
       /** Whether to allow rebase merges for pull requests. */
-      readonly allow_rebase_merge?: boolean;
+      readonly allow_rebase_merge: boolean;
       readonly template_repository?: components["schemas"]["repository"] | null;
       readonly temp_clone_token?: string;
       /** Whether to allow squash merges for pull requests. */
-      readonly allow_squash_merge?: boolean;
+      readonly allow_squash_merge: boolean;
       /** Whether to delete head branches when pull requests are merged */
-      readonly delete_branch_on_merge?: boolean;
+      readonly delete_branch_on_merge: boolean;
       /** Whether to allow merge commits for pull requests. */
-      readonly allow_merge_commit?: boolean;
+      readonly allow_merge_commit: boolean;
       readonly subscribers_count?: number;
       readonly network_count?: number;
       readonly open_issues: number;
@@ -7027,7 +7027,7 @@ export interface components {
       readonly open_issues: number;
       readonly watchers: number;
       /** Whether anonymous git access is allowed. */
-      readonly anonymous_access_enabled?: boolean;
+      readonly anonymous_access_enabled: boolean;
       readonly code_of_conduct?: components["schemas"]["code-of-conduct-simple"];
     };
     /** An artifact */
@@ -8262,7 +8262,7 @@ export interface components {
       /** A short description of the status. */
       readonly description: string;
       /** The environment of the deployment that the status is for. */
-      readonly environment?: string;
+      readonly environment: string;
       /** Deprecated: the URL to associate with this status. */
       readonly target_url: string;
       readonly created_at: string;
@@ -8270,9 +8270,9 @@ export interface components {
       readonly deployment_url: string;
       readonly repository_url: string;
       /** The URL for accessing your environment. */
-      readonly environment_url?: string;
+      readonly environment_url: string;
       /** The URL to associate with this status. */
-      readonly log_url?: string;
+      readonly log_url: string;
       readonly performed_via_github_app?: components["schemas"]["integration"] | null;
     };
     /** The amount of time to delay a job after the job is initially triggered. The time (in minutes) must be an integer between 0 and 43,200 (30 days). */
@@ -9063,13 +9063,13 @@ export interface components {
       /** The first line of the range for a multi-line comment. */
       readonly original_start_line?: number | null;
       /** The side of the first line of the range for a multi-line comment. */
-      readonly start_side?: ("LEFT" | "RIGHT") | null;
+      readonly start_side: ("LEFT" | "RIGHT") | null;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       readonly line?: number;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       readonly original_line?: number;
       /** The side of the diff to which the comment applies. The side of the last line of the range for a multi-line comment */
-      readonly side?: "LEFT" | "RIGHT";
+      readonly side: "LEFT" | "RIGHT";
       readonly reactions?: components["schemas"]["reaction-rollup"];
       readonly body_html?: string;
       readonly body_text?: string;
@@ -9139,9 +9139,9 @@ export interface components {
       readonly body_text?: string;
       readonly body_html?: string;
       /** The side of the first line of the range for a multi-line comment. */
-      readonly side?: "LEFT" | "RIGHT";
+      readonly side: "LEFT" | "RIGHT";
       /** The side of the first line of the range for a multi-line comment. */
-      readonly start_side?: ("LEFT" | "RIGHT") | null;
+      readonly start_side: ("LEFT" | "RIGHT") | null;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       readonly line?: number;
       /** The original line of the blob to which the comment applies. The last line of the range for a multi-line comment */
@@ -11504,7 +11504,7 @@ export interface operations {
           /** Name of the runner group. */
           readonly name?: string;
           /** Visibility of a runner group. You can select all organizations or select individual organizations. Can be one of: `all` or `selected` */
-          readonly visibility?: "selected" | "all";
+          readonly visibility: "selected" | "all";
         };
       };
     };
@@ -12674,7 +12674,7 @@ export interface operations {
           /** The Markdown text to render in HTML. */
           readonly text: string;
           /** The rendering mode. */
-          readonly mode?: "markdown" | "gfm";
+          readonly mode: "markdown" | "gfm";
           /** The repository context to use when creating references in `gfm` mode. */
           readonly context?: string;
         };
@@ -13062,7 +13062,7 @@ export interface operations {
       readonly content: {
         readonly "application/json": {
           /** Whether to block all notifications from a thread. */
-          readonly ignored?: boolean;
+          readonly ignored: boolean;
         };
       };
     };
@@ -13205,7 +13205,7 @@ export interface operations {
            * \* `admin` - can pull, push, and administer this repository.
            * \* `none` - no permissions granted by default.
            */
-          readonly default_repository_permission?: "read" | "write" | "admin" | "none";
+          readonly default_repository_permission: "read" | "write" | "admin" | "none";
           /**
            * Toggles the ability of non-admin organization members to create repositories. Can be one of:
            * \* `true` - all organization members can create repositories.
@@ -13213,7 +13213,7 @@ export interface operations {
            * Default: `true`
            * **Note:** A parameter can override this parameter. See `members_allowed_repository_creation_type` in this table for details. **Note:** A parameter can override this parameter. See `members_allowed_repository_creation_type` in this table for details.
            */
-          readonly members_can_create_repositories?: boolean;
+          readonly members_can_create_repositories: boolean;
           /**
            * Toggles whether organization members can create internal repositories, which are visible to all enterprise members. You can only allow members to create internal repositories if your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. Can be one of:
            * \* `true` - all organization members can create internal repositories.
@@ -13248,19 +13248,19 @@ export interface operations {
            * \* `true` - all organization members can create GitHub Pages sites.
            * \* `false` - no organization members can create GitHub Pages sites. Existing published sites will not be impacted.
            */
-          readonly members_can_create_pages?: boolean;
+          readonly members_can_create_pages: boolean;
           /**
            * Toggles whether organization members can create public GitHub Pages sites. Can be one of:
            * \* `true` - all organization members can create public GitHub Pages sites.
            * \* `false` - no organization members can create public GitHub Pages sites. Existing published sites will not be impacted.
            */
-          readonly members_can_create_public_pages?: boolean;
+          readonly members_can_create_public_pages: boolean;
           /**
            * Toggles whether organization members can create private GitHub Pages sites. Can be one of:
            * \* `true` - all organization members can create private GitHub Pages sites.
            * \* `false` - no organization members can create private GitHub Pages sites. Existing published sites will not be impacted.
            */
-          readonly members_can_create_private_pages?: boolean;
+          readonly members_can_create_private_pages: boolean;
           readonly blog?: string;
         };
       };
@@ -13502,7 +13502,7 @@ export interface operations {
           /** Name of the runner group. */
           readonly name: string;
           /** Visibility of a runner group. You can select all repositories, select individual repositories, or limit access to private repositories. Can be one of: `all`, `selected`, or `private`. */
-          readonly visibility?: "selected" | "all" | "private";
+          readonly visibility: "selected" | "all" | "private";
           /** List of repository IDs that can access the runner group. */
           readonly selected_repository_ids?: readonly number[];
           /** List of runner IDs to add to the runner group. */
@@ -14456,9 +14456,9 @@ export interface operations {
             readonly password?: string;
           };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          readonly events?: readonly string[];
+          readonly events: readonly string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          readonly active?: boolean;
+          readonly active: boolean;
         };
       };
     };
@@ -14523,9 +14523,9 @@ export interface operations {
             readonly insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
           };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          readonly events?: readonly string[];
+          readonly events: readonly string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          readonly active?: boolean;
+          readonly active: boolean;
           readonly name?: string;
         };
       };
@@ -14751,7 +14751,7 @@ export interface operations {
            * \* `direct_member` - Non-owner organization members with ability to see other members and join teams by invitation.
            * \* `billing_manager` - Non-owner organization members with ability to manage the billing settings of your organization.
            */
-          readonly role?: "admin" | "direct_member" | "billing_manager";
+          readonly role: "admin" | "direct_member" | "billing_manager";
           /** Specify IDs for the teams you want to invite new members to. */
           readonly team_ids?: readonly number[];
         };
@@ -14979,7 +14979,7 @@ export interface operations {
            * \* `admin` - The user will become an owner of the organization.
            * \* `member` - The user will become a non-owner member of the organization.
            */
-          readonly role?: "admin" | "member";
+          readonly role: "admin" | "member";
         };
       };
     };
@@ -15049,9 +15049,9 @@ export interface operations {
           /** A list of arrays indicating which repositories should be migrated. */
           readonly repositories: readonly string[];
           /** Indicates whether repositories should be locked (to prevent manipulation) while migrating data. */
-          readonly lock_repositories?: boolean;
+          readonly lock_repositories: boolean;
           /** Indicates whether attachments should be excluded from the migration (to reduce migration archive file size). */
-          readonly exclude_attachments?: boolean;
+          readonly exclude_attachments: boolean;
           readonly exclude?: readonly string[];
         };
       };
@@ -15623,36 +15623,36 @@ export interface operations {
           /** A URL with more information about the repository. */
           readonly homepage?: string;
           /** Either `true` to create a private repository or `false` to create a public one. */
-          readonly private?: boolean;
+          readonly private: boolean;
           /**
            * Can be `public` or `private`. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, `visibility` can also be `internal`. For more information, see "[Creating an internal repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-repository-visibility#about-internal-repositories)" in the GitHub Help documentation.
            * The `visibility` parameter overrides the `private` parameter when you use both parameters with the `nebula-preview` preview header.
            */
           readonly visibility?: "public" | "private" | "visibility" | "internal";
           /** Either `true` to enable issues for this repository or `false` to disable them. */
-          readonly has_issues?: boolean;
+          readonly has_issues: boolean;
           /** Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error. */
-          readonly has_projects?: boolean;
+          readonly has_projects: boolean;
           /** Either `true` to enable the wiki for this repository or `false` to disable it. */
-          readonly has_wiki?: boolean;
+          readonly has_wiki: boolean;
           /** Either `true` to make this repo available as a template repository or `false` to prevent it. */
-          readonly is_template?: boolean;
+          readonly is_template: boolean;
           /** The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization. */
           readonly team_id?: number;
           /** Pass `true` to create an initial commit with empty README. */
-          readonly auto_init?: boolean;
+          readonly auto_init: boolean;
           /** Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, "Haskell". */
           readonly gitignore_template?: string;
           /** Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, "mit" or "mpl-2.0". */
           readonly license_template?: string;
           /** Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging. */
-          readonly allow_squash_merge?: boolean;
+          readonly allow_squash_merge: boolean;
           /** Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits. */
-          readonly allow_merge_commit?: boolean;
+          readonly allow_merge_commit: boolean;
           /** Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging. */
-          readonly allow_rebase_merge?: boolean;
+          readonly allow_rebase_merge: boolean;
           /** Either `true` to allow automatically deleting head branches when pull requests are merged, or `false` to prevent automatic deletion. */
-          readonly delete_branch_on_merge?: boolean;
+          readonly delete_branch_on_merge: boolean;
         };
       };
     };
@@ -15827,7 +15827,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          readonly permission?: "pull" | "push" | "admin";
+          readonly permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           readonly parent_team_id?: number;
         };
@@ -15920,7 +15920,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          readonly permission?: "pull" | "push" | "admin";
+          readonly permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           readonly parent_team_id?: number | null;
         };
@@ -15989,7 +15989,7 @@ export interface operations {
           /** The discussion post's body text. */
           readonly body: string;
           /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
-          readonly private?: boolean;
+          readonly private: boolean;
         };
       };
     };
@@ -16526,7 +16526,7 @@ export interface operations {
            * \* `member` - a normal member of the team.
            * \* `maintainer` - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
            */
-          readonly role?: "member" | "maintainer";
+          readonly role: "member" | "maintainer";
         };
       };
     };
@@ -17347,7 +17347,7 @@ export interface operations {
       readonly content: {
         readonly "application/json": {
           /** The permission to grant the collaborator. */
-          readonly permission?: "read" | "write" | "admin";
+          readonly permission: "read" | "write" | "admin";
         };
       };
     };
@@ -17570,29 +17570,29 @@ export interface operations {
            * Either `true` to make the repository private or `false` to make it public. Default: `false`.
            * **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private. **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private.
            */
-          readonly private?: boolean;
+          readonly private: boolean;
           /** Can be `public` or `private`. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, `visibility` can also be `internal`. The `visibility` parameter overrides the `private` parameter when you use both along with the `nebula-preview` preview header. */
           readonly visibility?: "public" | "private" | "visibility" | "internal";
           /** Either `true` to enable issues for this repository or `false` to disable them. */
-          readonly has_issues?: boolean;
+          readonly has_issues: boolean;
           /** Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error. */
-          readonly has_projects?: boolean;
+          readonly has_projects: boolean;
           /** Either `true` to enable the wiki for this repository or `false` to disable it. */
-          readonly has_wiki?: boolean;
+          readonly has_wiki: boolean;
           /** Either `true` to make this repo available as a template repository or `false` to prevent it. */
-          readonly is_template?: boolean;
+          readonly is_template: boolean;
           /** Updates the default branch for this repository. */
           readonly default_branch?: string;
           /** Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging. */
-          readonly allow_squash_merge?: boolean;
+          readonly allow_squash_merge: boolean;
           /** Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits. */
-          readonly allow_merge_commit?: boolean;
+          readonly allow_merge_commit: boolean;
           /** Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging. */
-          readonly allow_rebase_merge?: boolean;
+          readonly allow_rebase_merge: boolean;
           /** Either `true` to allow automatically deleting head branches when pull requests are merged, or `false` to prevent automatic deletion. */
-          readonly delete_branch_on_merge?: boolean;
+          readonly delete_branch_on_merge: boolean;
           /** `true` to archive this repository. **Note**: You cannot unarchive repositories through the API. */
-          readonly archived?: boolean;
+          readonly archived: boolean;
         };
       };
     };
@@ -19784,7 +19784,7 @@ export interface operations {
           /** A reference for the run on the integrator's system. */
           readonly external_id?: string;
           /** The current status. Can be one of `queued`, `in_progress`, or `completed`. */
-          readonly status?: "queued" | "in_progress" | "completed";
+          readonly status: "queued" | "in_progress" | "completed";
           /** The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
           readonly started_at?: string;
           /**
@@ -20652,7 +20652,7 @@ export interface operations {
            * \* `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
            * \* `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
            */
-          readonly permission?: "pull" | "push" | "admin" | "maintain" | "triage";
+          readonly permission: "pull" | "push" | "admin" | "maintain" | "triage";
           readonly permissions?: string;
         };
       };
@@ -21692,21 +21692,21 @@ export interface operations {
           /** The ref to deploy. This can be a branch, tag, or SHA. */
           readonly ref: string;
           /** Specifies a task to execute (e.g., `deploy` or `deploy:migrations`). */
-          readonly task?: string;
+          readonly task: string;
           /** Attempts to automatically merge the default branch into the requested ref, if it's behind the default branch. */
-          readonly auto_merge?: boolean;
+          readonly auto_merge: boolean;
           /** The [status](https://docs.github.com/rest/reference/repos#statuses) contexts to verify against commit status checks. If you omit this parameter, GitHub verifies all unique contexts before creating a deployment. To bypass checking entirely, pass an empty array. Defaults to all unique contexts. */
           readonly required_contexts?: readonly string[];
           readonly payload?: { readonly [key: string]: any } | string;
           /** Name for the target deployment environment (e.g., `production`, `staging`, `qa`). */
-          readonly environment?: string;
+          readonly environment: string;
           /** Short description of the deployment. */
-          readonly description?: string | null;
+          readonly description: string | null;
           /**
            * Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. Default: `false`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          readonly transient_environment?: boolean;
+          readonly transient_environment: boolean;
           /**
            * Specifies if the given environment is one that end-users directly interact with. Default: `true` when `environment` is `production` and `false` otherwise.
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
@@ -21821,21 +21821,21 @@ export interface operations {
           /** The state of the status. Can be one of `error`, `failure`, `inactive`, `in_progress`, `queued` `pending`, or `success`. **Note:** To use the `inactive` state, you must provide the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. To use the `in_progress` and `queued` states, you must provide the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type. When you set a transient deployment to `inactive`, the deployment will be shown as `destroyed` in GitHub. */
           readonly state: "error" | "failure" | "inactive" | "in_progress" | "queued" | "pending" | "success";
           /** The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. **Note:** It's recommended to use the `log_url` parameter, which replaces `target_url`. */
-          readonly target_url?: string;
+          readonly target_url: string;
           /**
            * The full URL of the deployment's output. This parameter replaces `target_url`. We will continue to accept `target_url` to support legacy uses, but we recommend replacing `target_url` with `log_url`. Setting `log_url` will automatically set `target_url` to the same value. Default: `""`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          readonly log_url?: string;
+          readonly log_url: string;
           /** A short description of the status. The maximum description length is 140 characters. */
-          readonly description?: string;
+          readonly description: string;
           /** Name for the target deployment environment, which can be changed when setting a deploy status. For example, `production`, `staging`, or `qa`. **Note:** This parameter requires you to use the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type. */
           readonly environment?: "production" | "staging" | "qa";
           /**
            * Sets the URL for accessing your environment. Default: `""`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          readonly environment_url?: string;
+          readonly environment_url: string;
           /**
            * Adds a new `inactive` status to all prior non-transient, non-production environment deployments with the same repository and `environment` name as the created status's deployment. An `inactive` status is only added to deployments that had a `success` state. Default: `true`
            * **Note:** To add an `inactive` status to `production` environments, you must use the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type.
@@ -22118,7 +22118,7 @@ export interface operations {
           /** The new blob's content. */
           readonly content: string;
           /** The encoding used for `content`. Currently, `"utf-8"` and `"base64"` are supported. */
-          readonly encoding?: string;
+          readonly encoding: string;
         };
       };
     };
@@ -22413,7 +22413,7 @@ export interface operations {
           /** The SHA1 value to set this reference to */
           readonly sha: string;
           /** Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to `false` will make sure you're not overwriting work. */
-          readonly force?: boolean;
+          readonly force: boolean;
         };
       };
     };
@@ -22692,9 +22692,9 @@ export interface operations {
             readonly digest?: string;
           };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          readonly events?: readonly string[];
+          readonly events: readonly string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          readonly active?: boolean;
+          readonly active: boolean;
         };
       };
     };
@@ -22764,13 +22764,13 @@ export interface operations {
             readonly room?: string;
           };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events. */
-          readonly events?: readonly string[];
+          readonly events: readonly string[];
           /** Determines a list of events to be added to the list of events that the Hook triggers for. */
           readonly add_events?: readonly string[];
           /** Determines a list of events to be removed from the list of events that the Hook triggers for. */
           readonly remove_events?: readonly string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          readonly active?: boolean;
+          readonly active: boolean;
         };
       };
     };
@@ -24435,7 +24435,7 @@ export interface operations {
           /** The title of the milestone. */
           readonly title: string;
           /** The state of the milestone. Either `open` or `closed`. */
-          readonly state?: "open" | "closed";
+          readonly state: "open" | "closed";
           /** A description of the milestone. */
           readonly description?: string;
           /** The milestone due date. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
@@ -24501,7 +24501,7 @@ export interface operations {
           /** The title of the milestone. */
           readonly title?: string;
           /** The state of the milestone. Either `open` or `closed`. */
-          readonly state?: "open" | "closed";
+          readonly state: "open" | "closed";
           /** A description of the milestone. */
           readonly description?: string;
           /** The milestone due date. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
@@ -24664,7 +24664,7 @@ export interface operations {
             /** The repository branch used to publish your site's source files. */
             readonly branch: string;
             /** The repository directory that includes the source files for the Pages site. Allowed paths are `/` or `/docs`. Default: `/` */
-            readonly path?: "/" | "/docs";
+            readonly path: "/" | "/docs";
           };
         };
       };
@@ -25849,9 +25849,9 @@ export interface operations {
           /** Text describing the contents of the tag. */
           readonly body?: string;
           /** `true` to create a draft (unpublished) release, `false` to create a published one. */
-          readonly draft?: boolean;
+          readonly draft: boolean;
           /** `true` to identify the release as a prerelease. `false` to identify the release as a full release. */
-          readonly prerelease?: boolean;
+          readonly prerelease: boolean;
         };
       };
     };
@@ -26379,7 +26379,7 @@ export interface operations {
           /** A short description of the status. */
           readonly description?: string;
           /** A string label to differentiate this status from the status of other systems. This field is case-insensitive. */
-          readonly context?: string;
+          readonly context: string;
         };
       };
     };
@@ -26782,9 +26782,9 @@ export interface operations {
           /** A short description of the new repository. */
           readonly description?: string;
           /** Set to `true` to include the directory structure and files from all branches in the template repository, and not just the default branch. Default: `false`. */
-          readonly include_all_branches?: boolean;
+          readonly include_all_branches: boolean;
           /** Either `true` to create a new private repository or `false` to create a new public one. */
-          readonly private?: boolean;
+          readonly private: boolean;
         };
       };
     };
@@ -28047,7 +28047,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          readonly permission?: "pull" | "push" | "admin";
+          readonly permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           readonly parent_team_id?: number | null;
         };
@@ -28112,7 +28112,7 @@ export interface operations {
           /** The discussion post's body text. */
           readonly body: string;
           /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
-          readonly private?: boolean;
+          readonly private: boolean;
         };
       };
     };
@@ -28666,7 +28666,7 @@ export interface operations {
            * \* `member` - a normal member of the team.
            * \* `maintainer` - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
            */
-          readonly role?: "member" | "maintainer";
+          readonly role: "member" | "maintainer";
         };
       };
     };
@@ -30361,33 +30361,33 @@ export interface operations {
           /** A URL with more information about the repository. */
           readonly homepage?: string;
           /** Whether the repository is private or public. */
-          readonly private?: boolean;
+          readonly private: boolean;
           /** Whether issues are enabled. */
-          readonly has_issues?: boolean;
+          readonly has_issues: boolean;
           /** Whether projects are enabled. */
-          readonly has_projects?: boolean;
+          readonly has_projects: boolean;
           /** Whether the wiki is enabled. */
-          readonly has_wiki?: boolean;
+          readonly has_wiki: boolean;
           /** The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization. */
           readonly team_id?: number;
           /** Whether the repository is initialized with a minimal README. */
-          readonly auto_init?: boolean;
+          readonly auto_init: boolean;
           /** The desired language or platform to apply to the .gitignore. */
           readonly gitignore_template?: string;
           /** The license keyword of the open source license for this repository. */
           readonly license_template?: string;
           /** Whether to allow squash merges for pull requests. */
-          readonly allow_squash_merge?: boolean;
+          readonly allow_squash_merge: boolean;
           /** Whether to allow merge commits for pull requests. */
-          readonly allow_merge_commit?: boolean;
+          readonly allow_merge_commit: boolean;
           /** Whether to allow rebase merges for pull requests. */
-          readonly allow_rebase_merge?: boolean;
+          readonly allow_rebase_merge: boolean;
           /** Whether to delete head branches when pull requests are merged */
-          readonly delete_branch_on_merge?: boolean;
+          readonly delete_branch_on_merge: boolean;
           /** Whether downloads are enabled. */
-          readonly has_downloads?: boolean;
+          readonly has_downloads: boolean;
           /** Whether this repository acts as a template that can be used to generate new repositories. */
-          readonly is_template?: boolean;
+          readonly is_template: boolean;
         };
       };
     };

--- a/tests/v3/expected/github.ts
+++ b/tests/v3/expected/github.ts
@@ -5411,7 +5411,7 @@ export interface components {
       default_branch: string;
       open_issues_count: number;
       /** Whether this repository acts as a template that can be used to generate new repositories. */
-      is_template?: boolean;
+      is_template: boolean;
       topics?: string[];
       /** Whether issues are enabled. */
       has_issues: boolean;
@@ -5427,12 +5427,12 @@ export interface components {
       /** Returns whether or not this repository disabled. */
       disabled: boolean;
       /** The repository visibility: public, private, or internal. */
-      visibility?: string;
+      visibility: string;
       pushed_at: string | null;
       created_at: string | null;
       updated_at: string | null;
       /** Whether to allow rebase merges for pull requests. */
-      allow_rebase_merge?: boolean;
+      allow_rebase_merge: boolean;
       template_repository?: {
         id?: number;
         node_id?: string;
@@ -5540,11 +5540,11 @@ export interface components {
       } | null;
       temp_clone_token?: string;
       /** Whether to allow squash merges for pull requests. */
-      allow_squash_merge?: boolean;
+      allow_squash_merge: boolean;
       /** Whether to delete head branches when pull requests are merged */
-      delete_branch_on_merge?: boolean;
+      delete_branch_on_merge: boolean;
       /** Whether to allow merge commits for pull requests. */
-      allow_merge_commit?: boolean;
+      allow_merge_commit: boolean;
       subscribers_count?: number;
       network_count?: number;
       open_issues: number;
@@ -6833,7 +6833,7 @@ export interface components {
       default_branch: string;
       open_issues_count: number;
       /** Whether this repository acts as a template that can be used to generate new repositories. */
-      is_template?: boolean;
+      is_template: boolean;
       topics?: string[];
       /** Whether issues are enabled. */
       has_issues: boolean;
@@ -6849,20 +6849,20 @@ export interface components {
       /** Returns whether or not this repository disabled. */
       disabled: boolean;
       /** The repository visibility: public, private, or internal. */
-      visibility?: string;
+      visibility: string;
       pushed_at: string | null;
       created_at: string | null;
       updated_at: string | null;
       /** Whether to allow rebase merges for pull requests. */
-      allow_rebase_merge?: boolean;
+      allow_rebase_merge: boolean;
       template_repository?: components["schemas"]["repository"] | null;
       temp_clone_token?: string;
       /** Whether to allow squash merges for pull requests. */
-      allow_squash_merge?: boolean;
+      allow_squash_merge: boolean;
       /** Whether to delete head branches when pull requests are merged */
-      delete_branch_on_merge?: boolean;
+      delete_branch_on_merge: boolean;
       /** Whether to allow merge commits for pull requests. */
-      allow_merge_commit?: boolean;
+      allow_merge_commit: boolean;
       subscribers_count?: number;
       network_count?: number;
       open_issues: number;
@@ -7025,7 +7025,7 @@ export interface components {
       open_issues: number;
       watchers: number;
       /** Whether anonymous git access is allowed. */
-      anonymous_access_enabled?: boolean;
+      anonymous_access_enabled: boolean;
       code_of_conduct?: components["schemas"]["code-of-conduct-simple"];
     };
     /** An artifact */
@@ -8259,7 +8259,7 @@ export interface components {
       /** A short description of the status. */
       description: string;
       /** The environment of the deployment that the status is for. */
-      environment?: string;
+      environment: string;
       /** Deprecated: the URL to associate with this status. */
       target_url: string;
       created_at: string;
@@ -8267,9 +8267,9 @@ export interface components {
       deployment_url: string;
       repository_url: string;
       /** The URL for accessing your environment. */
-      environment_url?: string;
+      environment_url: string;
       /** The URL to associate with this status. */
-      log_url?: string;
+      log_url: string;
       performed_via_github_app?: components["schemas"]["integration"] | null;
     };
     /** The amount of time to delay a job after the job is initially triggered. The time (in minutes) must be an integer between 0 and 43,200 (30 days). */
@@ -9059,13 +9059,13 @@ export interface components {
       /** The first line of the range for a multi-line comment. */
       original_start_line?: number | null;
       /** The side of the first line of the range for a multi-line comment. */
-      start_side?: ("LEFT" | "RIGHT") | null;
+      start_side: ("LEFT" | "RIGHT") | null;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       line?: number;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       original_line?: number;
       /** The side of the diff to which the comment applies. The side of the last line of the range for a multi-line comment */
-      side?: "LEFT" | "RIGHT";
+      side: "LEFT" | "RIGHT";
       reactions?: components["schemas"]["reaction-rollup"];
       body_html?: string;
       body_text?: string;
@@ -9135,9 +9135,9 @@ export interface components {
       body_text?: string;
       body_html?: string;
       /** The side of the first line of the range for a multi-line comment. */
-      side?: "LEFT" | "RIGHT";
+      side: "LEFT" | "RIGHT";
       /** The side of the first line of the range for a multi-line comment. */
-      start_side?: ("LEFT" | "RIGHT") | null;
+      start_side: ("LEFT" | "RIGHT") | null;
       /** The line of the blob to which the comment applies. The last line of the range for a multi-line comment */
       line?: number;
       /** The original line of the blob to which the comment applies. The last line of the range for a multi-line comment */
@@ -11500,7 +11500,7 @@ export interface operations {
           /** Name of the runner group. */
           name?: string;
           /** Visibility of a runner group. You can select all organizations or select individual organizations. Can be one of: `all` or `selected` */
-          visibility?: "selected" | "all";
+          visibility: "selected" | "all";
         };
       };
     };
@@ -12670,7 +12670,7 @@ export interface operations {
           /** The Markdown text to render in HTML. */
           text: string;
           /** The rendering mode. */
-          mode?: "markdown" | "gfm";
+          mode: "markdown" | "gfm";
           /** The repository context to use when creating references in `gfm` mode. */
           context?: string;
         };
@@ -13058,7 +13058,7 @@ export interface operations {
       content: {
         "application/json": {
           /** Whether to block all notifications from a thread. */
-          ignored?: boolean;
+          ignored: boolean;
         };
       };
     };
@@ -13201,7 +13201,7 @@ export interface operations {
            * \* `admin` - can pull, push, and administer this repository.
            * \* `none` - no permissions granted by default.
            */
-          default_repository_permission?: "read" | "write" | "admin" | "none";
+          default_repository_permission: "read" | "write" | "admin" | "none";
           /**
            * Toggles the ability of non-admin organization members to create repositories. Can be one of:
            * \* `true` - all organization members can create repositories.
@@ -13209,7 +13209,7 @@ export interface operations {
            * Default: `true`
            * **Note:** A parameter can override this parameter. See `members_allowed_repository_creation_type` in this table for details. **Note:** A parameter can override this parameter. See `members_allowed_repository_creation_type` in this table for details.
            */
-          members_can_create_repositories?: boolean;
+          members_can_create_repositories: boolean;
           /**
            * Toggles whether organization members can create internal repositories, which are visible to all enterprise members. You can only allow members to create internal repositories if your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+. Can be one of:
            * \* `true` - all organization members can create internal repositories.
@@ -13244,19 +13244,19 @@ export interface operations {
            * \* `true` - all organization members can create GitHub Pages sites.
            * \* `false` - no organization members can create GitHub Pages sites. Existing published sites will not be impacted.
            */
-          members_can_create_pages?: boolean;
+          members_can_create_pages: boolean;
           /**
            * Toggles whether organization members can create public GitHub Pages sites. Can be one of:
            * \* `true` - all organization members can create public GitHub Pages sites.
            * \* `false` - no organization members can create public GitHub Pages sites. Existing published sites will not be impacted.
            */
-          members_can_create_public_pages?: boolean;
+          members_can_create_public_pages: boolean;
           /**
            * Toggles whether organization members can create private GitHub Pages sites. Can be one of:
            * \* `true` - all organization members can create private GitHub Pages sites.
            * \* `false` - no organization members can create private GitHub Pages sites. Existing published sites will not be impacted.
            */
-          members_can_create_private_pages?: boolean;
+          members_can_create_private_pages: boolean;
           blog?: string;
         };
       };
@@ -13498,7 +13498,7 @@ export interface operations {
           /** Name of the runner group. */
           name: string;
           /** Visibility of a runner group. You can select all repositories, select individual repositories, or limit access to private repositories. Can be one of: `all`, `selected`, or `private`. */
-          visibility?: "selected" | "all" | "private";
+          visibility: "selected" | "all" | "private";
           /** List of repository IDs that can access the runner group. */
           selected_repository_ids?: number[];
           /** List of runner IDs to add to the runner group. */
@@ -14452,9 +14452,9 @@ export interface operations {
             password?: string;
           };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          events?: string[];
+          events: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          active?: boolean;
+          active: boolean;
         };
       };
     };
@@ -14519,9 +14519,9 @@ export interface operations {
             insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
           };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          events?: string[];
+          events: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          active?: boolean;
+          active: boolean;
           name?: string;
         };
       };
@@ -14747,7 +14747,7 @@ export interface operations {
            * \* `direct_member` - Non-owner organization members with ability to see other members and join teams by invitation.
            * \* `billing_manager` - Non-owner organization members with ability to manage the billing settings of your organization.
            */
-          role?: "admin" | "direct_member" | "billing_manager";
+          role: "admin" | "direct_member" | "billing_manager";
           /** Specify IDs for the teams you want to invite new members to. */
           team_ids?: number[];
         };
@@ -14975,7 +14975,7 @@ export interface operations {
            * \* `admin` - The user will become an owner of the organization.
            * \* `member` - The user will become a non-owner member of the organization.
            */
-          role?: "admin" | "member";
+          role: "admin" | "member";
         };
       };
     };
@@ -15045,9 +15045,9 @@ export interface operations {
           /** A list of arrays indicating which repositories should be migrated. */
           repositories: string[];
           /** Indicates whether repositories should be locked (to prevent manipulation) while migrating data. */
-          lock_repositories?: boolean;
+          lock_repositories: boolean;
           /** Indicates whether attachments should be excluded from the migration (to reduce migration archive file size). */
-          exclude_attachments?: boolean;
+          exclude_attachments: boolean;
           exclude?: string[];
         };
       };
@@ -15619,36 +15619,36 @@ export interface operations {
           /** A URL with more information about the repository. */
           homepage?: string;
           /** Either `true` to create a private repository or `false` to create a public one. */
-          private?: boolean;
+          private: boolean;
           /**
            * Can be `public` or `private`. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, `visibility` can also be `internal`. For more information, see "[Creating an internal repository](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-repository-visibility#about-internal-repositories)" in the GitHub Help documentation.
            * The `visibility` parameter overrides the `private` parameter when you use both parameters with the `nebula-preview` preview header.
            */
           visibility?: "public" | "private" | "visibility" | "internal";
           /** Either `true` to enable issues for this repository or `false` to disable them. */
-          has_issues?: boolean;
+          has_issues: boolean;
           /** Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error. */
-          has_projects?: boolean;
+          has_projects: boolean;
           /** Either `true` to enable the wiki for this repository or `false` to disable it. */
-          has_wiki?: boolean;
+          has_wiki: boolean;
           /** Either `true` to make this repo available as a template repository or `false` to prevent it. */
-          is_template?: boolean;
+          is_template: boolean;
           /** The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization. */
           team_id?: number;
           /** Pass `true` to create an initial commit with empty README. */
-          auto_init?: boolean;
+          auto_init: boolean;
           /** Desired language or platform [.gitignore template](https://github.com/github/gitignore) to apply. Use the name of the template without the extension. For example, "Haskell". */
           gitignore_template?: string;
           /** Choose an [open source license template](https://choosealicense.com/) that best suits your needs, and then use the [license keyword](https://help.github.com/articles/licensing-a-repository/#searching-github-by-license-type) as the `license_template` string. For example, "mit" or "mpl-2.0". */
           license_template?: string;
           /** Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging. */
-          allow_squash_merge?: boolean;
+          allow_squash_merge: boolean;
           /** Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits. */
-          allow_merge_commit?: boolean;
+          allow_merge_commit: boolean;
           /** Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging. */
-          allow_rebase_merge?: boolean;
+          allow_rebase_merge: boolean;
           /** Either `true` to allow automatically deleting head branches when pull requests are merged, or `false` to prevent automatic deletion. */
-          delete_branch_on_merge?: boolean;
+          delete_branch_on_merge: boolean;
         };
       };
     };
@@ -15823,7 +15823,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          permission?: "pull" | "push" | "admin";
+          permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number;
         };
@@ -15916,7 +15916,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          permission?: "pull" | "push" | "admin";
+          permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number | null;
         };
@@ -15985,7 +15985,7 @@ export interface operations {
           /** The discussion post's body text. */
           body: string;
           /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
-          private?: boolean;
+          private: boolean;
         };
       };
     };
@@ -16522,7 +16522,7 @@ export interface operations {
            * \* `member` - a normal member of the team.
            * \* `maintainer` - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
            */
-          role?: "member" | "maintainer";
+          role: "member" | "maintainer";
         };
       };
     };
@@ -17343,7 +17343,7 @@ export interface operations {
       content: {
         "application/json": {
           /** The permission to grant the collaborator. */
-          permission?: "read" | "write" | "admin";
+          permission: "read" | "write" | "admin";
         };
       };
     };
@@ -17566,29 +17566,29 @@ export interface operations {
            * Either `true` to make the repository private or `false` to make it public. Default: `false`.
            * **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private. **Note**: You will get a `422` error if the organization restricts [changing repository visibility](https://help.github.com/articles/repository-permission-levels-for-an-organization#changing-the-visibility-of-repositories) to organization owners and a non-owner tries to change the value of private.
            */
-          private?: boolean;
+          private: boolean;
           /** Can be `public` or `private`. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, `visibility` can also be `internal`. The `visibility` parameter overrides the `private` parameter when you use both along with the `nebula-preview` preview header. */
           visibility?: "public" | "private" | "visibility" | "internal";
           /** Either `true` to enable issues for this repository or `false` to disable them. */
-          has_issues?: boolean;
+          has_issues: boolean;
           /** Either `true` to enable projects for this repository or `false` to disable them. **Note:** If you're creating a repository in an organization that has disabled repository projects, the default is `false`, and if you pass `true`, the API returns an error. */
-          has_projects?: boolean;
+          has_projects: boolean;
           /** Either `true` to enable the wiki for this repository or `false` to disable it. */
-          has_wiki?: boolean;
+          has_wiki: boolean;
           /** Either `true` to make this repo available as a template repository or `false` to prevent it. */
-          is_template?: boolean;
+          is_template: boolean;
           /** Updates the default branch for this repository. */
           default_branch?: string;
           /** Either `true` to allow squash-merging pull requests, or `false` to prevent squash-merging. */
-          allow_squash_merge?: boolean;
+          allow_squash_merge: boolean;
           /** Either `true` to allow merging pull requests with a merge commit, or `false` to prevent merging pull requests with merge commits. */
-          allow_merge_commit?: boolean;
+          allow_merge_commit: boolean;
           /** Either `true` to allow rebase-merging pull requests, or `false` to prevent rebase-merging. */
-          allow_rebase_merge?: boolean;
+          allow_rebase_merge: boolean;
           /** Either `true` to allow automatically deleting head branches when pull requests are merged, or `false` to prevent automatic deletion. */
-          delete_branch_on_merge?: boolean;
+          delete_branch_on_merge: boolean;
           /** `true` to archive this repository. **Note**: You cannot unarchive repositories through the API. */
-          archived?: boolean;
+          archived: boolean;
         };
       };
     };
@@ -19780,7 +19780,7 @@ export interface operations {
           /** A reference for the run on the integrator's system. */
           external_id?: string;
           /** The current status. Can be one of `queued`, `in_progress`, or `completed`. */
-          status?: "queued" | "in_progress" | "completed";
+          status: "queued" | "in_progress" | "completed";
           /** The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
           started_at?: string;
           /**
@@ -20648,7 +20648,7 @@ export interface operations {
            * \* `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
            * \* `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
            */
-          permission?: "pull" | "push" | "admin" | "maintain" | "triage";
+          permission: "pull" | "push" | "admin" | "maintain" | "triage";
           permissions?: string;
         };
       };
@@ -21688,21 +21688,21 @@ export interface operations {
           /** The ref to deploy. This can be a branch, tag, or SHA. */
           ref: string;
           /** Specifies a task to execute (e.g., `deploy` or `deploy:migrations`). */
-          task?: string;
+          task: string;
           /** Attempts to automatically merge the default branch into the requested ref, if it's behind the default branch. */
-          auto_merge?: boolean;
+          auto_merge: boolean;
           /** The [status](https://docs.github.com/rest/reference/repos#statuses) contexts to verify against commit status checks. If you omit this parameter, GitHub verifies all unique contexts before creating a deployment. To bypass checking entirely, pass an empty array. Defaults to all unique contexts. */
           required_contexts?: string[];
           payload?: { [key: string]: any } | string;
           /** Name for the target deployment environment (e.g., `production`, `staging`, `qa`). */
-          environment?: string;
+          environment: string;
           /** Short description of the deployment. */
-          description?: string | null;
+          description: string | null;
           /**
            * Specifies if the given environment is specific to the deployment and will no longer exist at some point in the future. Default: `false`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          transient_environment?: boolean;
+          transient_environment: boolean;
           /**
            * Specifies if the given environment is one that end-users directly interact with. Default: `true` when `environment` is `production` and `false` otherwise.
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
@@ -21817,21 +21817,21 @@ export interface operations {
           /** The state of the status. Can be one of `error`, `failure`, `inactive`, `in_progress`, `queued` `pending`, or `success`. **Note:** To use the `inactive` state, you must provide the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. To use the `in_progress` and `queued` states, you must provide the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type. When you set a transient deployment to `inactive`, the deployment will be shown as `destroyed` in GitHub. */
           state: "error" | "failure" | "inactive" | "in_progress" | "queued" | "pending" | "success";
           /** The target URL to associate with this status. This URL should contain output to keep the user updated while the task is running or serve as historical information for what happened in the deployment. **Note:** It's recommended to use the `log_url` parameter, which replaces `target_url`. */
-          target_url?: string;
+          target_url: string;
           /**
            * The full URL of the deployment's output. This parameter replaces `target_url`. We will continue to accept `target_url` to support legacy uses, but we recommend replacing `target_url` with `log_url`. Setting `log_url` will automatically set `target_url` to the same value. Default: `""`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          log_url?: string;
+          log_url: string;
           /** A short description of the status. The maximum description length is 140 characters. */
-          description?: string;
+          description: string;
           /** Name for the target deployment environment, which can be changed when setting a deploy status. For example, `production`, `staging`, or `qa`. **Note:** This parameter requires you to use the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type. */
           environment?: "production" | "staging" | "qa";
           /**
            * Sets the URL for accessing your environment. Default: `""`
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type. **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
-          environment_url?: string;
+          environment_url: string;
           /**
            * Adds a new `inactive` status to all prior non-transient, non-production environment deployments with the same repository and `environment` name as the created status's deployment. An `inactive` status is only added to deployments that had a `success` state. Default: `true`
            * **Note:** To add an `inactive` status to `production` environments, you must use the [`application/vnd.github.flash-preview+json`](https://docs.github.com/rest/overview/api-previews#deployment-statuses) custom media type.
@@ -22114,7 +22114,7 @@ export interface operations {
           /** The new blob's content. */
           content: string;
           /** The encoding used for `content`. Currently, `"utf-8"` and `"base64"` are supported. */
-          encoding?: string;
+          encoding: string;
         };
       };
     };
@@ -22409,7 +22409,7 @@ export interface operations {
           /** The SHA1 value to set this reference to */
           sha: string;
           /** Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to `false` will make sure you're not overwriting work. */
-          force?: boolean;
+          force: boolean;
         };
       };
     };
@@ -22688,9 +22688,9 @@ export interface operations {
             digest?: string;
           };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
-          events?: string[];
+          events: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          active?: boolean;
+          active: boolean;
         };
       };
     };
@@ -22760,13 +22760,13 @@ export interface operations {
             room?: string;
           };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events. */
-          events?: string[];
+          events: string[];
           /** Determines a list of events to be added to the list of events that the Hook triggers for. */
           add_events?: string[];
           /** Determines a list of events to be removed from the list of events that the Hook triggers for. */
           remove_events?: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
-          active?: boolean;
+          active: boolean;
         };
       };
     };
@@ -24431,7 +24431,7 @@ export interface operations {
           /** The title of the milestone. */
           title: string;
           /** The state of the milestone. Either `open` or `closed`. */
-          state?: "open" | "closed";
+          state: "open" | "closed";
           /** A description of the milestone. */
           description?: string;
           /** The milestone due date. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
@@ -24497,7 +24497,7 @@ export interface operations {
           /** The title of the milestone. */
           title?: string;
           /** The state of the milestone. Either `open` or `closed`. */
-          state?: "open" | "closed";
+          state: "open" | "closed";
           /** A description of the milestone. */
           description?: string;
           /** The milestone due date. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
@@ -24660,7 +24660,7 @@ export interface operations {
             /** The repository branch used to publish your site's source files. */
             branch: string;
             /** The repository directory that includes the source files for the Pages site. Allowed paths are `/` or `/docs`. Default: `/` */
-            path?: "/" | "/docs";
+            path: "/" | "/docs";
           };
         };
       };
@@ -25844,9 +25844,9 @@ export interface operations {
           /** Text describing the contents of the tag. */
           body?: string;
           /** `true` to create a draft (unpublished) release, `false` to create a published one. */
-          draft?: boolean;
+          draft: boolean;
           /** `true` to identify the release as a prerelease. `false` to identify the release as a full release. */
-          prerelease?: boolean;
+          prerelease: boolean;
         };
       };
     };
@@ -26374,7 +26374,7 @@ export interface operations {
           /** A short description of the status. */
           description?: string;
           /** A string label to differentiate this status from the status of other systems. This field is case-insensitive. */
-          context?: string;
+          context: string;
         };
       };
     };
@@ -26777,9 +26777,9 @@ export interface operations {
           /** A short description of the new repository. */
           description?: string;
           /** Set to `true` to include the directory structure and files from all branches in the template repository, and not just the default branch. Default: `false`. */
-          include_all_branches?: boolean;
+          include_all_branches: boolean;
           /** Either `true` to create a new private repository or `false` to create a new public one. */
-          private?: boolean;
+          private: boolean;
         };
       };
     };
@@ -28042,7 +28042,7 @@ export interface operations {
            * \* `push` - team members can pull and push, but not administer newly-added repositories.
            * \* `admin` - team members can pull, push and administer newly-added repositories.
            */
-          permission?: "pull" | "push" | "admin";
+          permission: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number | null;
         };
@@ -28107,7 +28107,7 @@ export interface operations {
           /** The discussion post's body text. */
           body: string;
           /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
-          private?: boolean;
+          private: boolean;
         };
       };
     };
@@ -28661,7 +28661,7 @@ export interface operations {
            * \* `member` - a normal member of the team.
            * \* `maintainer` - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
            */
-          role?: "member" | "maintainer";
+          role: "member" | "maintainer";
         };
       };
     };
@@ -30356,33 +30356,33 @@ export interface operations {
           /** A URL with more information about the repository. */
           homepage?: string;
           /** Whether the repository is private or public. */
-          private?: boolean;
+          private: boolean;
           /** Whether issues are enabled. */
-          has_issues?: boolean;
+          has_issues: boolean;
           /** Whether projects are enabled. */
-          has_projects?: boolean;
+          has_projects: boolean;
           /** Whether the wiki is enabled. */
-          has_wiki?: boolean;
+          has_wiki: boolean;
           /** The id of the team that will be granted access to this repository. This is only valid when creating a repository in an organization. */
           team_id?: number;
           /** Whether the repository is initialized with a minimal README. */
-          auto_init?: boolean;
+          auto_init: boolean;
           /** The desired language or platform to apply to the .gitignore. */
           gitignore_template?: string;
           /** The license keyword of the open source license for this repository. */
           license_template?: string;
           /** Whether to allow squash merges for pull requests. */
-          allow_squash_merge?: boolean;
+          allow_squash_merge: boolean;
           /** Whether to allow merge commits for pull requests. */
-          allow_merge_commit?: boolean;
+          allow_merge_commit: boolean;
           /** Whether to allow rebase merges for pull requests. */
-          allow_rebase_merge?: boolean;
+          allow_rebase_merge: boolean;
           /** Whether to delete head branches when pull requests are merged */
-          delete_branch_on_merge?: boolean;
+          delete_branch_on_merge: boolean;
           /** Whether downloads are enabled. */
-          has_downloads?: boolean;
+          has_downloads: boolean;
           /** Whether this repository acts as a template that can be used to generate new repositories. */
-          is_template?: boolean;
+          is_template: boolean;
         };
       };
     };

--- a/tests/v3/expected/http.ts
+++ b/tests/v3/expected/http.ts
@@ -761,7 +761,7 @@ export interface components {
           access_code?: boolean | null;
           sso?: boolean | null;
           plan_change?: boolean | null;
-          credential?: ("none" | "single" | "multiple" | "unknown") | null;
+          credential: ("none" | "single" | "multiple" | "unknown") | null;
         };
       } | null;
       /** An array of platform ids to restrict this product for. */
@@ -801,24 +801,24 @@ export interface components {
       name: components["schemas"]["Name"];
       type: "boolean" | "string" | "number";
       /** This sets whether or not the feature can be customized by a consumer. */
-      customizable?: boolean;
+      customizable: boolean;
       /**
        * This sets whether or not the feature can be upgraded by the consumer after the
        * resource has provisioned. Upgrading means setting a higher value or selecting a
        * higher element in the list.
        */
-      upgradable?: boolean;
+      upgradable: boolean;
       /**
        * This sets whether or not the feature can be downgraded by the consumer after the
        * resource has provisioned. Downgrading means setting a lower value or selecting a
        * lower element in the list.
        */
-      downgradable?: boolean;
+      downgradable: boolean;
       /**
        * Sets if this feature’s value is trackable from the provider,
        * this only really affects numeric constraints.
        */
-      measurable?: boolean;
+      measurable: boolean;
       values?: components["schemas"]["FeatureValuesList"];
     };
     /**
@@ -922,7 +922,7 @@ export interface components {
        * When true, everyone can see the product when requested. When false it will
        * not be visible to anyone except those on the provider team.
        */
-      public?: boolean;
+      public: boolean;
       /**
        * When true, the product will be displayed in product listings alongside
        * other products. When false the product will be excluded from listings,
@@ -930,7 +930,7 @@ export interface components {
        * Any pages that display information about the product when not listed,
        * should indicate to webcrawlers that the content should not be indexed.
        */
-      listed?: boolean;
+      listed: boolean;
       /**
        * Object to hold various flags for marketing purposes only. These are values
        * that need to be stored, but should not affect decision making in code. If
@@ -943,19 +943,19 @@ export interface components {
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        beta?: boolean;
+        beta: boolean;
         /**
          * Indicates whether or not the product is in `New` and should be
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        new?: boolean;
+        new: boolean;
         /**
          * Indicates whether or not the product is in `New` and should be
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        featured?: boolean;
+        featured: boolean;
       };
     };
     /**
@@ -996,7 +996,7 @@ export interface components {
        * * `multiple`: Multiple credentials are supported at the same time.
        * * `unknown`: The credential type is unknown.
        */
-      credential?: "none" | "single" | "multiple" | "unknown";
+      credential: "none" | "single" | "multiple" | "unknown";
     };
     ProductBody: {
       provider_id: components["schemas"]["ID"];

--- a/tests/v3/expected/manifold.additional.ts
+++ b/tests/v3/expected/manifold.additional.ts
@@ -762,7 +762,7 @@ export interface components {
               access_code?: boolean | null;
               sso?: boolean | null;
               plan_change?: boolean | null;
-              credential?: ("none" | "single" | "multiple" | "unknown") | null;
+              credential: ("none" | "single" | "multiple" | "unknown") | null;
             } & { [key: string]: any };
           } & { [key: string]: any })
         | null;
@@ -803,24 +803,24 @@ export interface components {
       name: components["schemas"]["Name"];
       type: "boolean" | "string" | "number";
       /** This sets whether or not the feature can be customized by a consumer. */
-      customizable?: boolean;
+      customizable: boolean;
       /**
        * This sets whether or not the feature can be upgraded by the consumer after the
        * resource has provisioned. Upgrading means setting a higher value or selecting a
        * higher element in the list.
        */
-      upgradable?: boolean;
+      upgradable: boolean;
       /**
        * This sets whether or not the feature can be downgraded by the consumer after the
        * resource has provisioned. Downgrading means setting a lower value or selecting a
        * lower element in the list.
        */
-      downgradable?: boolean;
+      downgradable: boolean;
       /**
        * Sets if this feature’s value is trackable from the provider,
        * this only really affects numeric constraints.
        */
-      measurable?: boolean;
+      measurable: boolean;
       values?: components["schemas"]["FeatureValuesList"];
     } & { [key: string]: any };
     /**
@@ -926,7 +926,7 @@ export interface components {
        * When true, everyone can see the product when requested. When false it will
        * not be visible to anyone except those on the provider team.
        */
-      public?: boolean;
+      public: boolean;
       /**
        * When true, the product will be displayed in product listings alongside
        * other products. When false the product will be excluded from listings,
@@ -934,7 +934,7 @@ export interface components {
        * Any pages that display information about the product when not listed,
        * should indicate to webcrawlers that the content should not be indexed.
        */
-      listed?: boolean;
+      listed: boolean;
       /**
        * Object to hold various flags for marketing purposes only. These are values
        * that need to be stored, but should not affect decision making in code. If
@@ -947,19 +947,19 @@ export interface components {
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        beta?: boolean;
+        beta: boolean;
         /**
          * Indicates whether or not the product is in `New` and should be
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        new?: boolean;
+        new: boolean;
         /**
          * Indicates whether or not the product is in `New` and should be
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        featured?: boolean;
+        featured: boolean;
       } & { [key: string]: any };
     } & { [key: string]: any };
     /**
@@ -1000,7 +1000,7 @@ export interface components {
        * * `multiple`: Multiple credentials are supported at the same time.
        * * `unknown`: The credential type is unknown.
        */
-      credential?: "none" | "single" | "multiple" | "unknown";
+      credential: "none" | "single" | "multiple" | "unknown";
     } & { [key: string]: any };
     ProductBody: {
       provider_id: components["schemas"]["ID"];

--- a/tests/v3/expected/manifold.immutable.ts
+++ b/tests/v3/expected/manifold.immutable.ts
@@ -761,7 +761,7 @@ export interface components {
           readonly access_code?: boolean | null;
           readonly sso?: boolean | null;
           readonly plan_change?: boolean | null;
-          readonly credential?: ("none" | "single" | "multiple" | "unknown") | null;
+          readonly credential: ("none" | "single" | "multiple" | "unknown") | null;
         };
       } | null;
       /** An array of platform ids to restrict this product for. */
@@ -801,24 +801,24 @@ export interface components {
       readonly name: components["schemas"]["Name"];
       readonly type: "boolean" | "string" | "number";
       /** This sets whether or not the feature can be customized by a consumer. */
-      readonly customizable?: boolean;
+      readonly customizable: boolean;
       /**
        * This sets whether or not the feature can be upgraded by the consumer after the
        * resource has provisioned. Upgrading means setting a higher value or selecting a
        * higher element in the list.
        */
-      readonly upgradable?: boolean;
+      readonly upgradable: boolean;
       /**
        * This sets whether or not the feature can be downgraded by the consumer after the
        * resource has provisioned. Downgrading means setting a lower value or selecting a
        * lower element in the list.
        */
-      readonly downgradable?: boolean;
+      readonly downgradable: boolean;
       /**
        * Sets if this feature’s value is trackable from the provider,
        * this only really affects numeric constraints.
        */
-      readonly measurable?: boolean;
+      readonly measurable: boolean;
       readonly values?: components["schemas"]["FeatureValuesList"];
     };
     /**
@@ -922,7 +922,7 @@ export interface components {
        * When true, everyone can see the product when requested. When false it will
        * not be visible to anyone except those on the provider team.
        */
-      readonly public?: boolean;
+      readonly public: boolean;
       /**
        * When true, the product will be displayed in product listings alongside
        * other products. When false the product will be excluded from listings,
@@ -930,7 +930,7 @@ export interface components {
        * Any pages that display information about the product when not listed,
        * should indicate to webcrawlers that the content should not be indexed.
        */
-      readonly listed?: boolean;
+      readonly listed: boolean;
       /**
        * Object to hold various flags for marketing purposes only. These are values
        * that need to be stored, but should not affect decision making in code. If
@@ -943,19 +943,19 @@ export interface components {
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        readonly beta?: boolean;
+        readonly beta: boolean;
         /**
          * Indicates whether or not the product is in `New` and should be
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        readonly new?: boolean;
+        readonly new: boolean;
         /**
          * Indicates whether or not the product is in `New` and should be
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        readonly featured?: boolean;
+        readonly featured: boolean;
       };
     };
     /**
@@ -996,7 +996,7 @@ export interface components {
        * * `multiple`: Multiple credentials are supported at the same time.
        * * `unknown`: The credential type is unknown.
        */
-      readonly credential?: "none" | "single" | "multiple" | "unknown";
+      readonly credential: "none" | "single" | "multiple" | "unknown";
     };
     readonly ProductBody: {
       readonly provider_id: components["schemas"]["ID"];

--- a/tests/v3/expected/manifold.ts
+++ b/tests/v3/expected/manifold.ts
@@ -761,7 +761,7 @@ export interface components {
           access_code?: boolean | null;
           sso?: boolean | null;
           plan_change?: boolean | null;
-          credential?: ("none" | "single" | "multiple" | "unknown") | null;
+          credential: ("none" | "single" | "multiple" | "unknown") | null;
         };
       } | null;
       /** An array of platform ids to restrict this product for. */
@@ -801,24 +801,24 @@ export interface components {
       name: components["schemas"]["Name"];
       type: "boolean" | "string" | "number";
       /** This sets whether or not the feature can be customized by a consumer. */
-      customizable?: boolean;
+      customizable: boolean;
       /**
        * This sets whether or not the feature can be upgraded by the consumer after the
        * resource has provisioned. Upgrading means setting a higher value or selecting a
        * higher element in the list.
        */
-      upgradable?: boolean;
+      upgradable: boolean;
       /**
        * This sets whether or not the feature can be downgraded by the consumer after the
        * resource has provisioned. Downgrading means setting a lower value or selecting a
        * lower element in the list.
        */
-      downgradable?: boolean;
+      downgradable: boolean;
       /**
        * Sets if this feature’s value is trackable from the provider,
        * this only really affects numeric constraints.
        */
-      measurable?: boolean;
+      measurable: boolean;
       values?: components["schemas"]["FeatureValuesList"];
     };
     /**
@@ -922,7 +922,7 @@ export interface components {
        * When true, everyone can see the product when requested. When false it will
        * not be visible to anyone except those on the provider team.
        */
-      public?: boolean;
+      public: boolean;
       /**
        * When true, the product will be displayed in product listings alongside
        * other products. When false the product will be excluded from listings,
@@ -930,7 +930,7 @@ export interface components {
        * Any pages that display information about the product when not listed,
        * should indicate to webcrawlers that the content should not be indexed.
        */
-      listed?: boolean;
+      listed: boolean;
       /**
        * Object to hold various flags for marketing purposes only. These are values
        * that need to be stored, but should not affect decision making in code. If
@@ -943,19 +943,19 @@ export interface components {
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        beta?: boolean;
+        beta: boolean;
         /**
          * Indicates whether or not the product is in `New` and should be
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        new?: boolean;
+        new: boolean;
         /**
          * Indicates whether or not the product is in `New` and should be
          * advertised as such. This does not have any impact on who can access the
          * product, it is just used to inform consumers through our clients.
          */
-        featured?: boolean;
+        featured: boolean;
       };
     };
     /**
@@ -996,7 +996,7 @@ export interface components {
        * * `multiple`: Multiple credentials are supported at the same time.
        * * `unknown`: The credential type is unknown.
        */
-      credential?: "none" | "single" | "multiple" | "unknown";
+      credential: "none" | "single" | "multiple" | "unknown";
     };
     ProductBody: {
       provider_id: components["schemas"]["ID"];

--- a/tests/v3/expected/petstore-openapitools.additional.ts
+++ b/tests/v3/expected/petstore-openapitools.additional.ts
@@ -73,7 +73,7 @@ export interface components {
       shipDate?: string;
       /** Order Status */
       status?: "placed" | "approved" | "delivered";
-      complete?: boolean;
+      complete: boolean;
     } & { [key: string]: any };
     /** A category for a pet */
     Category: {

--- a/tests/v3/expected/petstore-openapitools.immutable.ts
+++ b/tests/v3/expected/petstore-openapitools.immutable.ts
@@ -73,7 +73,7 @@ export interface components {
       readonly shipDate?: string;
       /** Order Status */
       readonly status?: "placed" | "approved" | "delivered";
-      readonly complete?: boolean;
+      readonly complete: boolean;
     };
     /** A category for a pet */
     readonly Category: {

--- a/tests/v3/expected/petstore-openapitools.ts
+++ b/tests/v3/expected/petstore-openapitools.ts
@@ -73,7 +73,7 @@ export interface components {
       shipDate?: string;
       /** Order Status */
       status?: "placed" | "approved" | "delivered";
-      complete?: boolean;
+      complete: boolean;
     };
     /** A category for a pet */
     Category: {

--- a/tests/v3/expected/petstore.additional.ts
+++ b/tests/v3/expected/petstore.additional.ts
@@ -72,7 +72,7 @@ export interface components {
       shipDate?: string;
       /** Order Status */
       status?: "placed" | "approved" | "delivered";
-      complete?: boolean;
+      complete: boolean;
     } & { [key: string]: any };
     Category: {
       id?: number;

--- a/tests/v3/expected/petstore.immutable.ts
+++ b/tests/v3/expected/petstore.immutable.ts
@@ -72,7 +72,7 @@ export interface components {
       readonly shipDate?: string;
       /** Order Status */
       readonly status?: "placed" | "approved" | "delivered";
-      readonly complete?: boolean;
+      readonly complete: boolean;
     };
     readonly Category: {
       readonly id?: number;

--- a/tests/v3/expected/petstore.ts
+++ b/tests/v3/expected/petstore.ts
@@ -72,7 +72,7 @@ export interface components {
       shipDate?: string;
       /** Order Status */
       status?: "placed" | "approved" | "delivered";
-      complete?: boolean;
+      complete: boolean;
     };
     Category: {
       id?: number;


### PR DESCRIPTION
Partially fixes #584.

This is a very good fix pointed out by @rustyconover, and handled in PR #584, but that currently would be blocking remote schemas, as `$ref`s would no-longer be resolvable (or at least, not easily). This PR does half of #584, where `$ref`s are not resolved. But it does improve the handling of `default: ` without blocking remote schemas.