### PR TITLE
Add docs for glob feature to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .cache
 .DS_Store
-**/generated/*.ts
+**/generated/
 coverage
 dist
 node_modules

--- a/README.md
+++ b/README.md
@@ -28,20 +28,34 @@ View examples:
 ```bash
 npx openapi-typescript schema.yaml --output schema.ts
 
-# 🤞 Loading spec from tests/v2/specs/stripe.yaml…
+# 🔭 Loading spec from schema.yaml…
 # 🚀 schema.yaml -> schema.ts [250ms]
+
+npx openapi-typescript "specs/**/*.yaml" --output schemas/
+# 🔭 Loading spec from specs/one.yaml…
+# 🔭 Loading spec from specs/two.yaml…
+# 🔭 Loading spec from specs/three.yaml…
+# 🚀 specs/one.yaml -> schemas/one.ts [250ms]
+# 🚀 specs/two.yaml -> schemas/two.ts [250ms]
+# 🚀 specs/three.yaml -> schemas/three.ts [250ms]
 ```
+
+_Note: if generating a single schema, `--output` must be a file (preferably `*.ts`). If using globs, `--output` must be a directory._
+
+_Thanks to [@sharmarajdaksh](https://github.com/sharmarajdaksh) for the glob feature!_
 
 #### ☁️ Reading specs from remote resource
 
 ```bash
 npx openapi-typescript https://petstore.swagger.io/v2/swagger.json --output petstore.ts
 
-# 🤞 Loading spec from https://petstore.swagger.io/v2/swagger.json…
+# 🔭 Loading spec from https://petstore.swagger.io/v2/swagger.json…
 # 🚀 https://petstore.swagger.io/v2/swagger.json -> petstore.ts [650ms]
 ```
 
-_Thanks to @psmyrdek for the remote spec feature!_
+_Note: for obvious reasons, globbing doesn’t work for remote schemas_
+
+_Thanks to [@psmyrdek](https://github.com/psmyrdek) for the remote spec feature!_
 
 #### Using in TypeScript
 
@@ -72,37 +86,6 @@ _Thanks to @gr2m for the operations feature!_
 ```bash
 npx openapi-typescript schema.yaml
 ```
-
-#### Generating multiple schemas
-
-In your `package.json`, for each schema you’d like to transform add one `generate:specs:[name]` npm-script. Then combine
-them all into one `generate:specs` script, like so:
-
-```json
-"scripts": {
-  "generate:specs": "npm run generate:specs:one && npm run generate:specs:two && npm run generate:specs:three",
-  "generate:specs:one": "npx openapi-typescript one.yaml -o one.ts",
-  "generate:specs:two": "npx openapi-typescript two.yaml -o two.ts",
-  "generate:specs:three": "npx openapi-typescript three.yaml -o three.ts"
-}
-```
-
-If you use [npm-run-all][npm-run-all], you can shorten this:
-
-```json
-"scripts": {
-  "generate:specs": "run-p generate:specs:*",
-```
-
-You can even specify unique options per-spec, if needed. To generate them all together, run:
-
-```bash
-npm run generate:specs
-```
-
-Rinse and repeat for more specs.
-
-For anything more complicated, or for generating specs dynamically, you can also use the [Node API](#node).
 
 #### CLI Options
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ npx openapi-typescript "specs/**/*.yaml" --output schemas/
 # 🔭 Loading spec from specs/one.yaml…
 # 🔭 Loading spec from specs/two.yaml…
 # 🔭 Loading spec from specs/three.yaml…
-# 🚀 specs/one.yaml -> schemas/one.ts [250ms]
-# 🚀 specs/two.yaml -> schemas/two.ts [250ms]
-# 🚀 specs/three.yaml -> schemas/three.ts [250ms]
+# 🚀 specs/one.yaml -> schemas/specs/one.ts [250ms]
+# 🚀 specs/two.yaml -> schemas/specs/two.ts [250ms]
+# 🚀 specs/three.yaml -> schemas/specs/three.ts [250ms]
 ```
 
 _Note: if generating a single schema, `--output` must be a file (preferably `*.ts`). If using globs, `--output` must be a directory._

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -102,7 +102,7 @@ async function generateSchema(pathToSpec) {
       outputFile = path.resolve(outputFile, basename);
     }
 
-    fs.writeFileSync(outputFile, result, "utf8");
+    await fs.promises.writeFile(outputFile, result, "utf8");
 
     const timeEnd = process.hrtime(timeStart);
     const time = timeEnd[0] + Math.round(timeEnd[1] / 1e6);
@@ -143,17 +143,12 @@ async function main() {
   }
 
   // error: tried to glob output to single file
-  if (
-    isGlob &&
-    output === OUTPUT_FILE &&
-    fs.existsSync(cli.flags.output) &&
-    (await fs.promises.stat(cli.flags.output)).isFile()
-  ) {
+  if (isGlob && output === OUTPUT_FILE && fs.existsSync(cli.flags.output) && fs.lstatSync(cli.flags.output).isFile()) {
     errorAndExit(`❌ Expected directory for --output if using glob patterns. Received "${cli.flags.output}".`);
   }
 
   // recursively create directories
-  if (output === OUTPUT_FILE) {
+  if (output === OUTPUT_FILE && output !== ".") {
     const parentDir = isGlob ? cli.flags.output : path.dirname(cli.flags.output); // if globbing, create output as directory; if file, create parent dir
     await fs.promises.mkdir(parentDir, { recursive: true });
   }

--- a/tests/bin/cli.test.ts
+++ b/tests/bin/cli.test.ts
@@ -6,39 +6,45 @@ import { execSync } from "child_process";
 // v3/index.test.ts. So this file is mainly for testing other flags.
 
 describe("cli", () => {
-  it("--prettier-config (JSON)", () => {
-    const expected = fs.readFileSync(path.join(__dirname, "expected", "prettier-json.ts"), "utf8");
+  it("--prettier-config (JSON)", async () => {
     execSync(
       `../../bin/cli.js specs/petstore.yaml -o generated/prettier-json.ts --prettier-config fixtures/.prettierrc`,
       { cwd: __dirname }
     );
-    const output = fs.readFileSync(path.join(__dirname, "generated", "prettier-json.ts"), "utf8");
-    expect(output).toBe(expected);
+    const [generated, expected] = await Promise.all([
+      fs.promises.readFile(path.join(__dirname, "generated", "prettier-json.ts"), "utf8"),
+      fs.promises.readFile(path.join(__dirname, "expected", "prettier-json.ts"), "utf8"),
+    ]);
+    expect(generated).toBe(expected);
   });
 
-  it("--prettier-config (.js)", () => {
-    const expected = fs.readFileSync(path.join(__dirname, "expected", "prettier-js.ts"), "utf8");
+  it("--prettier-config (.js)", async () => {
     execSync(
       `../../bin/cli.js specs/petstore.yaml -o generated/prettier-js.ts --prettier-config fixtures/prettier.config.js`,
       { cwd: __dirname }
     );
-    const output = fs.readFileSync(path.join(__dirname, "generated", "prettier-js.ts"), "utf8");
-    expect(output).toBe(expected);
+    const [generated, expected] = await Promise.all([
+      fs.promises.readFile(path.join(__dirname, "generated", "prettier-js.ts"), "utf8"),
+      fs.promises.readFile(path.join(__dirname, "expected", "prettier-js.ts"), "utf8"),
+    ]);
+    expect(generated).toBe(expected);
   });
 
-  it("stdout", () => {
+  it("stdout", async () => {
     const expected = fs.readFileSync(path.join(__dirname, "expected", "stdout.ts"), "utf8");
-    const result = execSync(`../../bin/cli.js specs/petstore.yaml`, { cwd: __dirname });
-    expect(result.toString("utf8")).toBe(expected);
+    const generated = execSync(`../../bin/cli.js specs/petstore.yaml`, { cwd: __dirname });
+    expect(generated.toString("utf8")).toBe(expected);
   });
 
-  it("supports glob paths", () => {
-    const expectedPetstore = fs.readFileSync(path.join(__dirname, "expected", "petstore.ts"), "utf8");
-    const expectedManifold = fs.readFileSync(path.join(__dirname, "expected", "manifold.ts"), "utf8");
+  it("supports glob paths", async () => {
     execSync(`../../bin/cli.js \"specs/*.yaml\" -o generated/`, { cwd: __dirname }); // Quotes are necessary because shells like zsh treats glob weirdly
-    const outputPetstore = fs.readFileSync(path.join(__dirname, "generated", "petstore.ts"), "utf8");
-    const outputManifold = fs.readFileSync(path.join(__dirname, "generated", "manifold.ts"), "utf8");
-    expect(outputPetstore).toBe(expectedPetstore);
-    expect(outputManifold).toBe(expectedManifold);
+    const [generatedPetstore, expectedPetstore, generatedManifold, expectedManifold] = await Promise.all([
+      fs.promises.readFile(path.join(__dirname, "generated", "specs", "petstore.ts"), "utf8"),
+      fs.promises.readFile(path.join(__dirname, "expected", "petstore.ts"), "utf8"),
+      fs.promises.readFile(path.join(__dirname, "generated", "specs", "manifold.ts"), "utf8"),
+      fs.promises.readFile(path.join(__dirname, "expected", "manifold.ts"), "utf8"),
+    ]);
+    expect(generatedPetstore).toBe(expectedPetstore);
+    expect(generatedManifold).toBe(expectedManifold);
   });
 });

