### PR TITLE
Add an explicit description of reason why remote globbing doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npx openapi-typescript https://petstore.swagger.io/v2/swagger.json --output pets
 # 🚀 https://petstore.swagger.io/v2/swagger.json -> petstore.ts [650ms]
 ```
 
-_Note: for obvious reasons, globbing doesn’t work for remote schemas_
+_Note: globbing doesn’t work for remote schemas because there is no reliable way to determine a list of files to select from a remote file system._
 
 _Thanks to [@psmyrdek](https://github.com/psmyrdek) for the remote spec feature!_
 


### PR DESCRIPTION
## Motivation

I came across `for obvious reasons` but then I realized that it wasn't very obvious to me. I wanted to make sure it's easier for others to understand in the future.

## Approach

I replaced it with the reason why I believe this might be the reason, but I could be wrong. If I'm wrong, please suggest the actual reason so I can update it. 