### PR TITLE
fix: only generate "external interface" if we have properties

### DIFF
--- a/examples/stripe-openapi2.ts
+++ b/examples/stripe-openapi2.ts
@@ -27560,5 +27560,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/examples/stripe-openapi3.ts
+++ b/examples/stripe-openapi3.ts
@@ -31434,5 +31434,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,9 +68,16 @@ export default async function openapiTS(
   }
 
   // 2b. external schemas (subschemas)
-  output += `export interface external {\n`;
+
   const externalKeys = Object.keys(external);
   externalKeys.sort((a, b) => a.localeCompare(b, "en", { numeric: true })); // sort external keys because they may have resolved in a different order each time
+
+  // only generate interface if we have any properties (don't create empty interface)
+  // https://github.com/drwpow/openapi-typescript/issues/680
+  if (externalKeys.length > 0) {
+    output += `export interface external {\n`;
+  }
+
   for (const subschemaURL of externalKeys) {
     output += `  "${subschemaURL}": {\n`;
     const subschemaTypes = transformAll(external[subschemaURL], { ...ctx, namespace: subschemaURL });
@@ -79,7 +86,10 @@ export default async function openapiTS(
     }
     output += `  }\n`;
   }
-  output += `}\n\n`;
+
+  if (externalKeys.length > 0) {
+    output += `}\n\n`;
+  }
 
   // 3. Prettify
   let prettierOptions: prettier.Options = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export const WARNING_MESSAGE = `/**
 
 export default async function openapiTS(
   schema: string | OpenAPI2 | OpenAPI3 | Record<string, SchemaObject>,
-  options: SwaggerToTSOptions = {} as any
+  options: SwaggerToTSOptions = {}
 ): Promise<string> {
   const ctx: GlobalContext = {
     additionalProperties: options.additionalProperties || false,
@@ -28,7 +28,7 @@ export default async function openapiTS(
     immutableTypes: options.immutableTypes || false,
     rawSchema: options.rawSchema || false,
     version: options.version || 3,
-  } as any;
+  };
 
   // note: we may be loading many large schemas into memory at once; take care to reuse references without cloning
 

--- a/tests/bin/expected/manifold.ts
+++ b/tests/bin/expected/manifold.ts
@@ -1008,5 +1008,3 @@ export interface parameters {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/bin/expected/petstore.ts
+++ b/tests/bin/expected/petstore.ts
@@ -463,5 +463,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/bin/expected/prettier-js.ts
+++ b/tests/bin/expected/prettier-js.ts
@@ -463,5 +463,3 @@ export interface operations {
     }
   }
 }
-
-export interface external {}

--- a/tests/bin/expected/prettier-json.ts
+++ b/tests/bin/expected/prettier-json.ts
@@ -463,5 +463,3 @@ export interface operations {
     }
   }
 }
-
-export interface external {}

--- a/tests/bin/expected/stdout.ts
+++ b/tests/bin/expected/stdout.ts
@@ -463,5 +463,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/empty-definitions.test.ts
+++ b/tests/empty-definitions.test.ts
@@ -55,8 +55,6 @@ export interface operations {
     };
   };
 }
-
-export interface external {}
 `);
 
     expect(await openapiTS(schema as any, { immutableTypes: true, version: 2 })).toBe(`/**
@@ -84,8 +82,6 @@ export interface operations {
     };
   };
 }
-
-export interface external {}
 `);
   });
 });

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -37,8 +37,6 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}
 `);
   });
 
@@ -93,8 +91,6 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}
 `);
   });
 });

--- a/tests/raw-schema.test.ts
+++ b/tests/raw-schema.test.ts
@@ -26,8 +26,6 @@ export interface definitions {
     email: string;
   };
 }
-
-export interface external {}
 `);
   });
 
@@ -57,8 +55,6 @@ export interface schemas {
     email: string;
   };
 }
-
-export interface external {}
 `);
   });
 });