--- a/tests/v2/index.test.ts
+++ b/tests/v2/index.test.ts
@@ -1,24 +1,26 @@
 import { execSync } from "child_process";
-import { readdirSync, readFileSync } from "fs";
-import { join } from "path";
+import fs from "fs";
+import path from "path";
 
-const schemas = readdirSync(join(__dirname, "specs"));
+const schemas = fs.readdirSync(path.join(__dirname, "specs"));
 
 // simple snapshot tests with valid schemas to make sure it can generally parse & generate output
 describe("cli", () => {
   schemas.forEach((schema) => {
     const output = schema.replace(".yaml", ".ts");
 
-    it(`reads ${schema} spec (v2) from file`, () => {
+    it(`reads ${schema} spec (v2) from file`, async () => {
       execSync(`../../bin/cli.js specs/${schema} -o generated/${output} --prettier-config .prettierrc`, {
         cwd: __dirname,
       });
-      const expected = readFileSync(join(__dirname, "expected", output), "utf8");
-      const generated = readFileSync(join(__dirname, "generated", output), "utf8");
+      const [generated, expected] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, "generated", output), "utf8"),
+        fs.promises.readFile(path.join(__dirname, "expected", output), "utf8"),
+      ]);
       expect(generated).toBe(expected);
     });
 
-    it(`reads ${schema} spec (v2) from file (immutable types)`, () => {
+    it(`reads ${schema} spec (v2) from file (immutable types)`, async () => {
       const output = schema.replace(".yaml", ".immutable.ts");
 
       execSync(
@@ -28,21 +30,23 @@ describe("cli", () => {
         }
       );
 
-      const expected = readFileSync(join(__dirname, "expected", output), "utf8");
-      const generated = readFileSync(join(__dirname, "generated", output), "utf8");
+      const [generated, expected] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, "generated", output), "utf8"),
+        fs.promises.readFile(path.join(__dirname, "expected", output), "utf8"),
+      ]);
       expect(generated).toBe(expected);
     });
   });
 
