### PR TITLE
Strictly requires npm 7.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Generate TypeScript types from Swagger OpenAPI specs",
   "version": "4.0.2",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": ">= 7.0.0"
   },
   "author": "drew@pow.rs",
   "license": "ISC",


### PR DESCRIPTION
Hey,

There is a small patch to strictly requires npm 7 to install dependencies.

Users with lower npm versions will get error message like this:

```
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for openapi-typescript@4.0.2: wanted: {"node":">= 12.0.0","npm":">= 7.0.0"} (current: {"node":"14.15.0","npm":"6.14.8"})
npm ERR! notsup Not compatible with your version of node/npm: openapi-typescript@4.0.2
npm ERR! notsup Not compatible with your version of node/npm: openapi-typescript@4.0.2
npm ERR! notsup Required: {"node":">= 12.0.0","npm":">= 7.0.0"}
npm ERR! notsup Actual:   {"npm":"6.14.8","node":"14.15.0"}
```

Refs:
- https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines
- https://docs.npmjs.com/cli/v7/using-npm/config#engine-strict