--- a/tests/v2/expected/http.ts
+++ b/tests/v2/expected/http.ts
@@ -1008,5 +1008,3 @@ export interface parameters {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v2/expected/manifold.immutable.ts
+++ b/tests/v2/expected/manifold.immutable.ts
@@ -1008,5 +1008,3 @@ export interface parameters {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v2/expected/manifold.ts
+++ b/tests/v2/expected/manifold.ts
@@ -1008,5 +1008,3 @@ export interface parameters {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v2/expected/null-in-enum.immutable.ts
+++ b/tests/v2/expected/null-in-enum.immutable.ts
@@ -36,5 +36,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v2/expected/null-in-enum.ts
+++ b/tests/v2/expected/null-in-enum.ts
@@ -36,5 +36,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v2/expected/petstore.immutable.ts
+++ b/tests/v2/expected/petstore.immutable.ts
@@ -421,5 +421,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v2/expected/petstore.ts
+++ b/tests/v2/expected/petstore.ts
@@ -421,5 +421,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v2/expected/stripe.immutable.ts
+++ b/tests/v2/expected/stripe.immutable.ts
@@ -27435,5 +27435,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v2/expected/stripe.ts
+++ b/tests/v2/expected/stripe.ts
@@ -27402,5 +27402,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/github.additional.ts
+++ b/tests/v3/expected/github.additional.ts
@@ -31287,5 +31287,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/github.immutable.ts
+++ b/tests/v3/expected/github.immutable.ts
@@ -31223,5 +31223,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/github.ts
+++ b/tests/v3/expected/github.ts
@@ -31219,5 +31219,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/http.ts
+++ b/tests/v3/expected/http.ts
@@ -1145,5 +1145,3 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v3/expected/manifold.additional.ts
+++ b/tests/v3/expected/manifold.additional.ts
@@ -1151,5 +1151,3 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v3/expected/manifold.immutable.ts
+++ b/tests/v3/expected/manifold.immutable.ts
@@ -1145,5 +1145,3 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v3/expected/manifold.ts
+++ b/tests/v3/expected/manifold.ts
@@ -1145,5 +1145,3 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v3/expected/null-in-enum.additional.ts
+++ b/tests/v3/expected/null-in-enum.additional.ts
@@ -36,5 +36,3 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v3/expected/null-in-enum.immutable.ts
+++ b/tests/v3/expected/null-in-enum.immutable.ts
@@ -36,5 +36,3 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v3/expected/null-in-enum.ts
+++ b/tests/v3/expected/null-in-enum.ts
@@ -36,5 +36,3 @@ export interface components {
 }
 
 export interface operations {}
-
-export interface external {}

--- a/tests/v3/expected/petstore-openapitools.additional.ts
+++ b/tests/v3/expected/petstore-openapitools.additional.ts
@@ -476,5 +476,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/petstore-openapitools.immutable.ts
+++ b/tests/v3/expected/petstore-openapitools.immutable.ts
@@ -476,5 +476,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/petstore-openapitools.ts
+++ b/tests/v3/expected/petstore-openapitools.ts
@@ -476,5 +476,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/petstore.additional.ts
+++ b/tests/v3/expected/petstore.additional.ts
@@ -463,5 +463,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/petstore.immutable.ts
+++ b/tests/v3/expected/petstore.immutable.ts
@@ -463,5 +463,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/petstore.ts
+++ b/tests/v3/expected/petstore.ts
@@ -463,5 +463,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/stripe.additional.ts
+++ b/tests/v3/expected/stripe.additional.ts
@@ -31339,5 +31339,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/stripe.immutable.ts
+++ b/tests/v3/expected/stripe.immutable.ts
@@ -30969,5 +30969,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}

--- a/tests/v3/expected/stripe.ts
+++ b/tests/v3/expected/stripe.ts
@@ -30920,5 +30920,3 @@ export interface operations {
     };
   };
 }
-
-export interface external {}


### PR DESCRIPTION
fixes: https://github.com/drwpow/openapi-typescript/issues/680