-  it("reads spec (v2) from remote resource", () => {
+  it("reads spec (v2) from remote resource", async () => {
     execSync(
       "../../bin/cli.js https://raw.githubusercontent.com/drwpow/openapi-typescript/main/tests/v2/specs/manifold.yaml -o generated/http.ts",
-      {
-        cwd: __dirname,
-      }
+      { cwd: __dirname }
     );
-    const expected = readFileSync(join(__dirname, "expected", "http.ts"), "utf8");
-    const generated = readFileSync(join(__dirname, "generated", "http.ts"), "utf8");
+    const [generated, expected] = await Promise.all([
+      fs.promises.readFile(path.join(__dirname, "generated", "http.ts"), "utf8"),
+      fs.promises.readFile(path.join(__dirname, "expected", "http.ts"), "utf8"),
+    ]);
     expect(generated).toBe(expected);
   });
 });

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -1,60 +1,62 @@
 import { execSync } from "child_process";
-import { readdirSync, readFileSync } from "fs";
-import { join } from "path";
+import fs from "fs";
+import path from "path";
 
-const schemas = readdirSync(join(__dirname, "specs"));
+const schemas = fs.readdirSync(path.join(__dirname, "specs"));
 
 describe("cli", () => {
   schemas.forEach((schema) => {
-    it(`reads ${schema} spec (v3) from file`, () => {
+    it(`reads ${schema} spec (v3) from file`, async () => {
       const output = schema.replace(".yaml", ".ts");
 
       execSync(`../../bin/cli.js specs/${schema} -o generated/${output} --prettier-config .prettierrc`, {
         cwd: __dirname,
       });
-      const expected = readFileSync(join(__dirname, "expected", output), "utf8");
-      const generated = readFileSync(join(__dirname, "generated", output), "utf8");
+      const [generated, expected] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, "generated", output), "utf8"),
+        fs.promises.readFile(path.join(__dirname, "expected", output), "utf8"),
+      ]);
       expect(generated).toBe(expected);
     });
 
-    it(`reads ${schema} spec (v3) from file (additional properties)`, () => {
+    it(`reads ${schema} spec (v3) from file (additional properties)`, async () => {
       const output = schema.replace(".yaml", ".additional.ts");
 
       execSync(
         `../../bin/cli.js specs/${schema} -o generated/${output} --prettier-config .prettierrc --additional-properties`,
-        {
-          cwd: __dirname,
-        }
+        { cwd: __dirname }
       );
-      const expected = readFileSync(join(__dirname, "expected", output), "utf8");
-      const generated = readFileSync(join(__dirname, "generated", output), "utf8");
+      const [generated, expected] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, "generated", output), "utf8"),
+        fs.promises.readFile(path.join(__dirname, "expected", output), "utf8"),
+      ]);
       expect(generated).toBe(expected);
     });
 
