### PR TITLE
Fix generation of empty directory

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -153,8 +153,12 @@ async function main() {
     inputSpecPaths.map(async (specPath) => {
       if (cli.flags.output !== "." && output === OUTPUT_FILE) {
         let outputDir = path.join(process.cwd(), cli.flags.output);
-        if (!isGlob) outputDir = path.dirname(outputDir); // use output dir for glob; use parent dir for single files
-        await fs.promises.mkdir(path.join(outputDir, path.dirname(specPath)), { recursive: true }); // recursively make parent dirs
+        if (isGlob) {
+          outputDir = path.join(outputDir, path.dirname(specPath)); // globs: use output dir + spec dir
+        } else {
+          outputDir = path.dirname(outputDir); // single files: just use output parent dir
+        }
+        await fs.promises.mkdir(outputDir, { recursive: true }); // recursively make parent dirs
       }
       await generateSchema(specPath);
     })

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts src",
     "prepare": "npm run build",
     "pregenerate": "npm run build",
-    "test": "npm run build && jest --no-cache",
+    "test": "npm run build && jest --no-cache --test-timeout=10000",
     "test:coverage": "npm run build && jest --no-cache --coverage && codecov",
     "typecheck": "tsc --noEmit",
     "version": "npm run build"


### PR DESCRIPTION
The latest glob changes would accidentally make an empty directory when loading a single file. While technically not breaking, it’s annoying. This fixes that.