### PR TITLE
Feat: add support for "type": "file" in parameters

### DIFF
--- a/src/transform/schema.ts
+++ b/src/transform/schema.ts
@@ -97,7 +97,8 @@ export function transformSchemaObj(node: any, options: TransformSchemaObjOptions
       }
       case "string":
       case "number":
-      case "boolean": {
+      case "boolean":
+      case "unknown": {
         output += nodeType(node) || "any";
         break;
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,17 @@ export function isRef(obj: any): obj is ReferenceObject {
 }
 
 /** Return type of node (works for v2 or v3, as there are no conflicting types) */
-type SchemaObjectType = "anyOf" | "array" | "boolean" | "enum" | "number" | "object" | "oneOf" | "ref" | "string";
+type SchemaObjectType =
+  | "anyOf"
+  | "array"
+  | "boolean"
+  | "enum"
+  | "number"
+  | "object"
+  | "oneOf"
+  | "ref"
+  | "string"
+  | "unknown";
 export function nodeType(obj: any): SchemaObjectType | undefined {
   if (!obj || typeof obj !== "object") {
     return undefined;
@@ -65,6 +75,11 @@ export function nodeType(obj: any): SchemaObjectType | undefined {
   // array
   if (obj.type === "array" || obj.items) {
     return "array";
+  }
+
+  // file
+  if (obj.type === "file") {
+    return "unknown";
   }
 
   // return object by default

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -209,6 +209,10 @@ describe("SchemaObject", () => {
         `components["parameters"]["ReferenceObject"]`
       );
     });
+
+    it("file", () => {
+      expect(transform({ type: "file" }, { ...defaults })).toBe("unknown");
+    });
   });
 
   describe("advanced", () => {

--- a/tests/v2/expected/petstore.immutable.ts
+++ b/tests/v2/expected/petstore.immutable.ts
@@ -235,7 +235,7 @@ export interface operations {
         /** Additional data to pass to server */
         readonly additionalMetadata?: string;
         /** file to upload */
-        readonly file?: { readonly [key: string]: unknown };
+        readonly file?: unknown;
       };
     };
     readonly responses: {

--- a/tests/v2/expected/petstore.ts
+++ b/tests/v2/expected/petstore.ts
@@ -235,7 +235,7 @@ export interface operations {
         /** Additional data to pass to server */
         additionalMetadata?: string;
         /** file to upload */
-        file?: { [key: string]: unknown };
+        file?: unknown;
       };
     };
     responses: {


### PR DESCRIPTION
Related to https://github.com/drwpow/openapi-typescript/issues/726. When `type: "file"` is encountered in parameters, weird results occur.