### PR TITLE
Fix JSON loader

### DIFF
--- a/tests/v2/index.test.ts
+++ b/tests/v2/index.test.ts
@@ -1,7 +1,9 @@
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
+import yaml from "js-yaml";
 import { sanitizeLB } from "../test-utils";
+import openapiTS from "../../src/index";
 
 const cmd = `node ../../bin/cli.js`;
 const schemas = fs.readdirSync(path.join(__dirname, "specs"));
@@ -47,5 +49,21 @@ describe("cli", () => {
       fs.promises.readFile(path.join(__dirname, "expected", "http.ts"), "utf8"),
     ]);
     expect(generated).toBe(sanitizeLB(expected));
+  });
+});
+
+describe("json", () => {
+  schemas.forEach((schema) => {
+    it(`reads ${schema} from JSON`, async () => {
+      const [schemaYAML, expected] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, "specs", schema), "utf8"),
+        fs.promises.readFile(path.join(__dirname, "expected", schema.replace(".yaml", ".ts")), "utf8"),
+      ]);
+      const schemaJSON = yaml.load(schemaYAML) as any;
+      const generated = await openapiTS(schemaJSON, {
+        prettierConfig: path.join(__dirname, "..", "..", ".prettierrc"),
+      });
+      expect(generated).toBe(sanitizeLB(expected));
+    });
   });
 });

--- a/tests/v3/index.test.ts
+++ b/tests/v3/index.test.ts
@@ -1,7 +1,9 @@
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
+import yaml from "js-yaml";
 import { sanitizeLB } from "../test-utils";
+import openapiTS from "../../src/index";
 
 const cmd = `node ../../bin/cli.js`;
 const schemas = fs.readdirSync(path.join(__dirname, "specs"));
@@ -58,5 +60,21 @@ describe("cli", () => {
       fs.promises.readFile(path.join(__dirname, "expected", "http.ts"), "utf8"),
     ]);
     expect(generated).toBe(sanitizeLB(expected));
+  });
+});
+
+describe("json", () => {
+  schemas.forEach((schema) => {
+    it(`reads ${schema} from JSON`, async () => {
+      const [schemaYAML, expected] = await Promise.all([
+        fs.promises.readFile(path.join(__dirname, "specs", schema), "utf8"),
+        fs.promises.readFile(path.join(__dirname, "expected", schema.replace(".yaml", ".ts")), "utf8"),
+      ]);
+      const schemaJSON = yaml.load(schemaYAML) as any;
+      const generated = await openapiTS(schemaJSON, {
+        prettierConfig: path.join(__dirname, "..", "..", ".prettierrc"),
+      });
+      expect(generated).toBe(sanitizeLB(expected));
+    });
   });
 });


### PR DESCRIPTION
Fixes #638. In the 4.0 update that supports remote schemas, `$ref`s have to be parsed upfront before anything else is transformed to know which schemas to fetch. But when passing in JSON, the $refs were accidentally skipped.

This PR also adds a test for the JS API to ensure it doesn’t break again.