-    it(`reads ${schema} spec (v3) from file (immutable types)`, () => {
+    it(`reads ${schema} spec (v3) from file (immutable types)`, async () => {
       const output = schema.replace(".yaml", ".immutable.ts");
 
       execSync(
         `../../bin/cli.js specs/${schema} -o generated/${output} --prettier-config .prettierrc --immutable-types`,
-        {
-          cwd: __dirname,
-        }
+        { cwd: __dirname }
       );
-      const expected = readFileSync(join(__dirname, "expected", output), "utf8");
-      const generated = readFileSync(join(__dirname, "generated", output), "utf8");
+      const [generated, expected] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, "generated", output), "utf8"),
+        fs.promises.readFile(path.join(__dirname, "expected", output), "utf8"),
+      ]);
       expect(generated).toBe(expected);
     });
   });
 
-  it("reads spec (v3) from remote resource", () => {
+  it("reads spec (v3) from remote resource", async () => {
     execSync(
       "../../bin/cli.js https://raw.githubusercontent.com/drwpow/openapi-typescript/main/tests/v3/specs/manifold.yaml -o generated/http.ts",
-      {
-        cwd: __dirname,
-      }
+      { cwd: __dirname }
     );
-    const expected = readFileSync(join(__dirname, "expected", "http.ts"), "utf8");
-    const generated = readFileSync(join(__dirname, "generated", "http.ts"), "utf8");
+    const [generated, expected] = await Promise.all([
+      fs.promises.readFile(path.join(__dirname, "generated", "http.ts"), "utf8"),
+      fs.promises.readFile(path.join(__dirname, "expected", "http.ts"), "utf8"),
+    ]);
     expect(generated).toBe(expected);
   });
 });


### PR DESCRIPTION
Adds glob docs to README, (#616), along with credit.

Also fixes an unreleased bug where specifying a glob pattern wouldn’t create the folder (it used the file behavior, where it would stop at the _parent_ directory, as with single files, however with globs we need that last directory, too)