### PR TITLE
Improve generated types for unknown schema objects

### DIFF
--- a/examples/stripe-openapi2.ts
+++ b/examples/stripe-openapi2.ts
@@ -1526,7 +1526,7 @@ export interface definitions {
     id: string;
     individual?: definitions["person"];
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "account";
     /** Whether Stripe can send payouts to this account. */
@@ -1747,7 +1747,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "alipay_account";
     /** If the Alipay account object is not reusable, the exact amount that you can create a charge for. */
@@ -1986,7 +1986,7 @@ export interface definitions {
     /** The last four digits of the bank account number. */
     last4: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "bank_account";
     /** The routing transit number for the bank account. */
@@ -2064,7 +2064,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "bitcoin_receiver";
     /** The ID of the payment created from the receiver, if any. Hidden when viewing the receiver with a publishable key. */
@@ -2177,7 +2177,7 @@ export interface definitions {
     /** The last four digits of the card. */
     last4: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** Cardholder name. */
     name?: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -2187,7 +2187,7 @@ export interface definitions {
     /** If the card number is tokenized, this is the method that was used. Can be `amex_express_checkout`, `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null. */
     tokenization_method?: string;
   };
-  card_mandate_payment_method_details: { [key: string]: any };
+  card_mandate_payment_method_details: { [key: string]: unknown };
   /**
    * To charge a credit or a debit card, you create a `Charge` object. You can
    * retrieve and refund individual charges as well as list all charges. Charges
@@ -2235,7 +2235,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "charge";
     /** The account (if any) the charge was made on behalf of without triggering an automatic transfer. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers) for details. */
@@ -2388,7 +2388,7 @@ export interface definitions {
       | "sv"
       | "zh";
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** The mode of the Checkout Session, one of `payment`, `setup`, or `subscription`. */
     mode?: "payment" | "setup" | "subscription";
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -2470,7 +2470,7 @@ export interface definitions {
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "country_spec";
     /** Currencies that can be accepted in the specific country (for transfers). */
-    supported_bank_account_currencies: { [key: string]: any };
+    supported_bank_account_currencies: { [key: string]: unknown };
     /** Currencies that can be accepted in the specified country (for payments). */
     supported_payment_currencies: string[];
     /** Payment methods available in the specified country. You may need to enable some payment methods (e.g., [ACH](https://stripe.com/docs/ach)) on your account before they appear in this list. The `stripe` payment method refers to [charging through your platform](https://stripe.com/docs/connect/destination-charges). */
@@ -2512,7 +2512,7 @@ export interface definitions {
     /** Maximum number of times this coupon can be redeemed, in total, across all customers, before it is no longer valid. */
     max_redemptions?: number;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** Name of the coupon displayed to customers on for instance invoices or receipts. */
     name?: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -2564,7 +2564,7 @@ export interface definitions {
     /** Customer-facing text that appears on the credit note PDF. */
     memo?: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** A unique number that identifies this particular credit note and appears on the PDF of the credit note and its associated invoice. */
     number: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -2667,7 +2667,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** The customer's full name or business name. */
     name?: string;
     /** The suffix of the customer's next invoice number, e.g., 0001. */
@@ -2753,7 +2753,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "customer_balance_transaction";
     /** Transaction type: `adjustment`, `applied_to_invoice`, `credit_note`, `initial`, `invoice_too_large`, `invoice_too_small`, `unspent_receiver_credit`, or `unapplied_from_invoice`. See the [Customer Balance page](https://stripe.com/docs/billing/customer/balance#types) to learn more about transaction types. */
@@ -3031,7 +3031,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "dispute";
     /** ID of the PaymentIntent that was disputed. */
@@ -3203,7 +3203,7 @@ export interface definitions {
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "exchange_rate";
     /** Hash where the keys are supported currencies and the values are the exchange rate at which the base id currency converts to the key currency. */
-    rates: { [key: string]: any };
+    rates: { [key: string]: unknown };
   };
   external_account: {
     /** The ID of the account that the bank account is associated with. */
@@ -3223,7 +3223,7 @@ export interface definitions {
     /** The last four digits of the bank account number. */
     last4: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "bank_account";
   };
@@ -3260,7 +3260,7 @@ export interface definitions {
     /** Unique identifier for the object. */
     id: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "fee_refund";
   };
@@ -3323,7 +3323,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "file_link";
     /** The publicly accessible URL to download the file. */
@@ -3477,7 +3477,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** The time at which payment will next be attempted. This value will be `null` for invoices where `collection_method=send_invoice`. */
     next_payment_attempt?: number;
     /** A unique, identifying string that appears on emails sent to the customer for this invoice. This starts with the customer's unique invoice_prefix if it is specified. */
@@ -3596,7 +3596,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "invoiceitem";
     period: definitions["invoice_line_item_period"];
@@ -3719,7 +3719,7 @@ export interface definitions {
     merchant_currency: string;
     merchant_data: definitions["issuing_authorization_merchant_data"];
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "issuing.authorization";
     pending_request?: definitions["issuing_authorization_pending_request"];
@@ -3757,7 +3757,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** The full unredacted card number. For security reasons, this is only available for virtual cards, and will be omitted unless you explicitly request it with [the `expand` parameter](https://stripe.com/docs/api/expanding_objects). Additionally, it's only available via the ["Retrieve a card" endpoint](https://stripe.com/docs/api/issuing/cards/retrieve), not via "List all cards" or any other endpoint. */
     number?: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -3793,7 +3793,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** The cardholder's name. This will be printed on cards issued to them. */
     name: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -3837,7 +3837,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** The total net amount required to settle with the network. */
     net_total: number;
     /** The card network for this settlement report. One of ["visa"] */
@@ -3887,7 +3887,7 @@ export interface definitions {
     merchant_currency: string;
     merchant_data: definitions["issuing_authorization_merchant_data"];
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "issuing.transaction";
     /** The nature of the transaction. */
@@ -5913,7 +5913,7 @@ export interface definitions {
     /** The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. */
     front?: string;
   };
-  light_account_logout: { [key: string]: any };
+  light_account_logout: { [key: string]: unknown };
   line_item: {
     /** The amount, in %s. */
     amount: number;
@@ -5930,7 +5930,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Note that for line items with `type=subscription` this will reflect the metadata of the subscription that caused the line item to be created. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "line_item";
     period: definitions["invoice_line_item_period"];
@@ -5981,7 +5981,7 @@ export interface definitions {
     /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
     url: string;
   };
-  mandate_multi_use: { [key: string]: any };
+  mandate_multi_use: { [key: string]: unknown };
   mandate_payment_method_details: {
     au_becs_debit?: definitions["mandate_au_becs_debit"];
     card?: definitions["card_mandate_payment_method_details"];
@@ -6003,9 +6003,9 @@ export interface definitions {
   };
   notification_event_data: {
     /** Object containing the API resource relevant to the event. For example, an `invoice.created` event will have a full [invoice object](https://stripe.com/docs/api#invoice_object) as the value of the object key. */
-    object: { [key: string]: any };
+    object: { [key: string]: unknown };
     /** Object containing the names of the attributes that have changed, and their previous values (sent along only with *.updated events). */
-    previous_attributes?: { [key: string]: any };
+    previous_attributes?: { [key: string]: unknown };
   };
   notification_event_request: {
     /** ID of the API request that caused the event. If null, the event was automatic (e.g., Stripe's automatic subscription handling). Request logs are available in the [dashboard](https://dashboard.stripe.com/logs), but currently not in the API. */
@@ -6013,7 +6013,7 @@ export interface definitions {
     /** The idempotency key transmitted during the request, if any. *Note: This property is populated only for events on or after May 23, 2017*. */
     idempotency_key?: string;
   };
-  offline_acceptance: { [key: string]: any };
+  offline_acceptance: { [key: string]: unknown };
   online_acceptance: {
     /** The IP address from which the Mandate was accepted by the customer. */
     ip_address?: string;
@@ -6055,7 +6055,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "order";
     /** A list of returns that have taken place for this order. */
@@ -6219,7 +6219,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. For more information, see the [documentation](https://stripe.com/docs/payments/payment-intents/creating-payment-intents#storing-information-in-metadata). */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     next_action?: definitions["payment_intent_next_action"];
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "payment_intent";
@@ -6265,7 +6265,7 @@ export interface definitions {
     /** Type of the next action to perform, one of `redirect_to_url` or `use_stripe_sdk`. */
     type: string;
     /** When confirming a PaymentIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js. */
-    use_stripe_sdk?: { [key: string]: any };
+    use_stripe_sdk?: { [key: string]: unknown };
   };
   payment_intent_next_action_redirect_to_url: {
     /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
@@ -6304,7 +6304,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "payment_method";
     sepa_debit?: definitions["payment_method_sepa_debit"];
@@ -6352,7 +6352,7 @@ export interface definitions {
     charge?: string;
     payment_method_details?: definitions["payment_method_details"];
   };
-  payment_method_card_present: { [key: string]: any };
+  payment_method_card_present: { [key: string]: unknown };
   payment_method_card_wallet: {
     amex_express_checkout?: definitions["payment_method_card_wallet_amex_express_checkout"];
     apple_pay?: definitions["payment_method_card_wallet_apple_pay"];
@@ -6371,9 +6371,9 @@ export interface definitions {
       | "visa_checkout";
     visa_checkout?: definitions["payment_method_card_wallet_visa_checkout"];
   };
-  payment_method_card_wallet_amex_express_checkout: { [key: string]: any };
-  payment_method_card_wallet_apple_pay: { [key: string]: any };
-  payment_method_card_wallet_google_pay: { [key: string]: any };
+  payment_method_card_wallet_amex_express_checkout: { [key: string]: unknown };
+  payment_method_card_wallet_apple_pay: { [key: string]: unknown };
+  payment_method_card_wallet_google_pay: { [key: string]: unknown };
   payment_method_card_wallet_masterpass: {
     billing_address?: definitions["address"];
     /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
@@ -6382,7 +6382,7 @@ export interface definitions {
     name?: string;
     shipping_address?: definitions["address"];
   };
-  payment_method_card_wallet_samsung_pay: { [key: string]: any };
+  payment_method_card_wallet_samsung_pay: { [key: string]: unknown };
   payment_method_card_wallet_visa_checkout: {
     billing_address?: definitions["address"];
     /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
@@ -6441,7 +6441,7 @@ export interface definitions {
     /** Routing transit number of the bank account. */
     routing_number?: string;
   };
-  payment_method_details_alipay: { [key: string]: any };
+  payment_method_details_alipay: { [key: string]: unknown };
   payment_method_details_au_becs_debit: {
     /** Bank-State-Branch number of the bank account. */
     bsb_number?: string;
@@ -6580,10 +6580,10 @@ export interface definitions {
     visa_checkout?: definitions["payment_method_details_card_wallet_visa_checkout"];
   };
   payment_method_details_card_wallet_amex_express_checkout: {
-    [key: string]: any;
+    [key: string]: unknown;
   };
-  payment_method_details_card_wallet_apple_pay: { [key: string]: any };
-  payment_method_details_card_wallet_google_pay: { [key: string]: any };
+  payment_method_details_card_wallet_apple_pay: { [key: string]: unknown };
+  payment_method_details_card_wallet_google_pay: { [key: string]: unknown };
   payment_method_details_card_wallet_masterpass: {
     billing_address?: definitions["address"];
     /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
@@ -6592,7 +6592,7 @@ export interface definitions {
     name?: string;
     shipping_address?: definitions["address"];
   };
-  payment_method_details_card_wallet_samsung_pay: { [key: string]: any };
+  payment_method_details_card_wallet_samsung_pay: { [key: string]: unknown };
   payment_method_details_card_wallet_visa_checkout: {
     billing_address?: definitions["address"];
     /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
@@ -6684,7 +6684,7 @@ export interface definitions {
      */
     verified_name?: string;
   };
-  payment_method_details_klarna: { [key: string]: any };
+  payment_method_details_klarna: { [key: string]: unknown };
   payment_method_details_multibanco: {
     /** Entity number associated with this Multibanco payment. */
     entity?: string;
@@ -6731,8 +6731,8 @@ export interface definitions {
      */
     verified_name?: string;
   };
-  payment_method_details_stripe_account: { [key: string]: any };
-  payment_method_details_wechat: { [key: string]: any };
+  payment_method_details_stripe_account: { [key: string]: unknown };
+  payment_method_details_wechat: { [key: string]: unknown };
   payment_method_fpx: {
     /** The customer's bank, if provided. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, or `pb_enterprise`. */
     bank:
@@ -7055,7 +7055,7 @@ export interface definitions {
     /** Unique identifier for the object. */
     id: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "account";
   };
@@ -7097,7 +7097,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** The method used to send this payout, which can be `standard` or `instant`. `instant` is only supported for payouts to debit cards. (See [Instant payouts for marketplaces](https://stripe.com/blog/instant-payouts-for-marketplaces) for more information.) */
     method: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -7143,7 +7143,7 @@ export interface definitions {
     last_name_kanji?: string;
     maiden_name?: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "person";
     phone?: string;
@@ -7210,7 +7210,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** A brief description of the plan, hidden from customers. */
     nickname?: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -7281,7 +7281,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions. */
     name: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -7359,7 +7359,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** The name of the value list. */
     name: string;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -7444,7 +7444,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** The ID of the [Custom account](https://stripe.com/docs/connect/custom-accounts) this recipient was migrated to. If set, the recipient can no longer be updated, nor can transfers be made to it: use the Custom account instead. */
     migrated_to?: string;
     /** Full, legal name of the recipient. */
@@ -7482,7 +7482,7 @@ export interface definitions {
     /** Unique identifier for the object. */
     id: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "refund";
     /** ID of the PaymentIntent that was refunded. */
@@ -7702,7 +7702,7 @@ export interface definitions {
     /** ID of the multi use Mandate generated by the SetupIntent. */
     mandate?: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     next_action?: definitions["setup_intent_next_action"];
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "setup_intent";
@@ -7735,7 +7735,7 @@ export interface definitions {
     /** Type of the next action to perform, one of `redirect_to_url` or `use_stripe_sdk`. */
     type: string;
     /** When confirming a SetupIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js. */
-    use_stripe_sdk?: { [key: string]: any };
+    use_stripe_sdk?: { [key: string]: unknown };
   };
   setup_intent_next_action_redirect_to_url: {
     /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
@@ -7790,7 +7790,7 @@ export interface definitions {
     /** Whether the SKU is available for purchase. */
     active: boolean;
     /** A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`. */
-    attributes: { [key: string]: any };
+    attributes: { [key: string]: unknown };
     /** Time at which the object was created. Measured in seconds since the Unix epoch. */
     created: number;
     /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -7803,7 +7803,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "sku";
     package_dimensions?: definitions["package_dimensions"];
@@ -7852,7 +7852,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     multibanco?: definitions["source_type_multibanco"];
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "source";
@@ -8340,7 +8340,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** Specifies the approximate timestamp on which any pending invoice items will be billed according to the schedule provided at `pending_invoice_item_interval`. */
     next_pending_invoice_item_invoice?: number;
     /** String representing the object's type. Objects of the same type share the same value. */
@@ -8400,7 +8400,7 @@ export interface definitions {
     /** Unique identifier for the object. */
     id: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "subscription_item";
     plan: definitions["plan"];
@@ -8444,7 +8444,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata?: { [key: string]: any };
+    metadata?: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "subscription_schedule";
     /** Configuration for the subscription schedule's phases. */
@@ -8627,7 +8627,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "tax_rate";
     /** This represents the tax rate percent out of 100. */
@@ -8660,7 +8660,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "terminal.location";
   };
@@ -8685,7 +8685,7 @@ export interface definitions {
     /** The location identifier of the reader. */
     location?: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "terminal.reader";
     /** Serial number of the reader. */
@@ -8802,7 +8802,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "topup";
     source: definitions["source"];
@@ -8847,7 +8847,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "transfer";
     /** A list of reversals that have been applied to the transfer. */
@@ -8909,7 +8909,7 @@ export interface definitions {
     /** Unique identifier for the object. */
     id: string;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "transfer_reversal";
     /** ID of the refund responsible for the transfer reversal. */
@@ -8993,7 +8993,7 @@ export interface definitions {
     /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
     livemode: boolean;
     /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: unknown };
     /** String representing the object's type. Objects of the same type share the same value. */
     object: "webhook_endpoint";
     /** The endpoint's secret, used to generate [webhook signatures](https://stripe.com/docs/webhooks/signatures). Only returned at creation. */
@@ -9043,7 +9043,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         three_d_secure: string;
@@ -9065,7 +9065,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
     };
     responses: {
@@ -9092,7 +9092,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -9207,7 +9207,7 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: { [key: string]: any };
+            dob?: unknown;
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -9218,7 +9218,7 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: { [key: string]: any };
+            metadata?: unknown;
             phone?: string;
             ssn_last_4?: string;
             verification?: {
@@ -9233,7 +9233,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -9267,7 +9267,7 @@ export interface operations {
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: { [key: string]: any };
+                delay_days?: unknown;
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?:
@@ -9336,7 +9336,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -9344,7 +9344,7 @@ export interface operations {
           /** Please refer to full [documentation](https://stripe.com/docs/api) instead. */
           external_account?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -9364,7 +9364,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -9418,7 +9418,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
         };
@@ -9458,7 +9458,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
     };
     responses: {
@@ -9485,7 +9485,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         capability: string;
@@ -9534,7 +9534,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -9570,7 +9570,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -9578,7 +9578,7 @@ export interface operations {
           /** Please refer to full [documentation](https://stripe.com/docs/api) instead. */
           external_account?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -9598,7 +9598,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -9652,7 +9652,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
         };
@@ -9748,7 +9748,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -9815,7 +9815,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: any };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -9839,7 +9839,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -9849,7 +9849,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: any };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -9885,7 +9885,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         person: string;
@@ -9942,7 +9942,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: any };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -9966,7 +9966,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -9976,7 +9976,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: any };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -10030,7 +10030,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -10097,7 +10097,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: any };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10121,7 +10121,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -10131,7 +10131,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: any };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -10167,7 +10167,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         person: string;
@@ -10224,7 +10224,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: any };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10248,7 +10248,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -10258,7 +10258,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: any };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -10344,7 +10344,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -10388,7 +10388,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -10505,7 +10505,7 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: { [key: string]: any };
+            dob?: unknown;
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -10516,7 +10516,7 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: { [key: string]: any };
+            metadata?: unknown;
             phone?: string;
             ssn_last_4?: string;
             verification?: {
@@ -10531,7 +10531,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -10565,7 +10565,7 @@ export interface operations {
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: { [key: string]: any };
+                delay_days?: unknown;
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?:
@@ -10607,7 +10607,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -10640,7 +10640,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -10755,7 +10755,7 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: { [key: string]: any };
+            dob?: unknown;
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -10766,7 +10766,7 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: { [key: string]: any };
+            metadata?: unknown;
             phone?: string;
             ssn_last_4?: string;
             verification?: {
@@ -10781,7 +10781,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -10815,7 +10815,7 @@ export interface operations {
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: { [key: string]: any };
+                delay_days?: unknown;
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?:
@@ -10884,7 +10884,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -10892,7 +10892,7 @@ export interface operations {
           /** Please refer to full [documentation](https://stripe.com/docs/api) instead. */
           external_account?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -10912,7 +10912,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -10968,7 +10968,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
         };
@@ -11009,7 +11009,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11039,7 +11039,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11090,7 +11090,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11132,7 +11132,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -11140,7 +11140,7 @@ export interface operations {
           /** Please refer to full [documentation](https://stripe.com/docs/api) instead. */
           external_account?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -11160,7 +11160,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11216,7 +11216,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
         };
@@ -11317,7 +11317,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11389,7 +11389,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: any };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11413,7 +11413,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -11423,7 +11423,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: any };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -11459,7 +11459,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11517,7 +11517,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: any };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11541,7 +11541,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -11551,7 +11551,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: any };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -11606,7 +11606,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11678,7 +11678,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: any };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11702,7 +11702,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -11712,7 +11712,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: any };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -11748,7 +11748,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11806,7 +11806,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: any };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11830,7 +11830,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -11840,7 +11840,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: any };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -11926,7 +11926,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         domain_name?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -11983,7 +11983,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         domain: string;
@@ -12023,7 +12023,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return application fees for the charge specified by this charge ID. */
         charge?: string;
         created?: number;
@@ -12059,7 +12059,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         fee: string;
@@ -12094,7 +12094,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -12114,7 +12114,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -12162,7 +12162,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -12218,7 +12218,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -12241,7 +12241,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
     };
     responses: {
@@ -12264,7 +12264,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         available_on?: number;
         created?: number;
         /** Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -12311,7 +12311,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -12337,7 +12337,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         available_on?: number;
         created?: number;
         /** Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -12384,7 +12384,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -12432,7 +12432,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Filter for active receivers. */
         active?: boolean;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12471,7 +12471,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -12493,7 +12493,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return transactions for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12532,7 +12532,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return transactions for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12569,7 +12569,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** Only return charges for the customer specified by this customer ID. */
         customer?: string;
@@ -12618,7 +12618,7 @@ export interface operations {
           /** Whether to immediately capture the charge. Defaults to `true`. When `false`, the charge issues an authorization (or pre-authorization), and will need to be [captured](https://stripe.com/docs/api#capture_charge) later. Uncaptured charges expire in _seven days_. For more information, see the [authorizing charges and settling later](https://stripe.com/docs/charges/placing-a-hold) documentation. */
           capture?: boolean;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: any };
+          card?: unknown;
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           currency?: string;
           /** The ID of an existing customer that will be charged in this request. */
@@ -12632,7 +12632,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The Stripe account ID for which these funds are intended. Automatically set if you use the `destination` parameter. For details, see [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers#on-behalf-of). */
           on_behalf_of?: string;
           /** The email address to which this charge's [receipt](https://stripe.com/docs/dashboard/receipts) will be sent. The receipt will not be sent until the charge is paid, and no receipts will be sent for test mode charges. If this charge is for a [Customer](https://stripe.com/docs/api/customers/object), the email address specified here will override the customer's email address. If `receipt_email` is specified for a charge in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails). */
@@ -12684,7 +12684,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         charge: string;
@@ -12721,7 +12721,7 @@ export interface operations {
             user_report: "" | "fraudulent" | "safe";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** This is the email address that the receipt for this charge will be sent to. If this field is updated, then a new email receipt will be sent to the updated address. */
           receipt_email?: string;
           /** Shipping information for the charge. Helps prevent fraud on charges for physical goods. */
@@ -12807,7 +12807,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         charge: string;
@@ -12865,7 +12865,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default). */
           submit?: boolean;
         };
@@ -12930,7 +12930,7 @@ export interface operations {
           amount?: number;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           payment_intent?: string;
           reason?: "duplicate" | "fraudulent" | "requested_by_customer";
           refund_application_fee?: boolean;
@@ -12954,7 +12954,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -12999,7 +12999,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           payment_intent?: string;
           reason?: "duplicate" | "fraudulent" | "requested_by_customer";
           refund_application_fee?: boolean;
@@ -13023,7 +13023,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         charge: string;
@@ -13053,7 +13053,7 @@ export interface operations {
         payload?: {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -13073,7 +13073,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13175,7 +13175,7 @@ export interface operations {
             | "sv"
             | "zh";
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The mode of the Checkout Session, one of `payment`, `setup`, or `subscription`. */
           mode?: "payment" | "setup" | "subscription";
           /** A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in `payment` mode. */
@@ -13183,7 +13183,7 @@ export interface operations {
             application_fee_amount?: number;
             capture_method?: "automatic" | "manual";
             description?: string;
-            metadata?: { [key: string]: any };
+            metadata?: { [key: string]: unknown };
             on_behalf_of?: string;
             receipt_email?: string;
             setup_future_usage?: "off_session" | "on_session";
@@ -13213,7 +13213,7 @@ export interface operations {
           /** A subset of parameters to be passed to SetupIntent creation for Checkout Sessions in `setup` mode. */
           setup_intent_data?: {
             description?: string;
-            metadata?: { [key: string]: any };
+            metadata?: { [key: string]: unknown };
             on_behalf_of?: string;
           };
           /** When set, provides configuration for Checkout to collect a shipping address from a customer. */
@@ -13474,7 +13474,7 @@ export interface operations {
               quantity?: number;
               tax_rates?: string[];
             }[];
-            metadata?: { [key: string]: any };
+            metadata?: { [key: string]: unknown };
             trial_end?: number;
             trial_from_plan?: boolean;
             trial_period_days?: number;
@@ -13506,7 +13506,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         session: string;
@@ -13528,7 +13528,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13561,7 +13561,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         country: string;
@@ -13583,7 +13583,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13638,7 +13638,7 @@ export interface operations {
           /** A positive integer specifying the number of times the coupon can be redeemed before it's no longer valid. For example, you might have a 50% off coupon that the first 20 readers of your blog can use. */
           max_redemptions?: number;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set. */
           name?: string;
           /** A positive float larger than 0, and smaller or equal to 100, that represents the discount the coupon will apply (required if `amount_off` is not passed). */
@@ -13664,7 +13664,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         coupon: string;
@@ -13693,7 +13693,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set. */
           name?: string;
         };
@@ -13733,7 +13733,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return credit notes for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13808,7 +13808,7 @@ export interface operations {
           /** The credit note's memo appears on the credit note PDF. */
           memo?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The integer amount in **%s** representing the amount that is credited outside of Stripe. */
           out_of_band_amount?: number;
           /** Reason for issuing this credit note, one of `duplicate`, `fraudulent`, `order_change`, or `product_unsatisfactory` */
@@ -13840,7 +13840,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The integer amount in **%s** representing the total amount of the credit note. */
         amount?: number;
         /** The integer amount in **%s** representing the amount to credit the customer's balance, which will be automatically applied to their next invoice. */
@@ -13848,7 +13848,7 @@ export interface operations {
         /** ID of the invoice. */
         invoice: string;
         /** Line items that make up the credit note. */
-        lines?: any[];
+        lines?: unknown[];
         /** The credit note's memo appears on the credit note PDF. */
         memo?: string;
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -13879,7 +13879,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The integer amount in **%s** representing the total amount of the credit note. */
         amount?: number;
         /** The integer amount in **%s** representing the amount to credit the customer's balance, which will be automatically applied to their next invoice. */
@@ -13891,7 +13891,7 @@ export interface operations {
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** Line items that make up the credit note. */
-        lines?: any[];
+        lines?: unknown[];
         /** The credit note's memo appears on the credit note PDF. */
         memo?: string;
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -13933,7 +13933,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13970,7 +13970,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -14001,7 +14001,7 @@ export interface operations {
           /** Credit note memo. */
           memo?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -14046,7 +14046,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A filter on the list based on the customer's `email` field. The value must be a string. */
         email?: string;
@@ -14084,7 +14084,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** The customer's address. */
-          address?: { [key: string]: any };
+          address?: unknown;
           /** An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice. */
           balance?: number;
           /** The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that particular subscription. */
@@ -14107,7 +14107,7 @@ export interface operations {
             footer?: string;
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The customer's full name or business name. */
           name?: string;
           /** The sequence to be used on the customer's next invoice. Defaults to 1. */
@@ -14119,7 +14119,7 @@ export interface operations {
           /** Customer's preferred languages, ordered by preference. */
           preferred_locales?: string[];
           /** The customer's shipping information. Appears on invoices emailed to this customer. */
-          shipping?: { [key: string]: any };
+          shipping?: unknown;
           /**
            * The source can be a [Token](https://stripe.com/docs/api#tokens) or a [Source](https://stripe.com/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free.
            *
@@ -14177,7 +14177,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14208,13 +14208,13 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** The customer's address. */
-          address?: { [key: string]: any };
+          address?: unknown;
           /** An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice. */
           balance?: number;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: any };
+          card?: unknown;
           /** The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that particular subscription. */
           coupon?: string;
           /** ID of Alipay account to make the customer's new default for invoice payments. */
@@ -14249,7 +14249,7 @@ export interface operations {
             footer?: string;
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The customer's full name or business name. */
           name?: string;
           /** The sequence to be used on the customer's next invoice. Defaults to 1. */
@@ -14259,7 +14259,7 @@ export interface operations {
           /** Customer's preferred languages, ordered by preference. */
           preferred_locales?: string[];
           /** The customer's shipping information. Appears on invoices emailed to this customer. */
-          shipping?: { [key: string]: any };
+          shipping?: unknown;
           /**
            * The source can be a [Token](https://stripe.com/docs/api#tokens) or a [Source](https://stripe.com/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free.
            *
@@ -14271,7 +14271,7 @@ export interface operations {
           /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
           tax_exempt?: "" | "exempt" | "none" | "reverse";
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: any };
+          trial_end?: unknown;
         };
       };
     };
@@ -14309,7 +14309,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14359,7 +14359,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -14379,7 +14379,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14412,7 +14412,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -14432,7 +14432,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14482,13 +14482,13 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: any };
+          card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** Please refer to full [documentation](https://stripe.com/docs/api) instead. */
           source?: string;
         };
@@ -14510,7 +14510,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14561,7 +14561,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -14654,7 +14654,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14703,13 +14703,13 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: any };
+          card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** Please refer to full [documentation](https://stripe.com/docs/api) instead. */
           source?: string;
         };
@@ -14731,7 +14731,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14782,7 +14782,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -14842,7 +14842,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14882,7 +14882,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14934,13 +14934,13 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: any };
+          bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: any };
+          card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** Please refer to full [documentation](https://stripe.com/docs/api) instead. */
           source?: string;
         };
@@ -14962,7 +14962,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -15013,7 +15013,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -15102,7 +15102,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -15150,7 +15150,7 @@ export interface operations {
           /** A future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. */
           billing_cycle_anchor?: number;
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: any };
+          billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
           cancel_at?: number;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
@@ -15171,14 +15171,14 @@ export interface operations {
           expand?: string[];
           /** A list of up to 20 subscription items, each with an attached plan. */
           items?: {
-            billing_thresholds?: { [key: string]: any };
-            metadata?: { [key: string]: any };
+            billing_thresholds?: unknown;
+            metadata?: { [key: string]: unknown };
             plan?: string;
             quantity?: number;
             tax_rates?: string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -15193,7 +15193,7 @@ export interface operations {
             | "error_if_incomplete"
             | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          pending_invoice_item_interval?: { [key: string]: any };
+          pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -15203,9 +15203,9 @@ export interface operations {
            */
           proration_behavior?: "always_invoice" | "create_prorations" | "none";
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: any };
+          tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: any };
+          trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
           /** Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. */
@@ -15229,7 +15229,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -15262,9 +15262,9 @@ export interface operations {
           /** Either `now` or `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle). */
           billing_cycle_anchor?: "now" | "unchanged";
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: any };
+          billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
-          cancel_at?: { [key: string]: any };
+          cancel_at?: unknown;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
           cancel_at_period_end?: boolean;
           /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
@@ -15283,21 +15283,21 @@ export interface operations {
           expand?: string[];
           /** List of subscription items, each with an attached plan. */
           items?: {
-            billing_thresholds?: { [key: string]: any };
+            billing_thresholds?: unknown;
             clear_usage?: boolean;
             deleted?: boolean;
             id?: string;
-            metadata?: { [key: string]: any };
+            metadata?: unknown;
             plan?: string;
             quantity?: number;
             tax_rates?: string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /** If specified, payment collection for this subscription will be paused. */
-          pause_collection?: { [key: string]: any };
+          pause_collection?: unknown;
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -15310,7 +15310,7 @@ export interface operations {
             | "error_if_incomplete"
             | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          pending_invoice_item_interval?: { [key: string]: any };
+          pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -15324,9 +15324,9 @@ export interface operations {
           /** If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. */
           proration_date?: number;
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: any };
+          tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: any };
+          trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
         };
@@ -15383,7 +15383,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -15425,7 +15425,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -15514,7 +15514,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -15556,7 +15556,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return disputes associated to the charge specified by this charge ID. */
         charge?: string;
         created?: number;
@@ -15594,7 +15594,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         dispute: string;
@@ -15657,7 +15657,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default). */
           submit?: boolean;
         };
@@ -15759,7 +15759,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** Filter events by whether all webhooks were successfully delivered. If false, events which are still pending or have failed all delivery attempts to a webhook endpoint will be returned. */
         delivery_success?: boolean;
@@ -15772,7 +15772,7 @@ export interface operations {
         /** A string containing a specific event name, or group of events using * as a wildcard. The list will be filtered to include only events with a matching event property. */
         type?: string;
         /** An array of up to 20 strings containing specific event names. The list will be filtered to include only events with a matching event property. You may pass either `type` or `types`, but not both. */
-        types?: any[];
+        types?: unknown[];
       };
     };
     responses: {
@@ -15799,7 +15799,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -15821,7 +15821,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is the currency that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with the exchange rate for currency X your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and total number of supported payout currencies, and the default is the max. */
@@ -15854,7 +15854,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         currency: string;
@@ -15876,7 +15876,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -15922,7 +15922,7 @@ export interface operations {
           /** The ID of the file. The file's `purpose` must be one of the following: `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `finance_report_run`, `pci_document`, `sigma_scheduled_query`, or `tax_document_user_upload`. */
           file: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -15942,7 +15942,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         link: string;
@@ -15971,9 +15971,9 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** A future timestamp after which the link will no longer be usable, or `now` to expire the link immediately. */
-          expires_at?: { [key: string]: any };
+          expires_at?: unknown;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -15993,7 +15993,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -16042,7 +16042,7 @@ export interface operations {
           file_link_data?: {
             create: boolean;
             expires_at?: number;
-            metadata?: { [key: string]: any };
+            metadata?: unknown;
           };
           /** The purpose of the uploaded file. Possible values are `additional_verification`, `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`, or `tax_document_user_upload`. */
           purpose:
@@ -16073,7 +16073,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         file: string;
@@ -16095,7 +16095,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** The identifier of the customer whose invoice items to return. If none is provided, all invoice items will be returned. */
         customer?: string;
@@ -16151,7 +16151,7 @@ export interface operations {
           /** The ID of an existing invoice to add this invoice item to. When left blank, the invoice item will be added to the next upcoming scheduled invoice. This is useful when adding invoice items in response to an invoice.created webhook. You can only add invoice items to draft invoices. */
           invoice?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The period associated with this invoice item. */
           period?: {
             end: number;
@@ -16186,7 +16186,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         invoiceitem: string;
@@ -16221,7 +16221,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The period associated with this invoice item. */
           period?: {
             end: number;
@@ -16272,7 +16272,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The collection method of the invoice to retrieve. Either `charge_automatically` or `send_invoice`. */
         collection_method?: string;
         created?: number;
@@ -16346,7 +16346,7 @@ export interface operations {
           /** Footer to be displayed on the invoice. */
           footer?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`. */
           statement_descriptor?: string;
           /** The ID of the subscription to invoice, if any. If not set, the created invoice will include all pending invoice items for the customer. If set, the created invoice will only include pending invoice items for that subscription and pending invoice items not associated with any subscription. The subscription's billing cycle and regular subscription events won't be affected. */
@@ -16378,13 +16378,13 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The code of the coupon to apply. If `subscription` or `subscription_items` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. The invoice can be previewed without a coupon by passing this value as an empty string. */
         coupon?: string;
         /** The identifier of the customer whose upcoming invoice you'd like to retrieve. */
         customer?: string;
         /** List of invoice items to add or update in the upcoming invoice preview. */
-        invoice_items?: any[];
+        invoice_items?: unknown[];
         /** The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields. */
         schedule?: string;
         /** The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If not provided, but a `subscription_items` is provided, you will preview creating a subscription with those items. If neither `subscription` nor `subscription_items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions. */
@@ -16400,7 +16400,7 @@ export interface operations {
         /** If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set. */
         subscription_default_tax_rates?: string;
         /** List of subscription items, each with an attached plan. */
-        subscription_items?: any[];
+        subscription_items?: unknown[];
         /** If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. */
         subscription_prorate?: boolean;
         /**
@@ -16439,7 +16439,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The code of the coupon to apply. If `subscription` or `subscription_items` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. The invoice can be previewed without a coupon by passing this value as an empty string. */
         coupon?: string;
         /** The identifier of the customer whose upcoming invoice you'd like to retrieve. */
@@ -16447,7 +16447,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** List of invoice items to add or update in the upcoming invoice preview. */
-        invoice_items?: any[];
+        invoice_items?: unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields. */
@@ -16467,7 +16467,7 @@ export interface operations {
         /** If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set. */
         subscription_default_tax_rates?: string;
         /** List of subscription items, each with an attached plan. */
-        subscription_items?: any[];
+        subscription_items?: unknown[];
         /** If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. */
         subscription_prorate?: boolean;
         /**
@@ -16515,7 +16515,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         invoice: string;
@@ -16576,11 +16576,11 @@ export interface operations {
           /** Footer to be displayed on the invoice. */
           footer?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`. */
           statement_descriptor?: string;
           /** The percent tax rate applied to the invoice, represented as a non-negative decimal number (with at most four decimal places) between 0 and 100. To unset a previously-set value, pass an empty string. This field can be updated only on `draft` invoices. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: any };
+          tax_percent?: unknown;
         };
       };
     };
@@ -16645,7 +16645,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -16800,7 +16800,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return issuer fraud records for the charge specified by this charge ID. */
         charge?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -16839,7 +16839,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         issuer_fraud_record: string;
@@ -16861,7 +16861,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return issuing transactions that belong to the given card. */
         card?: string;
         /** Only return authorizations belonging to the given cardholder. */
@@ -16902,7 +16902,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         authorization: string;
@@ -16931,7 +16931,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -16960,7 +16960,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -16987,7 +16987,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -17007,7 +17007,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return cardholders that were created during the given date interval. */
         created?: number;
         /** Only return cardholders that have the given email address. */
@@ -17087,7 +17087,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The cardholder's name. This will be printed on cards issued to them. */
           name: string;
           /** The cardholder's phone number. This will be transformed to [E.164](https://en.wikipedia.org/wiki/E.164) if it is not provided in that format already. */
@@ -17999,7 +17999,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         cardholder: string;
@@ -18061,7 +18061,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The cardholder's phone number. */
           phone_number?: string;
           /** Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details. */
@@ -18969,7 +18969,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return cards belonging to the Cardholder with the provided ID. */
         cardholder?: string;
         /** Only return cards that were issued during the given date interval. */
@@ -19024,7 +19024,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The card this is meant to be a replacement for (if any). */
           replacement_for?: string;
           /** If `replacement_for` is specified, this should indicate why that card is being replaced. */
@@ -19949,7 +19949,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         card: string;
@@ -19980,7 +19980,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details. */
           spending_controls?: {
             allowed_categories?: (
@@ -20885,7 +20885,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -20922,7 +20922,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -20942,7 +20942,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         dispute: string;
@@ -20971,7 +20971,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -20991,7 +20991,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return issuing settlements that were created during the given date interval. */
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -21026,7 +21026,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         settlement: string;
@@ -21055,7 +21055,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -21075,7 +21075,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return transactions that belong to the given card. */
         card?: string;
         /** Only return transactions that belong to the given cardholder. */
@@ -21114,7 +21114,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         transaction: string;
@@ -21143,7 +21143,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -21163,7 +21163,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         mandate: string;
@@ -21185,7 +21185,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Date this return was created. */
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -21222,7 +21222,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -21244,7 +21244,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Date this order was created. */
         created?: number;
         /** Only return orders for the given customer. */
@@ -21252,7 +21252,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Only return orders with the given IDs. */
-        ids?: any[];
+        ids?: unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
@@ -21262,7 +21262,7 @@ export interface operations {
         /** Filter orders based on when they were paid, fulfilled, canceled, or returned. */
         status_transitions?: string;
         /** Only return orders with the given upstream order IDs. */
-        upstream_ids?: any[];
+        upstream_ids?: unknown[];
       };
     };
     responses: {
@@ -21310,7 +21310,7 @@ export interface operations {
             type?: "discount" | "shipping" | "sku" | "tax";
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** Shipping address for the order. Required if any of the SKUs are for products that have `shippable` set to true. */
           shipping?: {
             address: {
@@ -21343,7 +21343,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -21374,7 +21374,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The shipping method to select for fulfilling this order. If specified, must be one of the `id`s of a shipping method in the `shipping_methods` array. If specified, will overwrite the existing selected shipping method, updating `items` as necessary. */
           selected_shipping_method?: string;
           /** Tracking information once the order has been fulfilled. */
@@ -21416,7 +21416,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** A [Token](https://stripe.com/docs/api#tokens)'s or a [Source](https://stripe.com/docs/api#sources)'s ID, as returned by [Elements](https://stripe.com/docs/elements). If no customer was attached to the order at creation, either `source` or `customer` is required. Otherwise, the specified source will be charged intead of the customer attached to the order. */
           source?: string;
         };
@@ -21471,7 +21471,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         created?: number;
         /** Only return PaymentIntents for the customer specified by this customer ID. */
@@ -21555,7 +21555,7 @@ export interface operations {
           mandate_data?: {
             customer_acceptance: {
               accepted_at?: number;
-              offline?: { [key: string]: any };
+              offline?: { [key: string]: unknown };
               online?: {
                 ip_address: string;
                 user_agent: string;
@@ -21564,9 +21564,9 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** Set to `true` to indicate that the customer is not in your checkout flow during this payment attempt, and therefore is unable to authenticate. This parameter is intended for scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards). This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm). */
-          off_session?: { [key: string]: any };
+          off_session?: unknown;
           /** The Stripe account ID for which these funds are intended. For details, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts). */
           on_behalf_of?: string;
           /**
@@ -21577,7 +21577,7 @@ export interface operations {
           payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           payment_method_options?: {
-            card?: { [key: string]: any };
+            card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. If this is not provided, defaults to ["card"]. */
           payment_method_types?: string[];
@@ -21649,7 +21649,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The client secret of the PaymentIntent. Required if a publishable key is used to retrieve the source. */
         client_secret?: string;
       };
@@ -21688,7 +21688,7 @@ export interface operations {
           /** Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
           amount?: number;
           /** The amount of the application fee (if any) for the resulting payment. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
-          application_fee_amount?: { [key: string]: any };
+          application_fee_amount?: unknown;
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           currency?: string;
           /**
@@ -21704,12 +21704,12 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           payment_method_options?: {
-            card?: { [key: string]: any };
+            card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
           payment_method_types?: string[];
@@ -21726,7 +21726,7 @@ export interface operations {
            */
           setup_future_usage?: "" | "off_session" | "on_session";
           /** Shipping information for this PaymentIntent. */
-          shipping?: { [key: string]: any };
+          shipping?: unknown;
           /** For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
           statement_descriptor?: string;
           /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
@@ -21883,7 +21883,7 @@ export interface operations {
           mandate_data?: {
             customer_acceptance: {
               accepted_at?: number;
-              offline?: { [key: string]: any };
+              offline?: { [key: string]: unknown };
               online?: {
                 ip_address: string;
                 user_agent: string;
@@ -21892,12 +21892,12 @@ export interface operations {
             };
           };
           /** Set to `true` to indicate that the customer is not in your checkout flow during this payment attempt, and therefore is unable to authenticate. This parameter is intended for scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards). */
-          off_session?: { [key: string]: any };
+          off_session?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           payment_method_options?: {
-            card?: { [key: string]: any };
+            card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
           payment_method_types?: string[];
@@ -21920,7 +21920,7 @@ export interface operations {
            */
           setup_future_usage?: "" | "off_session" | "on_session";
           /** Shipping information for this PaymentIntent. */
-          shipping?: { [key: string]: any };
+          shipping?: unknown;
           /** Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle additional authentication steps. */
           use_stripe_sdk?: boolean;
         };
@@ -21942,7 +21942,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The ID of the customer whose PaymentMethods will be retrieved. */
         customer: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -22000,7 +22000,7 @@ export interface operations {
             phone?: string;
           };
           /** If this is a `card` PaymentMethod, this hash contains the user's card details. For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`. When creating with a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance). We strongly recommend using Stripe.js instead of interacting with this API directly. */
-          card?: { [key: string]: any };
+          card?: { [key: string]: unknown };
           /** The `Customer` to whom the original PaymentMethod is attached. */
           customer?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -22046,7 +22046,7 @@ export interface operations {
               | "van_lanschot";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The PaymentMethod to share. */
           payment_method?: string;
           /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
@@ -22074,7 +22074,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         payment_method: string;
@@ -22122,9 +22122,9 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
-          sepa_debit?: { [key: string]: any };
+          sepa_debit?: { [key: string]: unknown };
         };
       };
     };
@@ -22208,7 +22208,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         arrival_date?: number;
         created?: number;
         /** The ID of an external account - only return payouts sent to this external account. */
@@ -22265,7 +22265,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The method used to send this payout, which can be `standard` or `instant`. `instant` is only supported for payouts to debit cards. (See [Instant payouts for marketplaces for more information](https://stripe.com/blog/instant-payouts-for-marketplaces).) */
           method?: "instant" | "standard";
           /** The balance type of your Stripe balance to draw this payout from. Balances for different payment sources are kept separately. You can find the amounts with the balances API. One of `bank_account`, `card`, or `fpx`. */
@@ -22291,7 +22291,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         payout: string;
@@ -22320,7 +22320,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -22365,7 +22365,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return plans that are active or inactive (e.g., pass `false` to list all inactive plans). */
         active?: boolean;
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
@@ -22426,14 +22426,14 @@ export interface operations {
           /** The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). */
           interval_count?: number;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A brief description of the plan, hidden from customers. */
           nickname?: string;
           /** The product whose pricing the created plan will represent. This can either be the ID of an existing product, or a dictionary containing fields used to create a [service product](https://stripe.com/docs/api#product_object-type). */
           product?: {
             active?: boolean;
             id?: string;
-            metadata?: { [key: string]: any };
+            metadata?: { [key: string]: unknown };
             name: string;
             statement_descriptor?: string;
             unit_label?: string;
@@ -22444,7 +22444,7 @@ export interface operations {
             flat_amount_decimal?: string;
             unit_amount?: number;
             unit_amount_decimal?: string;
-            up_to: { [key: string]: any };
+            up_to: unknown;
           }[];
           /** Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows. */
           tiers_mode?: "graduated" | "volume";
@@ -22476,7 +22476,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         plan: string;
@@ -22507,7 +22507,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A brief description of the plan, hidden from customers. */
           nickname?: string;
           /** The product the plan belongs to. Note that after updating, statement descriptors and line items of the plan in active subscriptions will be affected. */
@@ -22551,7 +22551,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return products that are active or inactive (e.g., pass `false` to list all inactive products). */
         active?: boolean;
         /** Only return products that were created during the given date interval. */
@@ -22559,7 +22559,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Only return products with the given IDs. */
-        ids?: any[];
+        ids?: unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** Only return products that can be shipped (i.e., physical, not digital products). */
@@ -22614,7 +22614,7 @@ export interface operations {
           /** A list of up to 8 URLs of images for this product, meant to be displayable to the customer. */
           images?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions. */
           name: string;
           /** The dimensions of this product for shipping purposes. A SKU associated with this product can override this value by having its own `package_dimensions`. May only be set if type=`good`. */
@@ -22658,7 +22658,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -22699,11 +22699,11 @@ export interface operations {
           /** A list of up to 8 URLs of images for this product, meant to be displayable to the customer. */
           images?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions. */
           name?: string;
           /** The dimensions of this product for shipping purposes. A SKU associated with this product can override this value by having its own `package_dimensions`. May only be set if `type=good`. */
-          package_dimensions?: { [key: string]: any };
+          package_dimensions?: unknown;
           /** Whether this product is shipped (i.e., physical goods). Defaults to `true`. May only be set if `type=good`. */
           shippable?: boolean;
           /**
@@ -22754,7 +22754,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return early fraud warnings for the charge specified by this charge ID. */
         charge?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -22793,7 +22793,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         early_fraud_warning: string;
@@ -22815,7 +22815,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -22879,7 +22879,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         item: string;
@@ -22919,7 +22919,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The alias used to reference the value list when writing rules. */
         alias?: string;
         /** A value contained within a value list - returns all value lists containing this value. */
@@ -22972,7 +22972,7 @@ export interface operations {
             | "ip_address"
             | "string";
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The human-readable name of the value list. */
           name: string;
         };
@@ -22994,7 +22994,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         value_list: string;
@@ -23025,7 +23025,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The human-readable name of the value list. */
           name?: string;
         };
@@ -23065,7 +23065,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -23117,7 +23117,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The recipient's full, legal name. For type `individual`, should be in the format `First Last`, `First Middle Last`, or `First M Last` (no prefixes or suffixes). For `corporation`, the full, incorporated name. */
           name: string;
           /** The recipient's tax ID, as a string. For type `individual`, the full SSN; for type `corporation`, the full EIN. */
@@ -23143,7 +23143,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -23188,7 +23188,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The recipient's full, legal name. For type `individual`, should be in the format `First Last`, `First Middle Last`, or `First M Last` (no prefixes or suffixes). For `corporation`, the full, incorporated name. */
           name?: string;
           /** The recipient's tax ID, as a string. For type `individual`, the full SSN; for type `corporation`, the full EIN. */
@@ -23230,7 +23230,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return refunds for the charge specified by this charge ID. */
         charge?: string;
         created?: number;
@@ -23274,7 +23274,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           payment_intent?: string;
           reason?: "duplicate" | "fraudulent" | "requested_by_customer";
           refund_application_fee?: boolean;
@@ -23298,7 +23298,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         refund: string;
@@ -23331,7 +23331,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -23351,7 +23351,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -24045,7 +24045,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         report_run: string;
@@ -24067,7 +24067,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
     };
     responses: {
@@ -24094,7 +24094,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         report_type: string;
@@ -24116,7 +24116,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -24150,7 +24150,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         review: string;
@@ -24197,7 +24197,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         created?: number;
         /** Only return SetupIntents for the customer specified by this customer ID. */
@@ -24258,7 +24258,7 @@ export interface operations {
           mandate_data?: {
             customer_acceptance: {
               accepted_at?: number;
-              offline?: { [key: string]: any };
+              offline?: { [key: string]: unknown };
               online?: {
                 ip_address: string;
                 user_agent: string;
@@ -24267,7 +24267,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The Stripe account ID for which this SetupIntent is created. */
           on_behalf_of?: string;
           /** ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent. */
@@ -24314,7 +24314,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The client secret of the SetupIntent. Required if a publishable key is used to retrieve the SetupIntent. */
         client_secret?: string;
       };
@@ -24353,7 +24353,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this SetupIntent. */
@@ -24443,7 +24443,7 @@ export interface operations {
           mandate_data?: {
             customer_acceptance: {
               accepted_at?: number;
-              offline?: { [key: string]: any };
+              offline?: { [key: string]: unknown };
               online?: {
                 ip_address: string;
                 user_agent: string;
@@ -24484,7 +24484,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24517,7 +24517,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         scheduled_query_run: string;
@@ -24539,7 +24539,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return SKUs that are active or inactive (e.g., pass `false` to list all inactive products). */
         active?: boolean;
         /** Only return SKUs that have the specified key-value pairs in this partially constructed dictionary. Can be specified only if `product` is also supplied. For instance, if the associated product has attributes `["color", "size"]`, passing in `attributes[color]=red` returns all the SKUs for this product that have `color` set to `red`. */
@@ -24547,7 +24547,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Only return SKUs with the given IDs. */
-        ids?: any[];
+        ids?: unknown[];
         /** Only return SKUs that are either in stock or out of stock (e.g., pass `false` to list all SKUs that are out of stock). If no value is provided, all SKUs are returned. */
         in_stock?: boolean;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24586,7 +24586,7 @@ export interface operations {
           /** Whether the SKU is available for purchase. Default to `true`. */
           active?: boolean;
           /** A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`. */
-          attributes?: { [key: string]: any };
+          attributes?: { [key: string]: unknown };
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           currency: string;
           /** Specifies which fields in the response should be expanded. */
@@ -24602,7 +24602,7 @@ export interface operations {
             value?: "" | "in_stock" | "limited" | "out_of_stock";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The dimensions of this SKU for shipping purposes. */
           package_dimensions?: {
             height: number;
@@ -24633,7 +24633,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -24666,7 +24666,7 @@ export interface operations {
           /** Whether this SKU is available for purchase. */
           active?: boolean;
           /** A dictionary of attributes and values for the attributes defined by the product. When specified, `attributes` will partially update the existing attributes dictionary on the product, with the postcondition that a value must be present for each attribute key on the product. */
-          attributes?: { [key: string]: any };
+          attributes?: { [key: string]: unknown };
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           currency?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -24680,9 +24680,9 @@ export interface operations {
             value?: "" | "in_stock" | "limited" | "out_of_stock";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The dimensions of this SKU for shipping purposes. */
-          package_dimensions?: { [key: string]: any };
+          package_dimensions?: unknown;
           /** The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency). */
           price?: number;
           /** The ID of the product that this SKU should belong to. The product must exist, have the same set of attribute names as the SKU's current product, and be of type `good`. */
@@ -24752,7 +24752,7 @@ export interface operations {
               type?: "offline" | "online";
               user_agent?: string;
             };
-            amount?: { [key: string]: any };
+            amount?: unknown;
             currency?: string;
             interval?: "one_time" | "scheduled" | "variable";
             notification_method?:
@@ -24763,7 +24763,7 @@ export interface operations {
               | "stripe_email";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** The source to share. */
           original_source?: string;
           /** Information about the owner of the payment instrument that may be used or required by particular source types. */
@@ -24840,7 +24840,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The client secret of the source. Required if a publishable key is used to retrieve the source. */
         client_secret?: string;
       };
@@ -24893,7 +24893,7 @@ export interface operations {
               type?: "offline" | "online";
               user_agent?: string;
             };
-            amount?: { [key: string]: any };
+            amount?: unknown;
             currency?: string;
             interval?: "one_time" | "scheduled" | "variable";
             notification_method?:
@@ -24904,7 +24904,7 @@ export interface operations {
               | "stripe_email";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Information about the owner of the payment instrument that may be used or required by particular source types. */
           owner?: {
             address?: {
@@ -24963,7 +24963,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         mandate_notification: string;
@@ -24986,7 +24986,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -25022,7 +25022,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         source: string;
@@ -25072,7 +25072,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -25109,11 +25109,11 @@ export interface operations {
         /** Body parameters for the request. */
         payload: {
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: any };
+          billing_thresholds?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -25164,7 +25164,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         item: string;
@@ -25191,11 +25191,11 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: any };
+          billing_thresholds?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -25287,7 +25287,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -25362,7 +25362,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return subscription schedules that were created canceled the given date interval. */
         canceled_at?: number;
         /** Only return subscription schedules that completed during the given date interval. */
@@ -25412,7 +25412,7 @@ export interface operations {
           customer?: string;
           /** Object representing the subscription schedule's default settings. */
           default_settings?: {
-            billing_thresholds?: { [key: string]: any };
+            billing_thresholds?: unknown;
             collection_method?: "charge_automatically" | "send_invoice";
             default_payment_method?: string;
             invoice_settings?: {
@@ -25426,11 +25426,11 @@ export interface operations {
           /** Migrate an existing subscription to be managed by a subscription schedule. If this parameter is set, a subscription schedule will be created using the subscription's plan(s), set to auto-renew using the subscription's interval. When using this parameter, other parameters (such as phase values) cannot be set. To create a subscription schedule with other modifications, we recommend making two separate API calls. */
           from_subscription?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. */
           phases?: {
             application_fee_percent?: number;
-            billing_thresholds?: { [key: string]: any };
+            billing_thresholds?: unknown;
             collection_method?: "charge_automatically" | "send_invoice";
             coupon?: string;
             default_payment_method?: string;
@@ -25441,7 +25441,7 @@ export interface operations {
             };
             iterations?: number;
             plans: {
-              billing_thresholds?: { [key: string]: any };
+              billing_thresholds?: unknown;
               plan?: string;
               quantity?: number;
               tax_rates?: string[];
@@ -25455,7 +25455,7 @@ export interface operations {
             trial_end?: number;
           }[];
           /** When the subscription schedule starts. We recommend using `now` so that it starts the subscription immediately. You can also use a Unix timestamp to backdate the subscription so that it starts on a past date, or set a future date for the subscription to start on. */
-          start_date?: { [key: string]: any };
+          start_date?: unknown;
         };
       };
     };
@@ -25475,7 +25475,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         schedule: string;
@@ -25503,7 +25503,7 @@ export interface operations {
         payload?: {
           /** Object representing the subscription schedule's default settings. */
           default_settings?: {
-            billing_thresholds?: { [key: string]: any };
+            billing_thresholds?: unknown;
             collection_method?: "charge_automatically" | "send_invoice";
             default_payment_method?: string;
             invoice_settings?: {
@@ -25515,22 +25515,22 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. Note that past phases can be omitted. */
           phases?: {
             application_fee_percent?: number;
-            billing_thresholds?: { [key: string]: any };
+            billing_thresholds?: unknown;
             collection_method?: "charge_automatically" | "send_invoice";
             coupon?: string;
             default_payment_method?: string;
             default_tax_rates?: string[];
-            end_date?: { [key: string]: any };
+            end_date?: unknown;
             invoice_settings?: {
               days_until_due?: number;
             };
             iterations?: number;
             plans: {
-              billing_thresholds?: { [key: string]: any };
+              billing_thresholds?: unknown;
               plan?: string;
               quantity?: number;
               tax_rates?: string[];
@@ -25539,10 +25539,10 @@ export interface operations {
               | "always_invoice"
               | "create_prorations"
               | "none";
-            start_date?: { [key: string]: any };
+            start_date?: unknown;
             tax_percent?: number;
             trial?: boolean;
-            trial_end?: { [key: string]: any };
+            trial_end?: unknown;
           }[];
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
@@ -25623,7 +25623,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The collection method of the subscriptions to retrieve. Either `charge_automatically` or `send_invoice`. */
         collection_method?: string;
         created?: number;
@@ -25675,7 +25675,7 @@ export interface operations {
           /** A future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. */
           billing_cycle_anchor?: number;
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: any };
+          billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
           cancel_at?: number;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
@@ -25698,14 +25698,14 @@ export interface operations {
           expand?: string[];
           /** A list of up to 20 subscription items, each with an attached plan. */
           items?: {
-            billing_thresholds?: { [key: string]: any };
-            metadata?: { [key: string]: any };
+            billing_thresholds?: unknown;
+            metadata?: { [key: string]: unknown };
             plan?: string;
             quantity?: number;
             tax_rates?: string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -25720,7 +25720,7 @@ export interface operations {
             | "error_if_incomplete"
             | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          pending_invoice_item_interval?: { [key: string]: any };
+          pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -25730,9 +25730,9 @@ export interface operations {
            */
           proration_behavior?: "always_invoice" | "create_prorations" | "none";
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: any };
+          tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: any };
+          trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
           /** Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. */
@@ -25756,7 +25756,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         subscription_exposed_id: string;
@@ -25787,9 +25787,9 @@ export interface operations {
           /** Either `now` or `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle). */
           billing_cycle_anchor?: "now" | "unchanged";
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: any };
+          billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
-          cancel_at?: { [key: string]: any };
+          cancel_at?: unknown;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
           cancel_at_period_end?: boolean;
           /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
@@ -25808,21 +25808,21 @@ export interface operations {
           expand?: string[];
           /** List of subscription items, each with an attached plan. */
           items?: {
-            billing_thresholds?: { [key: string]: any };
+            billing_thresholds?: unknown;
             clear_usage?: boolean;
             deleted?: boolean;
             id?: string;
-            metadata?: { [key: string]: any };
+            metadata?: unknown;
             plan?: string;
             quantity?: number;
             tax_rates?: string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /** If specified, payment collection for this subscription will be paused. */
-          pause_collection?: { [key: string]: any };
+          pause_collection?: unknown;
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -25835,7 +25835,7 @@ export interface operations {
             | "error_if_incomplete"
             | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          pending_invoice_item_interval?: { [key: string]: any };
+          pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -25849,9 +25849,9 @@ export interface operations {
           /** If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. */
           proration_date?: number;
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: any };
+          tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: any };
+          trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
         };
@@ -25926,7 +25926,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Optional flag to filter by tax rates that are either active or not active (archived) */
         active?: boolean;
         /** Optional range for filtering created date */
@@ -25979,7 +25979,7 @@ export interface operations {
           /** The jurisdiction for the tax rate. */
           jurisdiction?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** This represents the tax rate percent out of 100. */
           percentage: number;
         };
@@ -26001,7 +26001,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         tax_rate: string;
@@ -26038,7 +26038,7 @@ export interface operations {
           /** The jurisdiction for the tax rate. */
           jurisdiction?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -26082,7 +26082,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -26130,7 +26130,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -26150,7 +26150,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         location: string;
@@ -26190,7 +26190,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -26228,7 +26228,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Filters readers by device type */
         device_type?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -26276,7 +26276,7 @@ export interface operations {
           /** The location to assign the reader to. If no location is specified, the reader will be assigned to the account's default location. */
           location?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** A code generated by the reader used for registering to an account. */
           registration_code: string;
         };
@@ -26298,7 +26298,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         reader: string;
@@ -26329,7 +26329,7 @@ export interface operations {
           /** The new label of the reader. */
           label?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -26466,7 +26466,7 @@ export interface operations {
                 state?: string;
                 town?: string;
               };
-              dob?: { [key: string]: any };
+              dob?: unknown;
               email?: string;
               first_name?: string;
               first_name_kana?: string;
@@ -26477,7 +26477,7 @@ export interface operations {
               last_name_kana?: string;
               last_name_kanji?: string;
               maiden_name?: string;
-              metadata?: { [key: string]: any };
+              metadata?: unknown;
               phone?: string;
               ssn_last_4?: string;
               verification?: {
@@ -26502,7 +26502,7 @@ export interface operations {
             currency?: string;
             routing_number?: string;
           };
-          card?: { [key: string]: any };
+          card?: unknown;
           /** The customer (owned by the application's account) for which to create a token. This can be used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods). */
           customer?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -26535,7 +26535,7 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: { [key: string]: any };
+            dob?: unknown;
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -26546,13 +26546,13 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: { [key: string]: any };
+            metadata?: unknown;
             phone?: string;
             relationship?: {
               director?: boolean;
               executive?: boolean;
               owner?: boolean;
-              percent_ownership?: { [key: string]: any };
+              percent_ownership?: unknown;
               representative?: boolean;
               title?: string;
             };
@@ -26591,7 +26591,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         token: string;
@@ -26613,7 +26613,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A positive integer representing how much to transfer. */
         amount?: number;
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
@@ -26662,7 +26662,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The ID of a source to transfer funds from. For most users, this should be left unspecified which will use the bank account that was set up in the dashboard for the specified currency. In test mode, this can be a test bank token (see [Testing Top-ups](https://stripe.com/docs/connect/testing#testing-top-ups)). */
           source?: string;
           /** Extra information about a top-up for the source's bank statement. Limited to 15 ASCII characters. */
@@ -26688,7 +26688,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         topup: string;
@@ -26719,7 +26719,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -26764,7 +26764,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** Only return transfers for the destination specified by this account ID. */
         destination?: string;
@@ -26815,7 +26815,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: { [key: string]: unknown };
           /** You can use this parameter to transfer funds from a charge before they are added to your available balance. A pending balance will transfer immediately but the funds will not become available until the original charge becomes available. [See the Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-availability) for details. */
           source_transaction?: string;
           /** The source balance to use for this transfer. One of `bank_account`, `card`, or `fpx`. For most users, this will default to `card`. */
@@ -26841,7 +26841,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -26895,7 +26895,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** Boolean indicating whether the application fee should be refunded when reversing this transfer. If a full transfer reversal is given, the full application fee will be refunded. Otherwise, the application fee will be refunded with an amount proportional to the amount of the transfer reversed. */
           refund_application_fee?: boolean;
         };
@@ -26917,7 +26917,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         transfer: string;
@@ -26952,7 +26952,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -26972,7 +26972,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -27007,7 +27007,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
         };
       };
     };
@@ -27027,7 +27027,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -27317,7 +27317,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The URL of the webhook endpoint. */
           url: string;
         };
@@ -27339,7 +27339,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         webhook_endpoint: string;
@@ -27524,7 +27524,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: any };
+          metadata?: unknown;
           /** The URL of the webhook endpoint. */
           url?: string;
         };

--- a/examples/stripe-openapi3.ts
+++ b/examples/stripe-openapi3.ts
@@ -2237,7 +2237,7 @@ export interface components {
       /** If the card number is tokenized, this is the method that was used. Can be `amex_express_checkout`, `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null. */
       tokenization_method?: string | null;
     };
-    card_mandate_payment_method_details: { [key: string]: any };
+    card_mandate_payment_method_details: { [key: string]: unknown };
     /**
      * To charge a credit or a debit card, you create a `Charge` object. You can
      * retrieve and refund individual charges as well as list all charges. Charges
@@ -6153,7 +6153,7 @@ export interface components {
       /** The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. */
       front?: (Partial<string> & Partial<components["schemas"]["file"]>) | null;
     };
-    light_account_logout: { [key: string]: any };
+    light_account_logout: { [key: string]: unknown };
     line_item: {
       /** The amount, in %s. */
       amount: number;
@@ -6223,7 +6223,7 @@ export interface components {
       /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
       url: string;
     };
-    mandate_multi_use: { [key: string]: any };
+    mandate_multi_use: { [key: string]: unknown };
     mandate_payment_method_details: {
       au_becs_debit?: components["schemas"]["mandate_au_becs_debit"];
       card?: components["schemas"]["card_mandate_payment_method_details"];
@@ -6245,9 +6245,9 @@ export interface components {
     };
     notification_event_data: {
       /** Object containing the API resource relevant to the event. For example, an `invoice.created` event will have a full [invoice object](https://stripe.com/docs/api#invoice_object) as the value of the object key. */
-      object: { [key: string]: any };
+      object: { [key: string]: unknown };
       /** Object containing the names of the attributes that have changed, and their previous values (sent along only with *.updated events). */
-      previous_attributes?: { [key: string]: any };
+      previous_attributes?: { [key: string]: unknown };
     };
     notification_event_request: {
       /** ID of the API request that caused the event. If null, the event was automatic (e.g., Stripe's automatic subscription handling). Request logs are available in the [dashboard](https://dashboard.stripe.com/logs), but currently not in the API. */
@@ -6255,7 +6255,7 @@ export interface components {
       /** The idempotency key transmitted during the request, if any. *Note: This property is populated only for events on or after May 23, 2017*. */
       idempotency_key?: string | null;
     };
-    offline_acceptance: { [key: string]: any };
+    offline_acceptance: { [key: string]: unknown };
     online_acceptance: {
       /** The IP address from which the Mandate was accepted by the customer. */
       ip_address?: string | null;
@@ -6547,7 +6547,7 @@ export interface components {
       /** Type of the next action to perform, one of `redirect_to_url` or `use_stripe_sdk`. */
       type: string;
       /** When confirming a PaymentIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js. */
-      use_stripe_sdk?: { [key: string]: any };
+      use_stripe_sdk?: { [key: string]: unknown };
     };
     payment_intent_next_action_redirect_to_url: {
       /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
@@ -6658,7 +6658,7 @@ export interface components {
         components["schemas"]["payment_method_details"]
       > | null;
     };
-    payment_method_card_present: { [key: string]: any };
+    payment_method_card_present: { [key: string]: unknown };
     payment_method_card_wallet: {
       amex_express_checkout?: components["schemas"]["payment_method_card_wallet_amex_express_checkout"];
       apple_pay?: components["schemas"]["payment_method_card_wallet_apple_pay"];
@@ -6677,9 +6677,11 @@ export interface components {
         | "visa_checkout";
       visa_checkout?: components["schemas"]["payment_method_card_wallet_visa_checkout"];
     };
-    payment_method_card_wallet_amex_express_checkout: { [key: string]: any };
-    payment_method_card_wallet_apple_pay: { [key: string]: any };
-    payment_method_card_wallet_google_pay: { [key: string]: any };
+    payment_method_card_wallet_amex_express_checkout: {
+      [key: string]: unknown;
+    };
+    payment_method_card_wallet_apple_pay: { [key: string]: unknown };
+    payment_method_card_wallet_google_pay: { [key: string]: unknown };
     payment_method_card_wallet_masterpass: {
       /** Owner's verified billing address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       billing_address?: Partial<components["schemas"]["address"]> | null;
@@ -6690,7 +6692,7 @@ export interface components {
       /** Owner's verified shipping address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       shipping_address?: Partial<components["schemas"]["address"]> | null;
     };
-    payment_method_card_wallet_samsung_pay: { [key: string]: any };
+    payment_method_card_wallet_samsung_pay: { [key: string]: unknown };
     payment_method_card_wallet_visa_checkout: {
       /** Owner's verified billing address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       billing_address?: Partial<components["schemas"]["address"]> | null;
@@ -6751,7 +6753,7 @@ export interface components {
       /** Routing transit number of the bank account. */
       routing_number?: string | null;
     };
-    payment_method_details_alipay: { [key: string]: any };
+    payment_method_details_alipay: { [key: string]: unknown };
     payment_method_details_au_becs_debit: {
       /** Bank-State-Branch number of the bank account. */
       bsb_number?: string | null;
@@ -6912,10 +6914,10 @@ export interface components {
       visa_checkout?: components["schemas"]["payment_method_details_card_wallet_visa_checkout"];
     };
     payment_method_details_card_wallet_amex_express_checkout: {
-      [key: string]: any;
+      [key: string]: unknown;
     };
-    payment_method_details_card_wallet_apple_pay: { [key: string]: any };
-    payment_method_details_card_wallet_google_pay: { [key: string]: any };
+    payment_method_details_card_wallet_apple_pay: { [key: string]: unknown };
+    payment_method_details_card_wallet_google_pay: { [key: string]: unknown };
     payment_method_details_card_wallet_masterpass: {
       /** Owner's verified billing address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       billing_address?: Partial<components["schemas"]["address"]> | null;
@@ -6926,7 +6928,7 @@ export interface components {
       /** Owner's verified shipping address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       shipping_address?: Partial<components["schemas"]["address"]> | null;
     };
-    payment_method_details_card_wallet_samsung_pay: { [key: string]: any };
+    payment_method_details_card_wallet_samsung_pay: { [key: string]: unknown };
     payment_method_details_card_wallet_visa_checkout: {
       /** Owner's verified billing address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       billing_address?: Partial<components["schemas"]["address"]> | null;
@@ -7026,7 +7028,7 @@ export interface components {
        */
       verified_name?: string | null;
     };
-    payment_method_details_klarna: { [key: string]: any };
+    payment_method_details_klarna: { [key: string]: unknown };
     payment_method_details_multibanco: {
       /** Entity number associated with this Multibanco payment. */
       entity?: string | null;
@@ -7073,8 +7075,8 @@ export interface components {
        */
       verified_name?: string | null;
     };
-    payment_method_details_stripe_account: { [key: string]: any };
-    payment_method_details_wechat: { [key: string]: any };
+    payment_method_details_stripe_account: { [key: string]: unknown };
+    payment_method_details_wechat: { [key: string]: unknown };
     payment_method_fpx: {
       /** The customer's bank, if provided. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, or `pb_enterprise`. */
       bank:
@@ -8175,7 +8177,7 @@ export interface components {
       /** Type of the next action to perform, one of `redirect_to_url` or `use_stripe_sdk`. */
       type: string;
       /** When confirming a SetupIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js. */
-      use_stripe_sdk?: { [key: string]: any };
+      use_stripe_sdk?: { [key: string]: unknown };
     };
     setup_intent_next_action_redirect_to_url: {
       /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
@@ -9605,7 +9607,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -9633,7 +9635,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -9976,7 +9978,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10062,7 +10064,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10098,7 +10100,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10129,7 +10131,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10205,7 +10207,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10278,7 +10280,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10364,7 +10366,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10475,7 +10477,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10616,7 +10618,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10758,7 +10760,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10807,7 +10809,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -10948,7 +10950,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -11090,7 +11092,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -11174,7 +11176,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -11451,7 +11453,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -11729,7 +11731,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -11808,7 +11810,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -11896,7 +11898,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -11935,7 +11937,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -11967,7 +11969,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12047,7 +12049,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12126,7 +12128,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12214,7 +12216,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12336,7 +12338,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12482,7 +12484,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12625,7 +12627,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12677,7 +12679,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12823,7 +12825,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -12966,7 +12968,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13045,7 +13047,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13102,7 +13104,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13129,7 +13131,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13180,7 +13182,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13212,7 +13214,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13280,7 +13282,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13357,7 +13359,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13432,7 +13434,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13500,7 +13502,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13535,7 +13537,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13603,7 +13605,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13638,7 +13640,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13715,7 +13717,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13746,7 +13748,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13794,7 +13796,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13840,7 +13842,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -13895,7 +13897,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -14020,7 +14022,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -14162,7 +14164,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -14349,7 +14351,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -14418,7 +14420,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -14496,7 +14498,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -14926,7 +14928,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -14968,7 +14970,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -14999,7 +15001,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15049,7 +15051,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15129,7 +15131,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15190,7 +15192,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15236,7 +15238,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15370,7 +15372,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15446,7 +15448,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15492,7 +15494,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15523,7 +15525,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15638,7 +15640,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15782,7 +15784,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15945,7 +15947,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -15991,7 +15993,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16061,7 +16063,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16142,7 +16144,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16244,7 +16246,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16428,7 +16430,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16530,7 +16532,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16662,7 +16664,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16689,7 +16691,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16741,7 +16743,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -16843,7 +16845,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17024,7 +17026,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17162,7 +17164,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17350,7 +17352,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17378,7 +17380,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17424,7 +17426,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17513,7 +17515,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17541,7 +17543,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17594,7 +17596,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17625,7 +17627,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17841,7 +17843,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17872,7 +17874,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17914,7 +17916,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17945,7 +17947,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -17998,7 +18000,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18060,7 +18062,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18155,7 +18157,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18233,7 +18235,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18288,7 +18290,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18373,7 +18375,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18451,7 +18453,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18515,7 +18517,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18685,7 +18687,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18801,7 +18803,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18832,7 +18834,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -18930,7 +18932,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -19008,7 +19010,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -19190,7 +19192,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -19225,7 +19227,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -19281,7 +19283,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -19312,7 +19314,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -19468,7 +19470,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -20451,7 +20453,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -21466,7 +21468,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -22433,7 +22435,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23394,7 +23396,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23452,7 +23454,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23534,7 +23536,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23565,7 +23567,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23651,7 +23653,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23682,7 +23684,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23745,7 +23747,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23797,7 +23799,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23828,7 +23830,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -23917,7 +23919,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -24005,7 +24007,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -24181,7 +24183,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -24250,7 +24252,7 @@ export interface operations {
           mandate_data?: {
             customer_acceptance: {
               accepted_at?: number;
-              offline?: { [key: string]: any };
+              offline?: { [key: string]: unknown };
               online?: {
                 ip_address: string;
                 user_agent: string;
@@ -24370,7 +24372,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -24645,7 +24647,7 @@ export interface operations {
           mandate_data?: Partial<{
             customer_acceptance: {
               accepted_at?: number;
-              offline?: { [key: string]: any };
+              offline?: { [key: string]: unknown };
               online?: {
                 ip_address: string;
                 user_agent: string;
@@ -24772,7 +24774,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -24909,7 +24911,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -24961,7 +24963,7 @@ export interface operations {
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: Partial<{ [key: string]: string }> & Partial<"">;
           /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
-          sepa_debit?: { [key: string]: any };
+          sepa_debit?: { [key: string]: unknown };
         };
       };
     };
@@ -25096,7 +25098,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25174,7 +25176,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25290,7 +25292,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25396,7 +25398,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25463,7 +25465,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25523,7 +25525,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25619,7 +25621,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25713,7 +25715,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25757,7 +25759,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25792,7 +25794,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25845,7 +25847,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25905,7 +25907,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25932,7 +25934,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -25985,7 +25987,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -26056,7 +26058,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -26119,7 +26121,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -26171,7 +26173,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -26247,7 +26249,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -26326,7 +26328,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -26379,7 +26381,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -26443,7 +26445,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -26528,7 +26530,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27222,7 +27224,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27258,7 +27260,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27289,7 +27291,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27338,7 +27340,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27369,7 +27371,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27453,7 +27455,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27497,7 +27499,7 @@ export interface operations {
           mandate_data?: {
             customer_acceptance: {
               accepted_at?: number;
-              offline?: { [key: string]: any };
+              offline?: { [key: string]: unknown };
               online?: {
                 ip_address: string;
                 user_agent: string;
@@ -27567,7 +27569,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27706,7 +27708,7 @@ export interface operations {
           mandate_data?: Partial<{
             customer_acceptance: {
               accepted_at?: number;
-              offline?: { [key: string]: any };
+              offline?: { [key: string]: unknown };
               online?: {
                 ip_address: string;
                 user_agent: string;
@@ -27779,7 +27781,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27810,7 +27812,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27862,7 +27864,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -27948,7 +27950,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28037,7 +28039,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28187,7 +28189,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28323,7 +28325,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28368,7 +28370,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28400,7 +28402,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28476,7 +28478,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28570,7 +28572,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28729,7 +28731,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28851,7 +28853,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -28964,7 +28966,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29196,7 +29198,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29330,7 +29332,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29512,7 +29514,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29566,7 +29568,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29636,7 +29638,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29745,7 +29747,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29814,7 +29816,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29884,7 +29886,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29933,7 +29935,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -29997,7 +29999,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30058,7 +30060,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30340,7 +30342,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30400,7 +30402,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30470,7 +30472,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30588,7 +30590,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30675,7 +30677,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30750,7 +30752,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30820,7 +30822,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -30899,7 +30901,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -31212,7 +31214,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };
@@ -31429,7 +31431,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/x-www-form-urlencoded": { [key: string]: any };
+        "application/x-www-form-urlencoded": { [key: string]: unknown };
       };
     };
   };

--- a/src/transform/schema.ts
+++ b/src/transform/schema.ts
@@ -99,7 +99,7 @@ export function transformSchemaObj(node: any, options: TransformSchemaObjOptions
       case "number":
       case "boolean":
       case "unknown": {
-        output += nodeType(node) || "any";
+        output += nodeType(node);
         break;
       }
       case "enum": {
@@ -139,7 +139,7 @@ export function transformSchemaObj(node: any, options: TransformSchemaObjOptions
           (node.additionalProperties === undefined && options.additionalProperties && options.version === 3)
         ) {
           if ((node.additionalProperties ?? true) === true || Object.keys(node.additionalProperties).length === 0) {
-            additionalProperties = `{ ${readonly}[key: string]: any }`;
+            additionalProperties = `{ ${readonly}[key: string]: unknown }`;
           } else if (typeof node.additionalProperties === "object") {
             const oneOf: any[] | undefined = (node.additionalProperties as any).oneOf || undefined; // TypeScript does a really bad job at inference here, so we enforce a type
             const anyOf: any[] | undefined = (node.additionalProperties as any).anyOf || undefined; // "
@@ -149,7 +149,7 @@ export function transformSchemaObj(node: any, options: TransformSchemaObjOptions
               additionalProperties = `{ ${readonly}[key: string]: ${transformAnyOf(anyOf, options)}; }`;
             } else {
               additionalProperties = `{ ${readonly}[key: string]: ${
-                transformSchemaObj(node.additionalProperties, options) || "any"
+                transformSchemaObj(node.additionalProperties, options) || "unknown"
               }; }`;
             }
           }
@@ -172,7 +172,7 @@ export function transformSchemaObj(node: any, options: TransformSchemaObjOptions
         if (Array.isArray(node.items)) {
           output += `${readonly}${tsTupleOf(node.items.map((node: any) => transformSchemaObj(node, options)))}`;
         } else {
-          output += `${readonly}${tsArrayOf(node.items ? transformSchemaObj(node.items as any, options) : "any")}`;
+          output += `${readonly}${tsArrayOf(node.items ? transformSchemaObj(node.items as any, options) : "unknown")}`;
         }
         break;
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,9 +43,9 @@ type SchemaObjectType =
   | "ref"
   | "string"
   | "unknown";
-export function nodeType(obj: any): SchemaObjectType | undefined {
+export function nodeType(obj: any): SchemaObjectType {
   if (!obj || typeof obj !== "object") {
-    return undefined;
+    return "unknown";
   }
 
   if (obj.$ref) {
@@ -77,13 +77,20 @@ export function nodeType(obj: any): SchemaObjectType | undefined {
     return "array";
   }
 
-  // file
-  if (obj.type === "file") {
-    return "unknown";
+  // object
+  if (
+    obj.type === "object" ||
+    obj.hasOwnProperty("allOf") ||
+    obj.hasOwnProperty("anyOf") ||
+    obj.hasOwnProperty("oneOf") ||
+    obj.hasOwnProperty("properties") ||
+    obj.hasOwnProperty("additionalProperties")
+  ) {
+    return "object";
   }
 
-  // return object by default
-  return "object";
+  // return unknown by default
+  return "unknown";
 }
 
 /** Return OpenAPI version from definition */

--- a/tests/request.test.ts
+++ b/tests/request.test.ts
@@ -89,7 +89,7 @@ describe("requestBodies", () => {
             content: {
               "application/json": {
                 test?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
             };
           };`)
     );

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -58,7 +58,7 @@ describe("SchemaObject", () => {
       expect(transform(objUnknown, { ...defaults })).toBe(`{ [key: string]: unknown }`);
 
       // empty
-      expect(transform({}, { ...defaults })).toBe(`{ [key: string]: unknown }`);
+      expect(transform({}, { ...defaults })).toBe(`unknown`);
 
       // nullable
       expect(transform(objNullable, { ...defaults })).toBe(`({\n"string"?: string;\n\n}) | null`);
@@ -74,7 +74,7 @@ describe("SchemaObject", () => {
         `{\nreadonly "object"?: {\nreadonly "string"?: string;\nreadonly "number"?: components["schemas"]["object_ref"];\n\n};\n\n}`
       );
       expect(transform(objUnknown, opts)).toBe(`{ readonly [key: string]: unknown }`);
-      expect(transform({}, opts)).toBe(`{ readonly [key: string]: unknown }`);
+      expect(transform({}, opts)).toBe(`unknown`);
       expect(transform(objNullable, opts)).toBe(`({\nreadonly "string"?: string;\n\n}) | null`);
       expect(transform(objRequired, opts)).toBe(`{\nreadonly "required": string;\nreadonly "optional"?: boolean;\n\n}`);
     });
@@ -218,10 +218,10 @@ describe("SchemaObject", () => {
   describe("advanced", () => {
     it("additionalProperties", () => {
       // boolean
-      expect(transform({ additionalProperties: true }, { ...defaults })).toBe(`{ [key: string]: any }`);
+      expect(transform({ additionalProperties: true }, { ...defaults })).toBe(`{ [key: string]: unknown }`);
 
       // empty object
-      expect(transform({ additionalProperties: {} }, { ...defaults })).toBe(`{ [key: string]: any }`);
+      expect(transform({ additionalProperties: {} }, { ...defaults })).toBe(`{ [key: string]: unknown }`);
 
       // type
       expect(transform({ additionalProperties: { type: "string" } }, { ...defaults })).toBe(

--- a/tests/v2/expected/stripe.immutable.ts
+++ b/tests/v2/expected/stripe.immutable.ts
@@ -9003,7 +9003,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly three_d_secure: string;
@@ -9025,7 +9025,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
     };
     readonly responses: {
@@ -9052,7 +9052,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           readonly account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** Business information about the account. */
           readonly business_profile?: {
             readonly mcc?: string;
@@ -9163,7 +9163,7 @@ export interface operations {
               readonly state?: string;
               readonly town?: string;
             };
-            readonly dob?: { readonly [key: string]: unknown };
+            readonly dob?: unknown;
             readonly email?: string;
             readonly first_name?: string;
             readonly first_name_kana?: string;
@@ -9174,7 +9174,7 @@ export interface operations {
             readonly last_name_kana?: string;
             readonly last_name_kanji?: string;
             readonly maiden_name?: string;
-            readonly metadata?: { readonly [key: string]: unknown };
+            readonly metadata?: unknown;
             readonly phone?: string;
             readonly ssn_last_4?: string;
             readonly verification?: {
@@ -9189,7 +9189,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           readonly requested_capabilities?: readonly (
             | "au_becs_debit_payments"
@@ -9223,7 +9223,7 @@ export interface operations {
             readonly payouts?: {
               readonly debit_negative_balances?: boolean;
               readonly schedule?: {
-                readonly delay_days?: { readonly [key: string]: unknown };
+                readonly delay_days?: unknown;
                 readonly interval?: "daily" | "manual" | "monthly" | "weekly";
                 readonly monthly_anchor?: number;
                 readonly weekly_anchor?:
@@ -9292,7 +9292,7 @@ export interface operations {
         /** Body parameters for the request. */
         readonly payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           readonly default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -9320,7 +9320,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -9374,7 +9374,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Cardholder name. */
           readonly name?: string;
         };
@@ -9414,7 +9414,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
     };
     readonly responses: {
@@ -9441,7 +9441,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly capability: string;
@@ -9490,7 +9490,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -9526,7 +9526,7 @@ export interface operations {
         /** Body parameters for the request. */
         readonly payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           readonly default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -9554,7 +9554,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -9608,7 +9608,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Cardholder name. */
           readonly name?: string;
         };
@@ -9704,7 +9704,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -9771,7 +9771,7 @@ export interface operations {
             readonly town?: string;
           };
           /** The person's date of birth. */
-          readonly dob?: { readonly [key: string]: unknown };
+          readonly dob?: unknown;
           /** The person's email address. */
           readonly email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -9795,7 +9795,7 @@ export interface operations {
           /** The person's maiden name. */
           readonly maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           readonly person_token?: string;
           /** The person's phone number. */
@@ -9805,7 +9805,7 @@ export interface operations {
             readonly director?: boolean;
             readonly executive?: boolean;
             readonly owner?: boolean;
-            readonly percent_ownership?: { readonly [key: string]: unknown };
+            readonly percent_ownership?: unknown;
             readonly representative?: boolean;
             readonly title?: string;
           };
@@ -9841,7 +9841,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly person: string;
@@ -9898,7 +9898,7 @@ export interface operations {
             readonly town?: string;
           };
           /** The person's date of birth. */
-          readonly dob?: { readonly [key: string]: unknown };
+          readonly dob?: unknown;
           /** The person's email address. */
           readonly email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -9922,7 +9922,7 @@ export interface operations {
           /** The person's maiden name. */
           readonly maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           readonly person_token?: string;
           /** The person's phone number. */
@@ -9932,7 +9932,7 @@ export interface operations {
             readonly director?: boolean;
             readonly executive?: boolean;
             readonly owner?: boolean;
-            readonly percent_ownership?: { readonly [key: string]: unknown };
+            readonly percent_ownership?: unknown;
             readonly representative?: boolean;
             readonly title?: string;
           };
@@ -9986,7 +9986,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -10053,7 +10053,7 @@ export interface operations {
             readonly town?: string;
           };
           /** The person's date of birth. */
-          readonly dob?: { readonly [key: string]: unknown };
+          readonly dob?: unknown;
           /** The person's email address. */
           readonly email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10077,7 +10077,7 @@ export interface operations {
           /** The person's maiden name. */
           readonly maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           readonly person_token?: string;
           /** The person's phone number. */
@@ -10087,7 +10087,7 @@ export interface operations {
             readonly director?: boolean;
             readonly executive?: boolean;
             readonly owner?: boolean;
-            readonly percent_ownership?: { readonly [key: string]: unknown };
+            readonly percent_ownership?: unknown;
             readonly representative?: boolean;
             readonly title?: string;
           };
@@ -10123,7 +10123,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly person: string;
@@ -10180,7 +10180,7 @@ export interface operations {
             readonly town?: string;
           };
           /** The person's date of birth. */
-          readonly dob?: { readonly [key: string]: unknown };
+          readonly dob?: unknown;
           /** The person's email address. */
           readonly email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10204,7 +10204,7 @@ export interface operations {
           /** The person's maiden name. */
           readonly maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           readonly person_token?: string;
           /** The person's phone number. */
@@ -10214,7 +10214,7 @@ export interface operations {
             readonly director?: boolean;
             readonly executive?: boolean;
             readonly owner?: boolean;
-            readonly percent_ownership?: { readonly [key: string]: unknown };
+            readonly percent_ownership?: unknown;
             readonly representative?: boolean;
             readonly title?: string;
           };
@@ -10300,7 +10300,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
@@ -10344,7 +10344,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           readonly account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** Business information about the account. */
           readonly business_profile?: {
             readonly mcc?: string;
@@ -10457,7 +10457,7 @@ export interface operations {
               readonly state?: string;
               readonly town?: string;
             };
-            readonly dob?: { readonly [key: string]: unknown };
+            readonly dob?: unknown;
             readonly email?: string;
             readonly first_name?: string;
             readonly first_name_kana?: string;
@@ -10468,7 +10468,7 @@ export interface operations {
             readonly last_name_kana?: string;
             readonly last_name_kanji?: string;
             readonly maiden_name?: string;
-            readonly metadata?: { readonly [key: string]: unknown };
+            readonly metadata?: unknown;
             readonly phone?: string;
             readonly ssn_last_4?: string;
             readonly verification?: {
@@ -10483,7 +10483,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           readonly requested_capabilities?: readonly (
             | "au_becs_debit_payments"
@@ -10517,7 +10517,7 @@ export interface operations {
             readonly payouts?: {
               readonly debit_negative_balances?: boolean;
               readonly schedule?: {
-                readonly delay_days?: { readonly [key: string]: unknown };
+                readonly delay_days?: unknown;
                 readonly interval?: "daily" | "manual" | "monthly" | "weekly";
                 readonly monthly_anchor?: number;
                 readonly weekly_anchor?:
@@ -10559,7 +10559,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly account: string;
@@ -10592,7 +10592,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           readonly account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** Business information about the account. */
           readonly business_profile?: {
             readonly mcc?: string;
@@ -10703,7 +10703,7 @@ export interface operations {
               readonly state?: string;
               readonly town?: string;
             };
-            readonly dob?: { readonly [key: string]: unknown };
+            readonly dob?: unknown;
             readonly email?: string;
             readonly first_name?: string;
             readonly first_name_kana?: string;
@@ -10714,7 +10714,7 @@ export interface operations {
             readonly last_name_kana?: string;
             readonly last_name_kanji?: string;
             readonly maiden_name?: string;
-            readonly metadata?: { readonly [key: string]: unknown };
+            readonly metadata?: unknown;
             readonly phone?: string;
             readonly ssn_last_4?: string;
             readonly verification?: {
@@ -10729,7 +10729,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           readonly requested_capabilities?: readonly (
             | "au_becs_debit_payments"
@@ -10763,7 +10763,7 @@ export interface operations {
             readonly payouts?: {
               readonly debit_negative_balances?: boolean;
               readonly schedule?: {
-                readonly delay_days?: { readonly [key: string]: unknown };
+                readonly delay_days?: unknown;
                 readonly interval?: "daily" | "manual" | "monthly" | "weekly";
                 readonly monthly_anchor?: number;
                 readonly weekly_anchor?:
@@ -10832,7 +10832,7 @@ export interface operations {
         /** Body parameters for the request. */
         readonly payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           readonly default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -10860,7 +10860,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly account: string;
@@ -10916,7 +10916,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Cardholder name. */
           readonly name?: string;
         };
@@ -10957,7 +10957,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly account: string;
@@ -10987,7 +10987,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly account: string;
@@ -11038,7 +11038,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11080,7 +11080,7 @@ export interface operations {
         /** Body parameters for the request. */
         readonly payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           readonly default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -11108,7 +11108,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly account: string;
@@ -11164,7 +11164,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Cardholder name. */
           readonly name?: string;
         };
@@ -11265,7 +11265,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11337,7 +11337,7 @@ export interface operations {
             readonly town?: string;
           };
           /** The person's date of birth. */
-          readonly dob?: { readonly [key: string]: unknown };
+          readonly dob?: unknown;
           /** The person's email address. */
           readonly email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11361,7 +11361,7 @@ export interface operations {
           /** The person's maiden name. */
           readonly maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           readonly person_token?: string;
           /** The person's phone number. */
@@ -11371,7 +11371,7 @@ export interface operations {
             readonly director?: boolean;
             readonly executive?: boolean;
             readonly owner?: boolean;
-            readonly percent_ownership?: { readonly [key: string]: unknown };
+            readonly percent_ownership?: unknown;
             readonly representative?: boolean;
             readonly title?: string;
           };
@@ -11407,7 +11407,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly account: string;
@@ -11465,7 +11465,7 @@ export interface operations {
             readonly town?: string;
           };
           /** The person's date of birth. */
-          readonly dob?: { readonly [key: string]: unknown };
+          readonly dob?: unknown;
           /** The person's email address. */
           readonly email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11489,7 +11489,7 @@ export interface operations {
           /** The person's maiden name. */
           readonly maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           readonly person_token?: string;
           /** The person's phone number. */
@@ -11499,7 +11499,7 @@ export interface operations {
             readonly director?: boolean;
             readonly executive?: boolean;
             readonly owner?: boolean;
-            readonly percent_ownership?: { readonly [key: string]: unknown };
+            readonly percent_ownership?: unknown;
             readonly representative?: boolean;
             readonly title?: string;
           };
@@ -11554,7 +11554,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11626,7 +11626,7 @@ export interface operations {
             readonly town?: string;
           };
           /** The person's date of birth. */
-          readonly dob?: { readonly [key: string]: unknown };
+          readonly dob?: unknown;
           /** The person's email address. */
           readonly email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11650,7 +11650,7 @@ export interface operations {
           /** The person's maiden name. */
           readonly maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           readonly person_token?: string;
           /** The person's phone number. */
@@ -11660,7 +11660,7 @@ export interface operations {
             readonly director?: boolean;
             readonly executive?: boolean;
             readonly owner?: boolean;
-            readonly percent_ownership?: { readonly [key: string]: unknown };
+            readonly percent_ownership?: unknown;
             readonly representative?: boolean;
             readonly title?: string;
           };
@@ -11696,7 +11696,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly account: string;
@@ -11754,7 +11754,7 @@ export interface operations {
             readonly town?: string;
           };
           /** The person's date of birth. */
-          readonly dob?: { readonly [key: string]: unknown };
+          readonly dob?: unknown;
           /** The person's email address. */
           readonly email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11778,7 +11778,7 @@ export interface operations {
           /** The person's maiden name. */
           readonly maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           readonly person_token?: string;
           /** The person's phone number. */
@@ -11788,7 +11788,7 @@ export interface operations {
             readonly director?: boolean;
             readonly executive?: boolean;
             readonly owner?: boolean;
-            readonly percent_ownership?: { readonly [key: string]: unknown };
+            readonly percent_ownership?: unknown;
             readonly representative?: boolean;
             readonly title?: string;
           };
@@ -11874,7 +11874,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly domain_name?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
@@ -11931,7 +11931,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly domain: string;
@@ -11971,7 +11971,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return application fees for the charge specified by this charge ID. */
         readonly charge?: string;
         readonly created?: number;
@@ -12007,7 +12007,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly fee: string;
@@ -12042,7 +12042,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -12062,7 +12062,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -12110,7 +12110,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -12189,7 +12189,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
     };
     readonly responses: {
@@ -12212,7 +12212,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly available_on?: number;
         readonly created?: number;
         /** Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -12259,7 +12259,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -12285,7 +12285,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly available_on?: number;
         readonly created?: number;
         /** Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -12332,7 +12332,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -12380,7 +12380,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Filter for active receivers. */
         readonly active?: boolean;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12419,7 +12419,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -12441,7 +12441,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return transactions for the customer specified by this customer ID. */
         readonly customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12480,7 +12480,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return transactions for the customer specified by this customer ID. */
         readonly customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12517,7 +12517,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** Only return charges for the customer specified by this customer ID. */
         readonly customer?: string;
@@ -12566,7 +12566,7 @@ export interface operations {
           /** Whether to immediately capture the charge. Defaults to `true`. When `false`, the charge issues an authorization (or pre-authorization), and will need to be [captured](https://stripe.com/docs/api#capture_charge) later. Uncaptured charges expire in _seven days_. For more information, see the [authorizing charges and settling later](https://stripe.com/docs/charges/placing-a-hold) documentation. */
           readonly capture?: boolean;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          readonly card?: { readonly [key: string]: unknown };
+          readonly card?: unknown;
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           readonly currency?: string;
           /** The ID of an existing customer that will be charged in this request. */
@@ -12580,7 +12580,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The Stripe account ID for which these funds are intended. Automatically set if you use the `destination` parameter. For details, see [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers#on-behalf-of). */
           readonly on_behalf_of?: string;
           /** The email address to which this charge's [receipt](https://stripe.com/docs/dashboard/receipts) will be sent. The receipt will not be sent until the charge is paid, and no receipts will be sent for test mode charges. If this charge is for a [Customer](https://stripe.com/docs/api/customers/object), the email address specified here will override the customer's email address. If `receipt_email` is specified for a charge in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails). */
@@ -12632,7 +12632,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly charge: string;
@@ -12669,7 +12669,7 @@ export interface operations {
             readonly user_report: "" | "fraudulent" | "safe";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** This is the email address that the receipt for this charge will be sent to. If this field is updated, then a new email receipt will be sent to the updated address. */
           readonly receipt_email?: string;
           /** Shipping information for the charge. Helps prevent fraud on charges for physical goods. */
@@ -12755,7 +12755,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly charge: string;
@@ -12813,7 +12813,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default). */
           readonly submit?: boolean;
         };
@@ -12878,7 +12878,7 @@ export interface operations {
           readonly amount?: number;
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           readonly payment_intent?: string;
           readonly reason?: "duplicate" | "fraudulent" | "requested_by_customer";
           readonly refund_application_fee?: boolean;
@@ -12902,7 +12902,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -12971,7 +12971,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly charge: string;
@@ -13001,7 +13001,7 @@ export interface operations {
         readonly payload?: {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -13021,7 +13021,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13454,7 +13454,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly session: string;
@@ -13476,7 +13476,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13509,7 +13509,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly country: string;
@@ -13531,7 +13531,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13586,7 +13586,7 @@ export interface operations {
           /** A positive integer specifying the number of times the coupon can be redeemed before it's no longer valid. For example, you might have a 50% off coupon that the first 20 readers of your blog can use. */
           readonly max_redemptions?: number;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set. */
           readonly name?: string;
           /** A positive float larger than 0, and smaller or equal to 100, that represents the discount the coupon will apply (required if `amount_off` is not passed). */
@@ -13612,7 +13612,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly coupon: string;
@@ -13641,7 +13641,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set. */
           readonly name?: string;
         };
@@ -13681,7 +13681,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return credit notes for the customer specified by this customer ID. */
         readonly customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13784,7 +13784,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The integer amount in **%s** representing the total amount of the credit note. */
         readonly amount?: number;
         /** The integer amount in **%s** representing the amount to credit the customer's balance, which will be automatically applied to their next invoice. */
@@ -13792,7 +13792,7 @@ export interface operations {
         /** ID of the invoice. */
         readonly invoice: string;
         /** Line items that make up the credit note. */
-        readonly lines?: readonly any[];
+        readonly lines?: readonly unknown[];
         /** The credit note's memo appears on the credit note PDF. */
         readonly memo?: string;
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -13823,7 +13823,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The integer amount in **%s** representing the total amount of the credit note. */
         readonly amount?: number;
         /** The integer amount in **%s** representing the amount to credit the customer's balance, which will be automatically applied to their next invoice. */
@@ -13835,7 +13835,7 @@ export interface operations {
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         readonly limit?: number;
         /** Line items that make up the credit note. */
-        readonly lines?: readonly any[];
+        readonly lines?: readonly unknown[];
         /** The credit note's memo appears on the credit note PDF. */
         readonly memo?: string;
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -13877,7 +13877,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13914,7 +13914,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -13990,7 +13990,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** A filter on the list based on the customer's `email` field. The value must be a string. */
         readonly email?: string;
@@ -14028,7 +14028,7 @@ export interface operations {
         /** Body parameters for the request. */
         readonly payload?: {
           /** The customer's address. */
-          readonly address?: { readonly [key: string]: unknown };
+          readonly address?: unknown;
           /** An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice. */
           readonly balance?: number;
           /** The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that particular subscription. */
@@ -14051,7 +14051,7 @@ export interface operations {
             readonly footer?: string;
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The customer's full name or business name. */
           readonly name?: string;
           /** The sequence to be used on the customer's next invoice. Defaults to 1. */
@@ -14063,7 +14063,7 @@ export interface operations {
           /** Customer's preferred languages, ordered by preference. */
           readonly preferred_locales?: readonly string[];
           /** The customer's shipping information. Appears on invoices emailed to this customer. */
-          readonly shipping?: { readonly [key: string]: unknown };
+          readonly shipping?: unknown;
           /**
            * The source can be a [Token](https://stripe.com/docs/api#tokens) or a [Source](https://stripe.com/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free.
            *
@@ -14121,7 +14121,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -14152,13 +14152,13 @@ export interface operations {
         /** Body parameters for the request. */
         readonly payload?: {
           /** The customer's address. */
-          readonly address?: { readonly [key: string]: unknown };
+          readonly address?: unknown;
           /** An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice. */
           readonly balance?: number;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          readonly card?: { readonly [key: string]: unknown };
+          readonly card?: unknown;
           /** The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that particular subscription. */
           readonly coupon?: string;
           /** ID of Alipay account to make the customer's new default for invoice payments. */
@@ -14193,7 +14193,7 @@ export interface operations {
             readonly footer?: string;
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The customer's full name or business name. */
           readonly name?: string;
           /** The sequence to be used on the customer's next invoice. Defaults to 1. */
@@ -14203,7 +14203,7 @@ export interface operations {
           /** Customer's preferred languages, ordered by preference. */
           readonly preferred_locales?: readonly string[];
           /** The customer's shipping information. Appears on invoices emailed to this customer. */
-          readonly shipping?: { readonly [key: string]: unknown };
+          readonly shipping?: unknown;
           /**
            * The source can be a [Token](https://stripe.com/docs/api#tokens) or a [Source](https://stripe.com/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free.
            *
@@ -14215,7 +14215,7 @@ export interface operations {
           /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
           readonly tax_exempt?: "" | "exempt" | "none" | "reverse";
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          readonly trial_end?: { readonly [key: string]: unknown };
+          readonly trial_end?: unknown;
         };
       };
     };
@@ -14253,7 +14253,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14303,7 +14303,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -14323,7 +14323,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -14356,7 +14356,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -14376,7 +14376,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14426,9 +14426,9 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           readonly alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          readonly card?: { readonly [key: string]: unknown };
+          readonly card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -14454,7 +14454,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -14505,7 +14505,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Cardholder name. */
           readonly name?: string;
           readonly owner?: {
@@ -14598,7 +14598,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14647,9 +14647,9 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           readonly alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          readonly card?: { readonly [key: string]: unknown };
+          readonly card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -14675,7 +14675,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -14726,7 +14726,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Cardholder name. */
           readonly name?: string;
           readonly owner?: {
@@ -14786,7 +14786,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -14826,7 +14826,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14878,9 +14878,9 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           readonly alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          readonly bank_account?: { readonly [key: string]: unknown };
+          readonly bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          readonly card?: { readonly [key: string]: unknown };
+          readonly card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -14906,7 +14906,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -14957,7 +14957,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Cardholder name. */
           readonly name?: string;
           readonly owner?: {
@@ -15046,7 +15046,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -15094,7 +15094,7 @@ export interface operations {
           /** A future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. */
           readonly billing_cycle_anchor?: number;
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          readonly billing_thresholds?: { readonly [key: string]: unknown };
+          readonly billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
           readonly cancel_at?: number;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
@@ -15115,14 +15115,14 @@ export interface operations {
           readonly expand?: readonly string[];
           /** A list of up to 20 subscription items, each with an attached plan. */
           readonly items?: readonly {
-            readonly billing_thresholds?: { readonly [key: string]: unknown };
+            readonly billing_thresholds?: unknown;
             readonly metadata?: { readonly [key: string]: unknown };
             readonly plan?: string;
             readonly quantity?: number;
             readonly tax_rates?: readonly string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           readonly off_session?: boolean;
           /**
@@ -15134,7 +15134,7 @@ export interface operations {
            */
           readonly payment_behavior?: "allow_incomplete" | "error_if_incomplete" | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          readonly pending_invoice_item_interval?: { readonly [key: string]: unknown };
+          readonly pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           readonly prorate?: boolean;
           /**
@@ -15144,9 +15144,9 @@ export interface operations {
            */
           readonly proration_behavior?: "always_invoice" | "create_prorations" | "none";
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          readonly tax_percent?: { readonly [key: string]: unknown };
+          readonly tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          readonly trial_end?: { readonly [key: string]: unknown };
+          readonly trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           readonly trial_from_plan?: boolean;
           /** Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. */
@@ -15170,7 +15170,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -15203,9 +15203,9 @@ export interface operations {
           /** Either `now` or `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle). */
           readonly billing_cycle_anchor?: "now" | "unchanged";
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          readonly billing_thresholds?: { readonly [key: string]: unknown };
+          readonly billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
-          readonly cancel_at?: { readonly [key: string]: unknown };
+          readonly cancel_at?: unknown;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
           readonly cancel_at_period_end?: boolean;
           /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
@@ -15224,21 +15224,21 @@ export interface operations {
           readonly expand?: readonly string[];
           /** List of subscription items, each with an attached plan. */
           readonly items?: readonly {
-            readonly billing_thresholds?: { readonly [key: string]: unknown };
+            readonly billing_thresholds?: unknown;
             readonly clear_usage?: boolean;
             readonly deleted?: boolean;
             readonly id?: string;
-            readonly metadata?: { readonly [key: string]: unknown };
+            readonly metadata?: unknown;
             readonly plan?: string;
             readonly quantity?: number;
             readonly tax_rates?: readonly string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           readonly off_session?: boolean;
           /** If specified, payment collection for this subscription will be paused. */
-          readonly pause_collection?: { readonly [key: string]: unknown };
+          readonly pause_collection?: unknown;
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -15248,7 +15248,7 @@ export interface operations {
            */
           readonly payment_behavior?: "allow_incomplete" | "error_if_incomplete" | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          readonly pending_invoice_item_interval?: { readonly [key: string]: unknown };
+          readonly pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           readonly prorate?: boolean;
           /**
@@ -15262,9 +15262,9 @@ export interface operations {
           /** If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. */
           readonly proration_date?: number;
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          readonly tax_percent?: { readonly [key: string]: unknown };
+          readonly tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          readonly trial_end?: { readonly [key: string]: unknown };
+          readonly trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           readonly trial_from_plan?: boolean;
         };
@@ -15321,7 +15321,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -15363,7 +15363,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -15452,7 +15452,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly customer: string;
@@ -15494,7 +15494,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return disputes associated to the charge specified by this charge ID. */
         readonly charge?: string;
         readonly created?: number;
@@ -15532,7 +15532,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly dispute: string;
@@ -15595,7 +15595,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default). */
           readonly submit?: boolean;
         };
@@ -15697,7 +15697,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** Filter events by whether all webhooks were successfully delivered. If false, events which are still pending or have failed all delivery attempts to a webhook endpoint will be returned. */
         readonly delivery_success?: boolean;
@@ -15710,7 +15710,7 @@ export interface operations {
         /** A string containing a specific event name, or group of events using * as a wildcard. The list will be filtered to include only events with a matching event property. */
         readonly type?: string;
         /** An array of up to 20 strings containing specific event names. The list will be filtered to include only events with a matching event property. You may pass either `type` or `types`, but not both. */
-        readonly types?: readonly any[];
+        readonly types?: readonly unknown[];
       };
     };
     readonly responses: {
@@ -15737,7 +15737,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -15759,7 +15759,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is the currency that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with the exchange rate for currency X your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and total number of supported payout currencies, and the default is the max. */
@@ -15792,7 +15792,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly currency: string;
@@ -15814,7 +15814,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
@@ -15860,7 +15860,7 @@ export interface operations {
           /** The ID of the file. The file's `purpose` must be one of the following: `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `finance_report_run`, `pci_document`, `sigma_scheduled_query`, or `tax_document_user_upload`. */
           readonly file: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -15880,7 +15880,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly link: string;
@@ -15909,9 +15909,9 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** A future timestamp after which the link will no longer be usable, or `now` to expire the link immediately. */
-          readonly expires_at?: { readonly [key: string]: unknown };
+          readonly expires_at?: unknown;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -15931,7 +15931,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
@@ -15980,7 +15980,7 @@ export interface operations {
           readonly file_link_data?: {
             readonly create: boolean;
             readonly expires_at?: number;
-            readonly metadata?: { readonly [key: string]: unknown };
+            readonly metadata?: unknown;
           };
           /** The purpose of the uploaded file. Possible values are `additional_verification`, `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`, or `tax_document_user_upload`. */
           readonly purpose:
@@ -16011,7 +16011,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly file: string;
@@ -16033,7 +16033,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** The identifier of the customer whose invoice items to return. If none is provided, all invoice items will be returned. */
         readonly customer?: string;
@@ -16089,7 +16089,7 @@ export interface operations {
           /** The ID of an existing invoice to add this invoice item to. When left blank, the invoice item will be added to the next upcoming scheduled invoice. This is useful when adding invoice items in response to an invoice.created webhook. You can only add invoice items to draft invoices. */
           readonly invoice?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The period associated with this invoice item. */
           readonly period?: {
             readonly end: number;
@@ -16124,7 +16124,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly invoiceitem: string;
@@ -16159,7 +16159,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The period associated with this invoice item. */
           readonly period?: {
             readonly end: number;
@@ -16210,7 +16210,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The collection method of the invoice to retrieve. Either `charge_automatically` or `send_invoice`. */
         readonly collection_method?: string;
         readonly created?: number;
@@ -16284,7 +16284,7 @@ export interface operations {
           /** Footer to be displayed on the invoice. */
           readonly footer?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`. */
           readonly statement_descriptor?: string;
           /** The ID of the subscription to invoice, if any. If not set, the created invoice will include all pending invoice items for the customer. If set, the created invoice will only include pending invoice items for that subscription and pending invoice items not associated with any subscription. The subscription's billing cycle and regular subscription events won't be affected. */
@@ -16316,13 +16316,13 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The code of the coupon to apply. If `subscription` or `subscription_items` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. The invoice can be previewed without a coupon by passing this value as an empty string. */
         readonly coupon?: string;
         /** The identifier of the customer whose upcoming invoice you'd like to retrieve. */
         readonly customer?: string;
         /** List of invoice items to add or update in the upcoming invoice preview. */
-        readonly invoice_items?: readonly any[];
+        readonly invoice_items?: readonly unknown[];
         /** The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields. */
         readonly schedule?: string;
         /** The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If not provided, but a `subscription_items` is provided, you will preview creating a subscription with those items. If neither `subscription` nor `subscription_items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions. */
@@ -16338,7 +16338,7 @@ export interface operations {
         /** If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set. */
         readonly subscription_default_tax_rates?: string;
         /** List of subscription items, each with an attached plan. */
-        readonly subscription_items?: readonly any[];
+        readonly subscription_items?: readonly unknown[];
         /** If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. */
         readonly subscription_prorate?: boolean;
         /**
@@ -16377,7 +16377,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The code of the coupon to apply. If `subscription` or `subscription_items` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. The invoice can be previewed without a coupon by passing this value as an empty string. */
         readonly coupon?: string;
         /** The identifier of the customer whose upcoming invoice you'd like to retrieve. */
@@ -16385,7 +16385,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** List of invoice items to add or update in the upcoming invoice preview. */
-        readonly invoice_items?: readonly any[];
+        readonly invoice_items?: readonly unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         readonly limit?: number;
         /** The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields. */
@@ -16405,7 +16405,7 @@ export interface operations {
         /** If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set. */
         readonly subscription_default_tax_rates?: string;
         /** List of subscription items, each with an attached plan. */
-        readonly subscription_items?: readonly any[];
+        readonly subscription_items?: readonly unknown[];
         /** If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. */
         readonly subscription_prorate?: boolean;
         /**
@@ -16453,7 +16453,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly invoice: string;
@@ -16514,11 +16514,11 @@ export interface operations {
           /** Footer to be displayed on the invoice. */
           readonly footer?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`. */
           readonly statement_descriptor?: string;
           /** The percent tax rate applied to the invoice, represented as a non-negative decimal number (with at most four decimal places) between 0 and 100. To unset a previously-set value, pass an empty string. This field can be updated only on `draft` invoices. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          readonly tax_percent?: { readonly [key: string]: unknown };
+          readonly tax_percent?: unknown;
         };
       };
     };
@@ -16583,7 +16583,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -16738,7 +16738,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return issuer fraud records for the charge specified by this charge ID. */
         readonly charge?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -16777,7 +16777,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly issuer_fraud_record: string;
@@ -16799,7 +16799,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return issuing transactions that belong to the given card. */
         readonly card?: string;
         /** Only return authorizations belonging to the given cardholder. */
@@ -16840,7 +16840,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly authorization: string;
@@ -16869,7 +16869,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -16898,7 +16898,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -16925,7 +16925,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -16945,7 +16945,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return cardholders that were created during the given date interval. */
         readonly created?: number;
         /** Only return cardholders that have the given email address. */
@@ -17931,7 +17931,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly cardholder: string;
@@ -18895,7 +18895,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return cards belonging to the Cardholder with the provided ID. */
         readonly cardholder?: string;
         /** Only return cards that were issued during the given date interval. */
@@ -19869,7 +19869,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly card: string;
@@ -19900,7 +19900,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details. */
           readonly spending_controls?: {
             readonly allowed_categories?: readonly (
@@ -20799,7 +20799,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -20856,7 +20856,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly dispute: string;
@@ -20905,7 +20905,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return issuing settlements that were created during the given date interval. */
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -20940,7 +20940,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly settlement: string;
@@ -20989,7 +20989,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return transactions that belong to the given card. */
         readonly card?: string;
         /** Only return transactions that belong to the given cardholder. */
@@ -21028,7 +21028,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly transaction: string;
@@ -21057,7 +21057,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -21077,7 +21077,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly mandate: string;
@@ -21099,7 +21099,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Date this return was created. */
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -21136,7 +21136,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -21158,7 +21158,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Date this order was created. */
         readonly created?: number;
         /** Only return orders for the given customer. */
@@ -21166,7 +21166,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** Only return orders with the given IDs. */
-        readonly ids?: readonly any[];
+        readonly ids?: readonly unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         readonly limit?: number;
         /** A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
@@ -21176,7 +21176,7 @@ export interface operations {
         /** Filter orders based on when they were paid, fulfilled, canceled, or returned. */
         readonly status_transitions?: string;
         /** Only return orders with the given upstream order IDs. */
-        readonly upstream_ids?: readonly any[];
+        readonly upstream_ids?: readonly unknown[];
       };
     };
     readonly responses: {
@@ -21257,7 +21257,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -21288,7 +21288,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The shipping method to select for fulfilling this order. If specified, must be one of the `id`s of a shipping method in the `shipping_methods` array. If specified, will overwrite the existing selected shipping method, updating `items` as necessary. */
           readonly selected_shipping_method?: string;
           /** Tracking information once the order has been fulfilled. */
@@ -21385,7 +21385,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         readonly created?: number;
         /** Only return PaymentIntents for the customer specified by this customer ID. */
@@ -21480,7 +21480,7 @@ export interface operations {
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           readonly metadata?: { readonly [key: string]: unknown };
           /** Set to `true` to indicate that the customer is not in your checkout flow during this payment attempt, and therefore is unable to authenticate. This parameter is intended for scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards). This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm). */
-          readonly off_session?: { readonly [key: string]: unknown };
+          readonly off_session?: unknown;
           /** The Stripe account ID for which these funds are intended. For details, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts). */
           readonly on_behalf_of?: string;
           /**
@@ -21491,7 +21491,7 @@ export interface operations {
           readonly payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           readonly payment_method_options?: {
-            readonly card?: { readonly [key: string]: unknown };
+            readonly card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. If this is not provided, defaults to ["card"]. */
           readonly payment_method_types?: readonly string[];
@@ -21563,7 +21563,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The client secret of the PaymentIntent. Required if a publishable key is used to retrieve the source. */
         readonly client_secret?: string;
       };
@@ -21602,7 +21602,7 @@ export interface operations {
           /** Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
           readonly amount?: number;
           /** The amount of the application fee (if any) for the resulting payment. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
-          readonly application_fee_amount?: { readonly [key: string]: unknown };
+          readonly application_fee_amount?: unknown;
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           readonly currency?: string;
           /**
@@ -21618,12 +21618,12 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent. */
           readonly payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           readonly payment_method_options?: {
-            readonly card?: { readonly [key: string]: unknown };
+            readonly card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
           readonly payment_method_types?: readonly string[];
@@ -21640,7 +21640,7 @@ export interface operations {
            */
           readonly setup_future_usage?: "" | "off_session" | "on_session";
           /** Shipping information for this PaymentIntent. */
-          readonly shipping?: { readonly [key: string]: unknown };
+          readonly shipping?: unknown;
           /** For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
           readonly statement_descriptor?: string;
           /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
@@ -21802,12 +21802,12 @@ export interface operations {
             };
           };
           /** Set to `true` to indicate that the customer is not in your checkout flow during this payment attempt, and therefore is unable to authenticate. This parameter is intended for scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards). */
-          readonly off_session?: { readonly [key: string]: unknown };
+          readonly off_session?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent. */
           readonly payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           readonly payment_method_options?: {
-            readonly card?: { readonly [key: string]: unknown };
+            readonly card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
           readonly payment_method_types?: readonly string[];
@@ -21830,7 +21830,7 @@ export interface operations {
            */
           readonly setup_future_usage?: "" | "off_session" | "on_session";
           /** Shipping information for this PaymentIntent. */
-          readonly shipping?: { readonly [key: string]: unknown };
+          readonly shipping?: unknown;
           /** Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle additional authentication steps. */
           readonly use_stripe_sdk?: boolean;
         };
@@ -21852,7 +21852,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The ID of the customer whose PaymentMethods will be retrieved. */
         readonly customer: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -21984,7 +21984,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly payment_method: string;
@@ -22032,7 +22032,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
           readonly sepa_debit?: { readonly [key: string]: unknown };
         };
@@ -22118,7 +22118,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly arrival_date?: number;
         readonly created?: number;
         /** The ID of an external account - only return payouts sent to this external account. */
@@ -22201,7 +22201,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly payout: string;
@@ -22230,7 +22230,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -22275,7 +22275,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return plans that are active or inactive (e.g., pass `false` to list all inactive plans). */
         readonly active?: boolean;
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
@@ -22336,7 +22336,7 @@ export interface operations {
           /** The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). */
           readonly interval_count?: number;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A brief description of the plan, hidden from customers. */
           readonly nickname?: string;
           /** The product whose pricing the created plan will represent. This can either be the ID of an existing product, or a dictionary containing fields used to create a [service product](https://stripe.com/docs/api#product_object-type). */
@@ -22354,7 +22354,7 @@ export interface operations {
             readonly flat_amount_decimal?: string;
             readonly unit_amount?: number;
             readonly unit_amount_decimal?: string;
-            readonly up_to: { readonly [key: string]: unknown };
+            readonly up_to: unknown;
           }[];
           /** Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows. */
           readonly tiers_mode?: "graduated" | "volume";
@@ -22386,7 +22386,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly plan: string;
@@ -22417,7 +22417,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A brief description of the plan, hidden from customers. */
           readonly nickname?: string;
           /** The product the plan belongs to. Note that after updating, statement descriptors and line items of the plan in active subscriptions will be affected. */
@@ -22461,7 +22461,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return products that are active or inactive (e.g., pass `false` to list all inactive products). */
         readonly active?: boolean;
         /** Only return products that were created during the given date interval. */
@@ -22469,7 +22469,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** Only return products with the given IDs. */
-        readonly ids?: readonly any[];
+        readonly ids?: readonly unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         readonly limit?: number;
         /** Only return products that can be shipped (i.e., physical, not digital products). */
@@ -22568,7 +22568,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -22609,11 +22609,11 @@ export interface operations {
           /** A list of up to 8 URLs of images for this product, meant to be displayable to the customer. */
           readonly images?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions. */
           readonly name?: string;
           /** The dimensions of this product for shipping purposes. A SKU associated with this product can override this value by having its own `package_dimensions`. May only be set if `type=good`. */
-          readonly package_dimensions?: { readonly [key: string]: unknown };
+          readonly package_dimensions?: unknown;
           /** Whether this product is shipped (i.e., physical goods). Defaults to `true`. May only be set if `type=good`. */
           readonly shippable?: boolean;
           /**
@@ -22664,7 +22664,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return early fraud warnings for the charge specified by this charge ID. */
         readonly charge?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -22703,7 +22703,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly early_fraud_warning: string;
@@ -22725,7 +22725,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
@@ -22789,7 +22789,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly item: string;
@@ -22829,7 +22829,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The alias used to reference the value list when writing rules. */
         readonly alias?: string;
         /** A value contained within a value list - returns all value lists containing this value. */
@@ -22904,7 +22904,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly value_list: string;
@@ -22975,7 +22975,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
@@ -23027,7 +23027,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The recipient's full, legal name. For type `individual`, should be in the format `First Last`, `First Middle Last`, or `First M Last` (no prefixes or suffixes). For `corporation`, the full, incorporated name. */
           readonly name: string;
           /** The recipient's tax ID, as a string. For type `individual`, the full SSN; for type `corporation`, the full EIN. */
@@ -23053,7 +23053,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -23098,7 +23098,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The recipient's full, legal name. For type `individual`, should be in the format `First Last`, `First Middle Last`, or `First M Last` (no prefixes or suffixes). For `corporation`, the full, incorporated name. */
           readonly name?: string;
           /** The recipient's tax ID, as a string. For type `individual`, the full SSN; for type `corporation`, the full EIN. */
@@ -23140,7 +23140,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return refunds for the charge specified by this charge ID. */
         readonly charge?: string;
         readonly created?: number;
@@ -23208,7 +23208,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly refund: string;
@@ -23241,7 +23241,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -23261,7 +23261,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
@@ -23955,7 +23955,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly report_run: string;
@@ -23977,7 +23977,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
     };
     readonly responses: {
@@ -24004,7 +24004,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly report_type: string;
@@ -24026,7 +24026,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
@@ -24060,7 +24060,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly review: string;
@@ -24107,7 +24107,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         readonly created?: number;
         /** Only return SetupIntents for the customer specified by this customer ID. */
@@ -24224,7 +24224,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The client secret of the SetupIntent. Required if a publishable key is used to retrieve the SetupIntent. */
         readonly client_secret?: string;
       };
@@ -24263,7 +24263,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent. */
           readonly payment_method?: string;
           /** Payment-method-specific configuration for this SetupIntent. */
@@ -24391,7 +24391,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24424,7 +24424,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly scheduled_query_run: string;
@@ -24446,7 +24446,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return SKUs that are active or inactive (e.g., pass `false` to list all inactive products). */
         readonly active?: boolean;
         /** Only return SKUs that have the specified key-value pairs in this partially constructed dictionary. Can be specified only if `product` is also supplied. For instance, if the associated product has attributes `["color", "size"]`, passing in `attributes[color]=red` returns all the SKUs for this product that have `color` set to `red`. */
@@ -24454,7 +24454,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** Only return SKUs with the given IDs. */
-        readonly ids?: readonly any[];
+        readonly ids?: readonly unknown[];
         /** Only return SKUs that are either in stock or out of stock (e.g., pass `false` to list all SKUs that are out of stock). If no value is provided, all SKUs are returned. */
         readonly in_stock?: boolean;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24540,7 +24540,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -24587,9 +24587,9 @@ export interface operations {
             readonly value?: "" | "in_stock" | "limited" | "out_of_stock";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The dimensions of this SKU for shipping purposes. */
-          readonly package_dimensions?: { readonly [key: string]: unknown };
+          readonly package_dimensions?: unknown;
           /** The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency). */
           readonly price?: number;
           /** The ID of the product that this SKU should belong to. The product must exist, have the same set of attribute names as the SKU's current product, and be of type `good`. */
@@ -24659,7 +24659,7 @@ export interface operations {
               readonly type?: "offline" | "online";
               readonly user_agent?: string;
             };
-            readonly amount?: { readonly [key: string]: unknown };
+            readonly amount?: unknown;
             readonly currency?: string;
             readonly interval?: "one_time" | "scheduled" | "variable";
             readonly notification_method?: "deprecated_none" | "email" | "manual" | "none" | "stripe_email";
@@ -24742,7 +24742,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The client secret of the source. Required if a publishable key is used to retrieve the source. */
         readonly client_secret?: string;
       };
@@ -24795,13 +24795,13 @@ export interface operations {
               readonly type?: "offline" | "online";
               readonly user_agent?: string;
             };
-            readonly amount?: { readonly [key: string]: unknown };
+            readonly amount?: unknown;
             readonly currency?: string;
             readonly interval?: "one_time" | "scheduled" | "variable";
             readonly notification_method?: "deprecated_none" | "email" | "manual" | "none" | "stripe_email";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Information about the owner of the payment instrument that may be used or required by particular source types. */
           readonly owner?: {
             readonly address?: {
@@ -24860,7 +24860,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly mandate_notification: string;
@@ -24883,7 +24883,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24919,7 +24919,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly source: string;
@@ -24969,7 +24969,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -25006,7 +25006,7 @@ export interface operations {
         /** Body parameters for the request. */
         readonly payload: {
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-          readonly billing_thresholds?: { readonly [key: string]: unknown };
+          readonly billing_thresholds?: unknown;
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -25058,7 +25058,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly item: string;
@@ -25085,11 +25085,11 @@ export interface operations {
         /** Body parameters for the request. */
         readonly payload?: {
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-          readonly billing_thresholds?: { readonly [key: string]: unknown };
+          readonly billing_thresholds?: unknown;
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           readonly off_session?: boolean;
           /**
@@ -25178,7 +25178,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -25253,7 +25253,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Only return subscription schedules that were created canceled the given date interval. */
         readonly canceled_at?: number;
         /** Only return subscription schedules that completed during the given date interval. */
@@ -25303,7 +25303,7 @@ export interface operations {
           readonly customer?: string;
           /** Object representing the subscription schedule's default settings. */
           readonly default_settings?: {
-            readonly billing_thresholds?: { readonly [key: string]: unknown };
+            readonly billing_thresholds?: unknown;
             readonly collection_method?: "charge_automatically" | "send_invoice";
             readonly default_payment_method?: string;
             readonly invoice_settings?: {
@@ -25317,11 +25317,11 @@ export interface operations {
           /** Migrate an existing subscription to be managed by a subscription schedule. If this parameter is set, a subscription schedule will be created using the subscription's plan(s), set to auto-renew using the subscription's interval. When using this parameter, other parameters (such as phase values) cannot be set. To create a subscription schedule with other modifications, we recommend making two separate API calls. */
           readonly from_subscription?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. */
           readonly phases?: readonly {
             readonly application_fee_percent?: number;
-            readonly billing_thresholds?: { readonly [key: string]: unknown };
+            readonly billing_thresholds?: unknown;
             readonly collection_method?: "charge_automatically" | "send_invoice";
             readonly coupon?: string;
             readonly default_payment_method?: string;
@@ -25332,7 +25332,7 @@ export interface operations {
             };
             readonly iterations?: number;
             readonly plans: readonly {
-              readonly billing_thresholds?: { readonly [key: string]: unknown };
+              readonly billing_thresholds?: unknown;
               readonly plan?: string;
               readonly quantity?: number;
               readonly tax_rates?: readonly string[];
@@ -25343,7 +25343,7 @@ export interface operations {
             readonly trial_end?: number;
           }[];
           /** When the subscription schedule starts. We recommend using `now` so that it starts the subscription immediately. You can also use a Unix timestamp to backdate the subscription so that it starts on a past date, or set a future date for the subscription to start on. */
-          readonly start_date?: { readonly [key: string]: unknown };
+          readonly start_date?: unknown;
         };
       };
     };
@@ -25363,7 +25363,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly schedule: string;
@@ -25391,7 +25391,7 @@ export interface operations {
         readonly payload?: {
           /** Object representing the subscription schedule's default settings. */
           readonly default_settings?: {
-            readonly billing_thresholds?: { readonly [key: string]: unknown };
+            readonly billing_thresholds?: unknown;
             readonly collection_method?: "charge_automatically" | "send_invoice";
             readonly default_payment_method?: string;
             readonly invoice_settings?: {
@@ -25403,31 +25403,31 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. Note that past phases can be omitted. */
           readonly phases?: readonly {
             readonly application_fee_percent?: number;
-            readonly billing_thresholds?: { readonly [key: string]: unknown };
+            readonly billing_thresholds?: unknown;
             readonly collection_method?: "charge_automatically" | "send_invoice";
             readonly coupon?: string;
             readonly default_payment_method?: string;
             readonly default_tax_rates?: readonly string[];
-            readonly end_date?: { readonly [key: string]: unknown };
+            readonly end_date?: unknown;
             readonly invoice_settings?: {
               readonly days_until_due?: number;
             };
             readonly iterations?: number;
             readonly plans: readonly {
-              readonly billing_thresholds?: { readonly [key: string]: unknown };
+              readonly billing_thresholds?: unknown;
               readonly plan?: string;
               readonly quantity?: number;
               readonly tax_rates?: readonly string[];
             }[];
             readonly proration_behavior?: "always_invoice" | "create_prorations" | "none";
-            readonly start_date?: { readonly [key: string]: unknown };
+            readonly start_date?: unknown;
             readonly tax_percent?: number;
             readonly trial?: boolean;
-            readonly trial_end?: { readonly [key: string]: unknown };
+            readonly trial_end?: unknown;
           }[];
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           readonly prorate?: boolean;
@@ -25508,7 +25508,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** The collection method of the subscriptions to retrieve. Either `charge_automatically` or `send_invoice`. */
         readonly collection_method?: string;
         readonly created?: number;
@@ -25560,7 +25560,7 @@ export interface operations {
           /** A future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. */
           readonly billing_cycle_anchor?: number;
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          readonly billing_thresholds?: { readonly [key: string]: unknown };
+          readonly billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
           readonly cancel_at?: number;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
@@ -25583,14 +25583,14 @@ export interface operations {
           readonly expand?: readonly string[];
           /** A list of up to 20 subscription items, each with an attached plan. */
           readonly items?: readonly {
-            readonly billing_thresholds?: { readonly [key: string]: unknown };
+            readonly billing_thresholds?: unknown;
             readonly metadata?: { readonly [key: string]: unknown };
             readonly plan?: string;
             readonly quantity?: number;
             readonly tax_rates?: readonly string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           readonly off_session?: boolean;
           /**
@@ -25602,7 +25602,7 @@ export interface operations {
            */
           readonly payment_behavior?: "allow_incomplete" | "error_if_incomplete" | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          readonly pending_invoice_item_interval?: { readonly [key: string]: unknown };
+          readonly pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           readonly prorate?: boolean;
           /**
@@ -25612,9 +25612,9 @@ export interface operations {
            */
           readonly proration_behavior?: "always_invoice" | "create_prorations" | "none";
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          readonly tax_percent?: { readonly [key: string]: unknown };
+          readonly tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          readonly trial_end?: { readonly [key: string]: unknown };
+          readonly trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           readonly trial_from_plan?: boolean;
           /** Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. */
@@ -25638,7 +25638,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly subscription_exposed_id: string;
@@ -25669,9 +25669,9 @@ export interface operations {
           /** Either `now` or `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle). */
           readonly billing_cycle_anchor?: "now" | "unchanged";
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          readonly billing_thresholds?: { readonly [key: string]: unknown };
+          readonly billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
-          readonly cancel_at?: { readonly [key: string]: unknown };
+          readonly cancel_at?: unknown;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
           readonly cancel_at_period_end?: boolean;
           /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
@@ -25690,21 +25690,21 @@ export interface operations {
           readonly expand?: readonly string[];
           /** List of subscription items, each with an attached plan. */
           readonly items?: readonly {
-            readonly billing_thresholds?: { readonly [key: string]: unknown };
+            readonly billing_thresholds?: unknown;
             readonly clear_usage?: boolean;
             readonly deleted?: boolean;
             readonly id?: string;
-            readonly metadata?: { readonly [key: string]: unknown };
+            readonly metadata?: unknown;
             readonly plan?: string;
             readonly quantity?: number;
             readonly tax_rates?: readonly string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           readonly off_session?: boolean;
           /** If specified, payment collection for this subscription will be paused. */
-          readonly pause_collection?: { readonly [key: string]: unknown };
+          readonly pause_collection?: unknown;
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -25714,7 +25714,7 @@ export interface operations {
            */
           readonly payment_behavior?: "allow_incomplete" | "error_if_incomplete" | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          readonly pending_invoice_item_interval?: { readonly [key: string]: unknown };
+          readonly pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           readonly prorate?: boolean;
           /**
@@ -25728,9 +25728,9 @@ export interface operations {
           /** If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. */
           readonly proration_date?: number;
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          readonly tax_percent?: { readonly [key: string]: unknown };
+          readonly tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          readonly trial_end?: { readonly [key: string]: unknown };
+          readonly trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           readonly trial_from_plan?: boolean;
         };
@@ -25805,7 +25805,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Optional flag to filter by tax rates that are either active or not active (archived) */
         readonly active?: boolean;
         /** Optional range for filtering created date */
@@ -25880,7 +25880,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly tax_rate: string;
@@ -25917,7 +25917,7 @@ export interface operations {
           /** The jurisdiction for the tax rate. */
           readonly jurisdiction?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -25961,7 +25961,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -26009,7 +26009,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -26029,7 +26029,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly location: string;
@@ -26069,7 +26069,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -26107,7 +26107,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** Filters readers by device type */
         readonly device_type?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -26155,7 +26155,7 @@ export interface operations {
           /** The location to assign the reader to. If no location is specified, the reader will be assigned to the account's default location. */
           readonly location?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** A code generated by the reader used for registering to an account. */
           readonly registration_code: string;
         };
@@ -26177,7 +26177,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly reader: string;
@@ -26208,7 +26208,7 @@ export interface operations {
           /** The new label of the reader. */
           readonly label?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -26341,7 +26341,7 @@ export interface operations {
                 readonly state?: string;
                 readonly town?: string;
               };
-              readonly dob?: { readonly [key: string]: unknown };
+              readonly dob?: unknown;
               readonly email?: string;
               readonly first_name?: string;
               readonly first_name_kana?: string;
@@ -26352,7 +26352,7 @@ export interface operations {
               readonly last_name_kana?: string;
               readonly last_name_kanji?: string;
               readonly maiden_name?: string;
-              readonly metadata?: { readonly [key: string]: unknown };
+              readonly metadata?: unknown;
               readonly phone?: string;
               readonly ssn_last_4?: string;
               readonly verification?: {
@@ -26377,7 +26377,7 @@ export interface operations {
             readonly currency?: string;
             readonly routing_number?: string;
           };
-          readonly card?: { readonly [key: string]: unknown };
+          readonly card?: unknown;
           /** The customer (owned by the application's account) for which to create a token. This can be used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods). */
           readonly customer?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -26410,7 +26410,7 @@ export interface operations {
               readonly state?: string;
               readonly town?: string;
             };
-            readonly dob?: { readonly [key: string]: unknown };
+            readonly dob?: unknown;
             readonly email?: string;
             readonly first_name?: string;
             readonly first_name_kana?: string;
@@ -26421,13 +26421,13 @@ export interface operations {
             readonly last_name_kana?: string;
             readonly last_name_kanji?: string;
             readonly maiden_name?: string;
-            readonly metadata?: { readonly [key: string]: unknown };
+            readonly metadata?: unknown;
             readonly phone?: string;
             readonly relationship?: {
               readonly director?: boolean;
               readonly executive?: boolean;
               readonly owner?: boolean;
-              readonly percent_ownership?: { readonly [key: string]: unknown };
+              readonly percent_ownership?: unknown;
               readonly representative?: boolean;
               readonly title?: string;
             };
@@ -26466,7 +26466,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly token: string;
@@ -26488,7 +26488,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A positive integer representing how much to transfer. */
         readonly amount?: number;
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
@@ -26537,7 +26537,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The ID of a source to transfer funds from. For most users, this should be left unspecified which will use the bank account that was set up in the dashboard for the specified currency. In test mode, this can be a test bank token (see [Testing Top-ups](https://stripe.com/docs/connect/testing#testing-top-ups)). */
           readonly source?: string;
           /** Extra information about a top-up for the source's bank statement. Limited to 15 ASCII characters. */
@@ -26563,7 +26563,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly topup: string;
@@ -26594,7 +26594,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -26639,7 +26639,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         readonly created?: number;
         /** Only return transfers for the destination specified by this account ID. */
         readonly destination?: string;
@@ -26716,7 +26716,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -26770,7 +26770,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** Boolean indicating whether the application fee should be refunded when reversing this transfer. If a full transfer reversal is given, the full application fee will be refunded. Otherwise, the application fee will be refunded with an amount proportional to the amount of the transfer reversed. */
           readonly refund_application_fee?: boolean;
         };
@@ -26792,7 +26792,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly transfer: string;
@@ -26827,7 +26827,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -26847,7 +26847,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly id: string;
@@ -26882,7 +26882,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
         };
       };
     };
@@ -26902,7 +26902,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         readonly ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -27192,7 +27192,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The URL of the webhook endpoint. */
           readonly url: string;
         };
@@ -27214,7 +27214,7 @@ export interface operations {
     readonly parameters: {
       readonly query: {
         /** Specifies which fields in the response should be expanded. */
-        readonly expand?: readonly any[];
+        readonly expand?: readonly unknown[];
       };
       readonly path: {
         readonly webhook_endpoint: string;
@@ -27399,7 +27399,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           readonly expand?: readonly string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          readonly metadata?: { readonly [key: string]: unknown };
+          readonly metadata?: unknown;
           /** The URL of the webhook endpoint. */
           readonly url?: string;
         };

--- a/tests/v2/expected/stripe.ts
+++ b/tests/v2/expected/stripe.ts
@@ -8991,7 +8991,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         three_d_secure: string;
@@ -9013,7 +9013,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
     };
     responses: {
@@ -9040,7 +9040,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -9151,7 +9151,7 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: { [key: string]: unknown };
+            dob?: unknown;
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -9162,7 +9162,7 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: { [key: string]: unknown };
+            metadata?: unknown;
             phone?: string;
             ssn_last_4?: string;
             verification?: {
@@ -9177,7 +9177,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -9211,7 +9211,7 @@ export interface operations {
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: { [key: string]: unknown };
+                delay_days?: unknown;
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?: "friday" | "monday" | "saturday" | "sunday" | "thursday" | "tuesday" | "wednesday";
@@ -9273,7 +9273,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -9301,7 +9301,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -9355,7 +9355,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
         };
@@ -9395,7 +9395,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
     };
     responses: {
@@ -9422,7 +9422,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         capability: string;
@@ -9471,7 +9471,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -9507,7 +9507,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -9535,7 +9535,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -9589,7 +9589,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
         };
@@ -9685,7 +9685,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -9752,7 +9752,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: unknown };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -9776,7 +9776,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -9786,7 +9786,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: unknown };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -9822,7 +9822,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         person: string;
@@ -9879,7 +9879,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: unknown };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -9903,7 +9903,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -9913,7 +9913,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: unknown };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -9967,7 +9967,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -10034,7 +10034,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: unknown };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10058,7 +10058,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -10068,7 +10068,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: unknown };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -10104,7 +10104,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         person: string;
@@ -10161,7 +10161,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: unknown };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10185,7 +10185,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -10195,7 +10195,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: unknown };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -10281,7 +10281,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -10325,7 +10325,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -10438,7 +10438,7 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: { [key: string]: unknown };
+            dob?: unknown;
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -10449,7 +10449,7 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: { [key: string]: unknown };
+            metadata?: unknown;
             phone?: string;
             ssn_last_4?: string;
             verification?: {
@@ -10464,7 +10464,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -10498,7 +10498,7 @@ export interface operations {
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: { [key: string]: unknown };
+                delay_days?: unknown;
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?: "friday" | "monday" | "saturday" | "sunday" | "thursday" | "tuesday" | "wednesday";
@@ -10533,7 +10533,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -10566,7 +10566,7 @@ export interface operations {
           /** An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account. */
           account_token?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -10677,7 +10677,7 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: { [key: string]: unknown };
+            dob?: unknown;
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -10688,7 +10688,7 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: { [key: string]: unknown };
+            metadata?: unknown;
             phone?: string;
             ssn_last_4?: string;
             verification?: {
@@ -10703,7 +10703,7 @@ export interface operations {
             };
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -10737,7 +10737,7 @@ export interface operations {
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: { [key: string]: unknown };
+                delay_days?: unknown;
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?: "friday" | "monday" | "saturday" | "sunday" | "thursday" | "tuesday" | "wednesday";
@@ -10799,7 +10799,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -10827,7 +10827,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -10883,7 +10883,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
         };
@@ -10924,7 +10924,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -10954,7 +10954,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11005,7 +11005,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11047,7 +11047,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -11075,7 +11075,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11131,7 +11131,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
         };
@@ -11232,7 +11232,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11304,7 +11304,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: unknown };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11328,7 +11328,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -11338,7 +11338,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: unknown };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -11374,7 +11374,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11432,7 +11432,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: unknown };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11456,7 +11456,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -11466,7 +11466,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: unknown };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -11521,7 +11521,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -11593,7 +11593,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: unknown };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11617,7 +11617,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -11627,7 +11627,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: unknown };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -11663,7 +11663,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         account: string;
@@ -11721,7 +11721,7 @@ export interface operations {
             town?: string;
           };
           /** The person's date of birth. */
-          dob?: { [key: string]: unknown };
+          dob?: unknown;
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -11745,7 +11745,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -11755,7 +11755,7 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: { [key: string]: unknown };
+            percent_ownership?: unknown;
             representative?: boolean;
             title?: string;
           };
@@ -11841,7 +11841,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         domain_name?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -11898,7 +11898,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         domain: string;
@@ -11938,7 +11938,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return application fees for the charge specified by this charge ID. */
         charge?: string;
         created?: number;
@@ -11974,7 +11974,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         fee: string;
@@ -12009,7 +12009,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -12029,7 +12029,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -12077,7 +12077,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -12156,7 +12156,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
     };
     responses: {
@@ -12179,7 +12179,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         available_on?: number;
         created?: number;
         /** Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -12226,7 +12226,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -12252,7 +12252,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         available_on?: number;
         created?: number;
         /** Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -12299,7 +12299,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -12347,7 +12347,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Filter for active receivers. */
         active?: boolean;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12386,7 +12386,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -12408,7 +12408,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return transactions for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12447,7 +12447,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return transactions for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -12484,7 +12484,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** Only return charges for the customer specified by this customer ID. */
         customer?: string;
@@ -12533,7 +12533,7 @@ export interface operations {
           /** Whether to immediately capture the charge. Defaults to `true`. When `false`, the charge issues an authorization (or pre-authorization), and will need to be [captured](https://stripe.com/docs/api#capture_charge) later. Uncaptured charges expire in _seven days_. For more information, see the [authorizing charges and settling later](https://stripe.com/docs/charges/placing-a-hold) documentation. */
           capture?: boolean;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: unknown };
+          card?: unknown;
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           currency?: string;
           /** The ID of an existing customer that will be charged in this request. */
@@ -12547,7 +12547,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The Stripe account ID for which these funds are intended. Automatically set if you use the `destination` parameter. For details, see [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers#on-behalf-of). */
           on_behalf_of?: string;
           /** The email address to which this charge's [receipt](https://stripe.com/docs/dashboard/receipts) will be sent. The receipt will not be sent until the charge is paid, and no receipts will be sent for test mode charges. If this charge is for a [Customer](https://stripe.com/docs/api/customers/object), the email address specified here will override the customer's email address. If `receipt_email` is specified for a charge in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails). */
@@ -12599,7 +12599,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         charge: string;
@@ -12636,7 +12636,7 @@ export interface operations {
             user_report: "" | "fraudulent" | "safe";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** This is the email address that the receipt for this charge will be sent to. If this field is updated, then a new email receipt will be sent to the updated address. */
           receipt_email?: string;
           /** Shipping information for the charge. Helps prevent fraud on charges for physical goods. */
@@ -12722,7 +12722,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         charge: string;
@@ -12780,7 +12780,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default). */
           submit?: boolean;
         };
@@ -12845,7 +12845,7 @@ export interface operations {
           amount?: number;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           payment_intent?: string;
           reason?: "duplicate" | "fraudulent" | "requested_by_customer";
           refund_application_fee?: boolean;
@@ -12869,7 +12869,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -12938,7 +12938,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         charge: string;
@@ -12968,7 +12968,7 @@ export interface operations {
         payload?: {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -12988,7 +12988,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13421,7 +13421,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         session: string;
@@ -13443,7 +13443,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13476,7 +13476,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         country: string;
@@ -13498,7 +13498,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13553,7 +13553,7 @@ export interface operations {
           /** A positive integer specifying the number of times the coupon can be redeemed before it's no longer valid. For example, you might have a 50% off coupon that the first 20 readers of your blog can use. */
           max_redemptions?: number;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set. */
           name?: string;
           /** A positive float larger than 0, and smaller or equal to 100, that represents the discount the coupon will apply (required if `amount_off` is not passed). */
@@ -13579,7 +13579,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         coupon: string;
@@ -13608,7 +13608,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set. */
           name?: string;
         };
@@ -13648,7 +13648,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return credit notes for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13751,7 +13751,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The integer amount in **%s** representing the total amount of the credit note. */
         amount?: number;
         /** The integer amount in **%s** representing the amount to credit the customer's balance, which will be automatically applied to their next invoice. */
@@ -13759,7 +13759,7 @@ export interface operations {
         /** ID of the invoice. */
         invoice: string;
         /** Line items that make up the credit note. */
-        lines?: any[];
+        lines?: unknown[];
         /** The credit note's memo appears on the credit note PDF. */
         memo?: string;
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -13790,7 +13790,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The integer amount in **%s** representing the total amount of the credit note. */
         amount?: number;
         /** The integer amount in **%s** representing the amount to credit the customer's balance, which will be automatically applied to their next invoice. */
@@ -13802,7 +13802,7 @@ export interface operations {
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** Line items that make up the credit note. */
-        lines?: any[];
+        lines?: unknown[];
         /** The credit note's memo appears on the credit note PDF. */
         memo?: string;
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -13844,7 +13844,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -13881,7 +13881,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -13957,7 +13957,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A filter on the list based on the customer's `email` field. The value must be a string. */
         email?: string;
@@ -13995,7 +13995,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** The customer's address. */
-          address?: { [key: string]: unknown };
+          address?: unknown;
           /** An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice. */
           balance?: number;
           /** The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that particular subscription. */
@@ -14018,7 +14018,7 @@ export interface operations {
             footer?: string;
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The customer's full name or business name. */
           name?: string;
           /** The sequence to be used on the customer's next invoice. Defaults to 1. */
@@ -14030,7 +14030,7 @@ export interface operations {
           /** Customer's preferred languages, ordered by preference. */
           preferred_locales?: string[];
           /** The customer's shipping information. Appears on invoices emailed to this customer. */
-          shipping?: { [key: string]: unknown };
+          shipping?: unknown;
           /**
            * The source can be a [Token](https://stripe.com/docs/api#tokens) or a [Source](https://stripe.com/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free.
            *
@@ -14088,7 +14088,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14119,13 +14119,13 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** The customer's address. */
-          address?: { [key: string]: unknown };
+          address?: unknown;
           /** An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice. */
           balance?: number;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: unknown };
+          card?: unknown;
           /** The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that particular subscription. */
           coupon?: string;
           /** ID of Alipay account to make the customer's new default for invoice payments. */
@@ -14160,7 +14160,7 @@ export interface operations {
             footer?: string;
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The customer's full name or business name. */
           name?: string;
           /** The sequence to be used on the customer's next invoice. Defaults to 1. */
@@ -14170,7 +14170,7 @@ export interface operations {
           /** Customer's preferred languages, ordered by preference. */
           preferred_locales?: string[];
           /** The customer's shipping information. Appears on invoices emailed to this customer. */
-          shipping?: { [key: string]: unknown };
+          shipping?: unknown;
           /**
            * The source can be a [Token](https://stripe.com/docs/api#tokens) or a [Source](https://stripe.com/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free.
            *
@@ -14182,7 +14182,7 @@ export interface operations {
           /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
           tax_exempt?: "" | "exempt" | "none" | "reverse";
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: unknown };
+          trial_end?: unknown;
         };
       };
     };
@@ -14220,7 +14220,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14270,7 +14270,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -14290,7 +14290,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14323,7 +14323,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -14343,7 +14343,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14393,9 +14393,9 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: unknown };
+          card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -14421,7 +14421,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14472,7 +14472,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -14565,7 +14565,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14614,9 +14614,9 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: unknown };
+          card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -14642,7 +14642,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14693,7 +14693,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -14753,7 +14753,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14793,7 +14793,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -14845,9 +14845,9 @@ export interface operations {
           /** A token returned by [Stripe.js](https://stripe.com/docs/stripe.js) representing the user’s Alipay account details. */
           alipay_account?: string;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
-          bank_account?: { [key: string]: unknown };
+          bank_account?: unknown;
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
-          card?: { [key: string]: unknown };
+          card?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -14873,7 +14873,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -14924,7 +14924,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -15013,7 +15013,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -15061,7 +15061,7 @@ export interface operations {
           /** A future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. */
           billing_cycle_anchor?: number;
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: unknown };
+          billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
           cancel_at?: number;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
@@ -15082,14 +15082,14 @@ export interface operations {
           expand?: string[];
           /** A list of up to 20 subscription items, each with an attached plan. */
           items?: {
-            billing_thresholds?: { [key: string]: unknown };
+            billing_thresholds?: unknown;
             metadata?: { [key: string]: unknown };
             plan?: string;
             quantity?: number;
             tax_rates?: string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -15101,7 +15101,7 @@ export interface operations {
            */
           payment_behavior?: "allow_incomplete" | "error_if_incomplete" | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          pending_invoice_item_interval?: { [key: string]: unknown };
+          pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -15111,9 +15111,9 @@ export interface operations {
            */
           proration_behavior?: "always_invoice" | "create_prorations" | "none";
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: unknown };
+          tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: unknown };
+          trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
           /** Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. */
@@ -15137,7 +15137,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -15170,9 +15170,9 @@ export interface operations {
           /** Either `now` or `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle). */
           billing_cycle_anchor?: "now" | "unchanged";
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: unknown };
+          billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
-          cancel_at?: { [key: string]: unknown };
+          cancel_at?: unknown;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
           cancel_at_period_end?: boolean;
           /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
@@ -15191,21 +15191,21 @@ export interface operations {
           expand?: string[];
           /** List of subscription items, each with an attached plan. */
           items?: {
-            billing_thresholds?: { [key: string]: unknown };
+            billing_thresholds?: unknown;
             clear_usage?: boolean;
             deleted?: boolean;
             id?: string;
-            metadata?: { [key: string]: unknown };
+            metadata?: unknown;
             plan?: string;
             quantity?: number;
             tax_rates?: string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /** If specified, payment collection for this subscription will be paused. */
-          pause_collection?: { [key: string]: unknown };
+          pause_collection?: unknown;
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -15215,7 +15215,7 @@ export interface operations {
            */
           payment_behavior?: "allow_incomplete" | "error_if_incomplete" | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          pending_invoice_item_interval?: { [key: string]: unknown };
+          pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -15229,9 +15229,9 @@ export interface operations {
           /** If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. */
           proration_date?: number;
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: unknown };
+          tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: unknown };
+          trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
         };
@@ -15288,7 +15288,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -15330,7 +15330,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -15419,7 +15419,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         customer: string;
@@ -15461,7 +15461,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return disputes associated to the charge specified by this charge ID. */
         charge?: string;
         created?: number;
@@ -15499,7 +15499,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         dispute: string;
@@ -15562,7 +15562,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default). */
           submit?: boolean;
         };
@@ -15664,7 +15664,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** Filter events by whether all webhooks were successfully delivered. If false, events which are still pending or have failed all delivery attempts to a webhook endpoint will be returned. */
         delivery_success?: boolean;
@@ -15677,7 +15677,7 @@ export interface operations {
         /** A string containing a specific event name, or group of events using * as a wildcard. The list will be filtered to include only events with a matching event property. */
         type?: string;
         /** An array of up to 20 strings containing specific event names. The list will be filtered to include only events with a matching event property. You may pass either `type` or `types`, but not both. */
-        types?: any[];
+        types?: unknown[];
       };
     };
     responses: {
@@ -15704,7 +15704,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -15726,7 +15726,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is the currency that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with the exchange rate for currency X your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and total number of supported payout currencies, and the default is the max. */
@@ -15759,7 +15759,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         currency: string;
@@ -15781,7 +15781,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -15827,7 +15827,7 @@ export interface operations {
           /** The ID of the file. The file's `purpose` must be one of the following: `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `finance_report_run`, `pci_document`, `sigma_scheduled_query`, or `tax_document_user_upload`. */
           file: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -15847,7 +15847,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         link: string;
@@ -15876,9 +15876,9 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** A future timestamp after which the link will no longer be usable, or `now` to expire the link immediately. */
-          expires_at?: { [key: string]: unknown };
+          expires_at?: unknown;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -15898,7 +15898,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -15947,7 +15947,7 @@ export interface operations {
           file_link_data?: {
             create: boolean;
             expires_at?: number;
-            metadata?: { [key: string]: unknown };
+            metadata?: unknown;
           };
           /** The purpose of the uploaded file. Possible values are `additional_verification`, `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`, or `tax_document_user_upload`. */
           purpose:
@@ -15978,7 +15978,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         file: string;
@@ -16000,7 +16000,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** The identifier of the customer whose invoice items to return. If none is provided, all invoice items will be returned. */
         customer?: string;
@@ -16056,7 +16056,7 @@ export interface operations {
           /** The ID of an existing invoice to add this invoice item to. When left blank, the invoice item will be added to the next upcoming scheduled invoice. This is useful when adding invoice items in response to an invoice.created webhook. You can only add invoice items to draft invoices. */
           invoice?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The period associated with this invoice item. */
           period?: {
             end: number;
@@ -16091,7 +16091,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         invoiceitem: string;
@@ -16126,7 +16126,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The period associated with this invoice item. */
           period?: {
             end: number;
@@ -16177,7 +16177,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The collection method of the invoice to retrieve. Either `charge_automatically` or `send_invoice`. */
         collection_method?: string;
         created?: number;
@@ -16251,7 +16251,7 @@ export interface operations {
           /** Footer to be displayed on the invoice. */
           footer?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`. */
           statement_descriptor?: string;
           /** The ID of the subscription to invoice, if any. If not set, the created invoice will include all pending invoice items for the customer. If set, the created invoice will only include pending invoice items for that subscription and pending invoice items not associated with any subscription. The subscription's billing cycle and regular subscription events won't be affected. */
@@ -16283,13 +16283,13 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The code of the coupon to apply. If `subscription` or `subscription_items` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. The invoice can be previewed without a coupon by passing this value as an empty string. */
         coupon?: string;
         /** The identifier of the customer whose upcoming invoice you'd like to retrieve. */
         customer?: string;
         /** List of invoice items to add or update in the upcoming invoice preview. */
-        invoice_items?: any[];
+        invoice_items?: unknown[];
         /** The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields. */
         schedule?: string;
         /** The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If not provided, but a `subscription_items` is provided, you will preview creating a subscription with those items. If neither `subscription` nor `subscription_items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions. */
@@ -16305,7 +16305,7 @@ export interface operations {
         /** If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set. */
         subscription_default_tax_rates?: string;
         /** List of subscription items, each with an attached plan. */
-        subscription_items?: any[];
+        subscription_items?: unknown[];
         /** If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. */
         subscription_prorate?: boolean;
         /**
@@ -16344,7 +16344,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The code of the coupon to apply. If `subscription` or `subscription_items` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. The invoice can be previewed without a coupon by passing this value as an empty string. */
         coupon?: string;
         /** The identifier of the customer whose upcoming invoice you'd like to retrieve. */
@@ -16352,7 +16352,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** List of invoice items to add or update in the upcoming invoice preview. */
-        invoice_items?: any[];
+        invoice_items?: unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields. */
@@ -16372,7 +16372,7 @@ export interface operations {
         /** If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set. */
         subscription_default_tax_rates?: string;
         /** List of subscription items, each with an attached plan. */
-        subscription_items?: any[];
+        subscription_items?: unknown[];
         /** If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. */
         subscription_prorate?: boolean;
         /**
@@ -16420,7 +16420,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         invoice: string;
@@ -16481,11 +16481,11 @@ export interface operations {
           /** Footer to be displayed on the invoice. */
           footer?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`. */
           statement_descriptor?: string;
           /** The percent tax rate applied to the invoice, represented as a non-negative decimal number (with at most four decimal places) between 0 and 100. To unset a previously-set value, pass an empty string. This field can be updated only on `draft` invoices. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: unknown };
+          tax_percent?: unknown;
         };
       };
     };
@@ -16550,7 +16550,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -16705,7 +16705,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return issuer fraud records for the charge specified by this charge ID. */
         charge?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -16744,7 +16744,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         issuer_fraud_record: string;
@@ -16766,7 +16766,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return issuing transactions that belong to the given card. */
         card?: string;
         /** Only return authorizations belonging to the given cardholder. */
@@ -16807,7 +16807,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         authorization: string;
@@ -16836,7 +16836,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -16865,7 +16865,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -16892,7 +16892,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -16912,7 +16912,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return cardholders that were created during the given date interval. */
         created?: number;
         /** Only return cardholders that have the given email address. */
@@ -17898,7 +17898,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         cardholder: string;
@@ -18862,7 +18862,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return cards belonging to the Cardholder with the provided ID. */
         cardholder?: string;
         /** Only return cards that were issued during the given date interval. */
@@ -19836,7 +19836,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         card: string;
@@ -19867,7 +19867,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details. */
           spending_controls?: {
             allowed_categories?: (
@@ -20766,7 +20766,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -20823,7 +20823,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         dispute: string;
@@ -20872,7 +20872,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return issuing settlements that were created during the given date interval. */
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -20907,7 +20907,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         settlement: string;
@@ -20956,7 +20956,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return transactions that belong to the given card. */
         card?: string;
         /** Only return transactions that belong to the given cardholder. */
@@ -20995,7 +20995,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         transaction: string;
@@ -21024,7 +21024,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -21044,7 +21044,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         mandate: string;
@@ -21066,7 +21066,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Date this return was created. */
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -21103,7 +21103,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -21125,7 +21125,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Date this order was created. */
         created?: number;
         /** Only return orders for the given customer. */
@@ -21133,7 +21133,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Only return orders with the given IDs. */
-        ids?: any[];
+        ids?: unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
@@ -21143,7 +21143,7 @@ export interface operations {
         /** Filter orders based on when they were paid, fulfilled, canceled, or returned. */
         status_transitions?: string;
         /** Only return orders with the given upstream order IDs. */
-        upstream_ids?: any[];
+        upstream_ids?: unknown[];
       };
     };
     responses: {
@@ -21224,7 +21224,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -21255,7 +21255,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The shipping method to select for fulfilling this order. If specified, must be one of the `id`s of a shipping method in the `shipping_methods` array. If specified, will overwrite the existing selected shipping method, updating `items` as necessary. */
           selected_shipping_method?: string;
           /** Tracking information once the order has been fulfilled. */
@@ -21352,7 +21352,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         created?: number;
         /** Only return PaymentIntents for the customer specified by this customer ID. */
@@ -21447,7 +21447,7 @@ export interface operations {
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: { [key: string]: unknown };
           /** Set to `true` to indicate that the customer is not in your checkout flow during this payment attempt, and therefore is unable to authenticate. This parameter is intended for scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards). This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm). */
-          off_session?: { [key: string]: unknown };
+          off_session?: unknown;
           /** The Stripe account ID for which these funds are intended. For details, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts). */
           on_behalf_of?: string;
           /**
@@ -21458,7 +21458,7 @@ export interface operations {
           payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           payment_method_options?: {
-            card?: { [key: string]: unknown };
+            card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. If this is not provided, defaults to ["card"]. */
           payment_method_types?: string[];
@@ -21530,7 +21530,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The client secret of the PaymentIntent. Required if a publishable key is used to retrieve the source. */
         client_secret?: string;
       };
@@ -21569,7 +21569,7 @@ export interface operations {
           /** Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
           amount?: number;
           /** The amount of the application fee (if any) for the resulting payment. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
-          application_fee_amount?: { [key: string]: unknown };
+          application_fee_amount?: unknown;
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           currency?: string;
           /**
@@ -21585,12 +21585,12 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           payment_method_options?: {
-            card?: { [key: string]: unknown };
+            card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
           payment_method_types?: string[];
@@ -21607,7 +21607,7 @@ export interface operations {
            */
           setup_future_usage?: "" | "off_session" | "on_session";
           /** Shipping information for this PaymentIntent. */
-          shipping?: { [key: string]: unknown };
+          shipping?: unknown;
           /** For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
           statement_descriptor?: string;
           /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
@@ -21769,12 +21769,12 @@ export interface operations {
             };
           };
           /** Set to `true` to indicate that the customer is not in your checkout flow during this payment attempt, and therefore is unable to authenticate. This parameter is intended for scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards). */
-          off_session?: { [key: string]: unknown };
+          off_session?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
           payment_method_options?: {
-            card?: { [key: string]: unknown };
+            card?: unknown;
           };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
           payment_method_types?: string[];
@@ -21797,7 +21797,7 @@ export interface operations {
            */
           setup_future_usage?: "" | "off_session" | "on_session";
           /** Shipping information for this PaymentIntent. */
-          shipping?: { [key: string]: unknown };
+          shipping?: unknown;
           /** Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle additional authentication steps. */
           use_stripe_sdk?: boolean;
         };
@@ -21819,7 +21819,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The ID of the customer whose PaymentMethods will be retrieved. */
         customer: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -21951,7 +21951,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         payment_method: string;
@@ -21999,7 +21999,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
           sepa_debit?: { [key: string]: unknown };
         };
@@ -22085,7 +22085,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         arrival_date?: number;
         created?: number;
         /** The ID of an external account - only return payouts sent to this external account. */
@@ -22168,7 +22168,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         payout: string;
@@ -22197,7 +22197,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -22242,7 +22242,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return plans that are active or inactive (e.g., pass `false` to list all inactive plans). */
         active?: boolean;
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
@@ -22303,7 +22303,7 @@ export interface operations {
           /** The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). */
           interval_count?: number;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A brief description of the plan, hidden from customers. */
           nickname?: string;
           /** The product whose pricing the created plan will represent. This can either be the ID of an existing product, or a dictionary containing fields used to create a [service product](https://stripe.com/docs/api#product_object-type). */
@@ -22321,7 +22321,7 @@ export interface operations {
             flat_amount_decimal?: string;
             unit_amount?: number;
             unit_amount_decimal?: string;
-            up_to: { [key: string]: unknown };
+            up_to: unknown;
           }[];
           /** Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows. */
           tiers_mode?: "graduated" | "volume";
@@ -22353,7 +22353,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         plan: string;
@@ -22384,7 +22384,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A brief description of the plan, hidden from customers. */
           nickname?: string;
           /** The product the plan belongs to. Note that after updating, statement descriptors and line items of the plan in active subscriptions will be affected. */
@@ -22428,7 +22428,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return products that are active or inactive (e.g., pass `false` to list all inactive products). */
         active?: boolean;
         /** Only return products that were created during the given date interval. */
@@ -22436,7 +22436,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Only return products with the given IDs. */
-        ids?: any[];
+        ids?: unknown[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** Only return products that can be shipped (i.e., physical, not digital products). */
@@ -22535,7 +22535,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -22576,11 +22576,11 @@ export interface operations {
           /** A list of up to 8 URLs of images for this product, meant to be displayable to the customer. */
           images?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions. */
           name?: string;
           /** The dimensions of this product for shipping purposes. A SKU associated with this product can override this value by having its own `package_dimensions`. May only be set if `type=good`. */
-          package_dimensions?: { [key: string]: unknown };
+          package_dimensions?: unknown;
           /** Whether this product is shipped (i.e., physical goods). Defaults to `true`. May only be set if `type=good`. */
           shippable?: boolean;
           /**
@@ -22631,7 +22631,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return early fraud warnings for the charge specified by this charge ID. */
         charge?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -22670,7 +22670,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         early_fraud_warning: string;
@@ -22692,7 +22692,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -22756,7 +22756,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         item: string;
@@ -22796,7 +22796,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The alias used to reference the value list when writing rules. */
         alias?: string;
         /** A value contained within a value list - returns all value lists containing this value. */
@@ -22871,7 +22871,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         value_list: string;
@@ -22942,7 +22942,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -22994,7 +22994,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The recipient's full, legal name. For type `individual`, should be in the format `First Last`, `First Middle Last`, or `First M Last` (no prefixes or suffixes). For `corporation`, the full, incorporated name. */
           name: string;
           /** The recipient's tax ID, as a string. For type `individual`, the full SSN; for type `corporation`, the full EIN. */
@@ -23020,7 +23020,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -23065,7 +23065,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The recipient's full, legal name. For type `individual`, should be in the format `First Last`, `First Middle Last`, or `First M Last` (no prefixes or suffixes). For `corporation`, the full, incorporated name. */
           name?: string;
           /** The recipient's tax ID, as a string. For type `individual`, the full SSN; for type `corporation`, the full EIN. */
@@ -23107,7 +23107,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return refunds for the charge specified by this charge ID. */
         charge?: string;
         created?: number;
@@ -23175,7 +23175,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         refund: string;
@@ -23208,7 +23208,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -23228,7 +23228,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -23922,7 +23922,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         report_run: string;
@@ -23944,7 +23944,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
     };
     responses: {
@@ -23971,7 +23971,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         report_type: string;
@@ -23993,7 +23993,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
@@ -24027,7 +24027,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         review: string;
@@ -24074,7 +24074,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         created?: number;
         /** Only return SetupIntents for the customer specified by this customer ID. */
@@ -24191,7 +24191,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The client secret of the SetupIntent. Required if a publishable key is used to retrieve the SetupIntent. */
         client_secret?: string;
       };
@@ -24230,7 +24230,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this SetupIntent. */
@@ -24358,7 +24358,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24391,7 +24391,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         scheduled_query_run: string;
@@ -24413,7 +24413,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return SKUs that are active or inactive (e.g., pass `false` to list all inactive products). */
         active?: boolean;
         /** Only return SKUs that have the specified key-value pairs in this partially constructed dictionary. Can be specified only if `product` is also supplied. For instance, if the associated product has attributes `["color", "size"]`, passing in `attributes[color]=red` returns all the SKUs for this product that have `color` set to `red`. */
@@ -24421,7 +24421,7 @@ export interface operations {
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Only return SKUs with the given IDs. */
-        ids?: any[];
+        ids?: unknown[];
         /** Only return SKUs that are either in stock or out of stock (e.g., pass `false` to list all SKUs that are out of stock). If no value is provided, all SKUs are returned. */
         in_stock?: boolean;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24507,7 +24507,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -24554,9 +24554,9 @@ export interface operations {
             value?: "" | "in_stock" | "limited" | "out_of_stock";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The dimensions of this SKU for shipping purposes. */
-          package_dimensions?: { [key: string]: unknown };
+          package_dimensions?: unknown;
           /** The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency). */
           price?: number;
           /** The ID of the product that this SKU should belong to. The product must exist, have the same set of attribute names as the SKU's current product, and be of type `good`. */
@@ -24626,7 +24626,7 @@ export interface operations {
               type?: "offline" | "online";
               user_agent?: string;
             };
-            amount?: { [key: string]: unknown };
+            amount?: unknown;
             currency?: string;
             interval?: "one_time" | "scheduled" | "variable";
             notification_method?: "deprecated_none" | "email" | "manual" | "none" | "stripe_email";
@@ -24709,7 +24709,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The client secret of the source. Required if a publishable key is used to retrieve the source. */
         client_secret?: string;
       };
@@ -24762,13 +24762,13 @@ export interface operations {
               type?: "offline" | "online";
               user_agent?: string;
             };
-            amount?: { [key: string]: unknown };
+            amount?: unknown;
             currency?: string;
             interval?: "one_time" | "scheduled" | "variable";
             notification_method?: "deprecated_none" | "email" | "manual" | "none" | "stripe_email";
           };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Information about the owner of the payment instrument that may be used or required by particular source types. */
           owner?: {
             address?: {
@@ -24827,7 +24827,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         mandate_notification: string;
@@ -24850,7 +24850,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24886,7 +24886,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         source: string;
@@ -24936,7 +24936,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -24973,7 +24973,7 @@ export interface operations {
         /** Body parameters for the request. */
         payload: {
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: unknown };
+          billing_thresholds?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -25025,7 +25025,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         item: string;
@@ -25052,11 +25052,11 @@ export interface operations {
         /** Body parameters for the request. */
         payload?: {
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: unknown };
+          billing_thresholds?: unknown;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -25145,7 +25145,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -25220,7 +25220,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Only return subscription schedules that were created canceled the given date interval. */
         canceled_at?: number;
         /** Only return subscription schedules that completed during the given date interval. */
@@ -25270,7 +25270,7 @@ export interface operations {
           customer?: string;
           /** Object representing the subscription schedule's default settings. */
           default_settings?: {
-            billing_thresholds?: { [key: string]: unknown };
+            billing_thresholds?: unknown;
             collection_method?: "charge_automatically" | "send_invoice";
             default_payment_method?: string;
             invoice_settings?: {
@@ -25284,11 +25284,11 @@ export interface operations {
           /** Migrate an existing subscription to be managed by a subscription schedule. If this parameter is set, a subscription schedule will be created using the subscription's plan(s), set to auto-renew using the subscription's interval. When using this parameter, other parameters (such as phase values) cannot be set. To create a subscription schedule with other modifications, we recommend making two separate API calls. */
           from_subscription?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. */
           phases?: {
             application_fee_percent?: number;
-            billing_thresholds?: { [key: string]: unknown };
+            billing_thresholds?: unknown;
             collection_method?: "charge_automatically" | "send_invoice";
             coupon?: string;
             default_payment_method?: string;
@@ -25299,7 +25299,7 @@ export interface operations {
             };
             iterations?: number;
             plans: {
-              billing_thresholds?: { [key: string]: unknown };
+              billing_thresholds?: unknown;
               plan?: string;
               quantity?: number;
               tax_rates?: string[];
@@ -25310,7 +25310,7 @@ export interface operations {
             trial_end?: number;
           }[];
           /** When the subscription schedule starts. We recommend using `now` so that it starts the subscription immediately. You can also use a Unix timestamp to backdate the subscription so that it starts on a past date, or set a future date for the subscription to start on. */
-          start_date?: { [key: string]: unknown };
+          start_date?: unknown;
         };
       };
     };
@@ -25330,7 +25330,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         schedule: string;
@@ -25358,7 +25358,7 @@ export interface operations {
         payload?: {
           /** Object representing the subscription schedule's default settings. */
           default_settings?: {
-            billing_thresholds?: { [key: string]: unknown };
+            billing_thresholds?: unknown;
             collection_method?: "charge_automatically" | "send_invoice";
             default_payment_method?: string;
             invoice_settings?: {
@@ -25370,31 +25370,31 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. Note that past phases can be omitted. */
           phases?: {
             application_fee_percent?: number;
-            billing_thresholds?: { [key: string]: unknown };
+            billing_thresholds?: unknown;
             collection_method?: "charge_automatically" | "send_invoice";
             coupon?: string;
             default_payment_method?: string;
             default_tax_rates?: string[];
-            end_date?: { [key: string]: unknown };
+            end_date?: unknown;
             invoice_settings?: {
               days_until_due?: number;
             };
             iterations?: number;
             plans: {
-              billing_thresholds?: { [key: string]: unknown };
+              billing_thresholds?: unknown;
               plan?: string;
               quantity?: number;
               tax_rates?: string[];
             }[];
             proration_behavior?: "always_invoice" | "create_prorations" | "none";
-            start_date?: { [key: string]: unknown };
+            start_date?: unknown;
             tax_percent?: number;
             trial?: boolean;
-            trial_end?: { [key: string]: unknown };
+            trial_end?: unknown;
           }[];
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
@@ -25475,7 +25475,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** The collection method of the subscriptions to retrieve. Either `charge_automatically` or `send_invoice`. */
         collection_method?: string;
         created?: number;
@@ -25527,7 +25527,7 @@ export interface operations {
           /** A future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. */
           billing_cycle_anchor?: number;
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: unknown };
+          billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
           cancel_at?: number;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
@@ -25550,14 +25550,14 @@ export interface operations {
           expand?: string[];
           /** A list of up to 20 subscription items, each with an attached plan. */
           items?: {
-            billing_thresholds?: { [key: string]: unknown };
+            billing_thresholds?: unknown;
             metadata?: { [key: string]: unknown };
             plan?: string;
             quantity?: number;
             tax_rates?: string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -25569,7 +25569,7 @@ export interface operations {
            */
           payment_behavior?: "allow_incomplete" | "error_if_incomplete" | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          pending_invoice_item_interval?: { [key: string]: unknown };
+          pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -25579,9 +25579,9 @@ export interface operations {
            */
           proration_behavior?: "always_invoice" | "create_prorations" | "none";
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: unknown };
+          tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: unknown };
+          trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
           /** Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. */
@@ -25605,7 +25605,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         subscription_exposed_id: string;
@@ -25636,9 +25636,9 @@ export interface operations {
           /** Either `now` or `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle). */
           billing_cycle_anchor?: "now" | "unchanged";
           /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds. */
-          billing_thresholds?: { [key: string]: unknown };
+          billing_thresholds?: unknown;
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
-          cancel_at?: { [key: string]: unknown };
+          cancel_at?: unknown;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
           cancel_at_period_end?: boolean;
           /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
@@ -25657,21 +25657,21 @@ export interface operations {
           expand?: string[];
           /** List of subscription items, each with an attached plan. */
           items?: {
-            billing_thresholds?: { [key: string]: unknown };
+            billing_thresholds?: unknown;
             clear_usage?: boolean;
             deleted?: boolean;
             id?: string;
-            metadata?: { [key: string]: unknown };
+            metadata?: unknown;
             plan?: string;
             quantity?: number;
             tax_rates?: string[];
           }[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /** If specified, payment collection for this subscription will be paused. */
-          pause_collection?: { [key: string]: unknown };
+          pause_collection?: unknown;
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -25681,7 +25681,7 @@ export interface operations {
            */
           payment_behavior?: "allow_incomplete" | "error_if_incomplete" | "pending_if_incomplete";
           /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
-          pending_invoice_item_interval?: { [key: string]: unknown };
+          pending_invoice_item_interval?: unknown;
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -25695,9 +25695,9 @@ export interface operations {
           /** If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. */
           proration_date?: number;
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: { [key: string]: unknown };
+          tax_percent?: unknown;
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: { [key: string]: unknown };
+          trial_end?: unknown;
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
         };
@@ -25772,7 +25772,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Optional flag to filter by tax rates that are either active or not active (archived) */
         active?: boolean;
         /** Optional range for filtering created date */
@@ -25847,7 +25847,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         tax_rate: string;
@@ -25884,7 +25884,7 @@ export interface operations {
           /** The jurisdiction for the tax rate. */
           jurisdiction?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -25928,7 +25928,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -25976,7 +25976,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -25996,7 +25996,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         location: string;
@@ -26036,7 +26036,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -26074,7 +26074,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** Filters readers by device type */
         device_type?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -26122,7 +26122,7 @@ export interface operations {
           /** The location to assign the reader to. If no location is specified, the reader will be assigned to the account's default location. */
           location?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** A code generated by the reader used for registering to an account. */
           registration_code: string;
         };
@@ -26144,7 +26144,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         reader: string;
@@ -26175,7 +26175,7 @@ export interface operations {
           /** The new label of the reader. */
           label?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -26308,7 +26308,7 @@ export interface operations {
                 state?: string;
                 town?: string;
               };
-              dob?: { [key: string]: unknown };
+              dob?: unknown;
               email?: string;
               first_name?: string;
               first_name_kana?: string;
@@ -26319,7 +26319,7 @@ export interface operations {
               last_name_kana?: string;
               last_name_kanji?: string;
               maiden_name?: string;
-              metadata?: { [key: string]: unknown };
+              metadata?: unknown;
               phone?: string;
               ssn_last_4?: string;
               verification?: {
@@ -26344,7 +26344,7 @@ export interface operations {
             currency?: string;
             routing_number?: string;
           };
-          card?: { [key: string]: unknown };
+          card?: unknown;
           /** The customer (owned by the application's account) for which to create a token. This can be used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods). */
           customer?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -26377,7 +26377,7 @@ export interface operations {
               state?: string;
               town?: string;
             };
-            dob?: { [key: string]: unknown };
+            dob?: unknown;
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -26388,13 +26388,13 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: { [key: string]: unknown };
+            metadata?: unknown;
             phone?: string;
             relationship?: {
               director?: boolean;
               executive?: boolean;
               owner?: boolean;
-              percent_ownership?: { [key: string]: unknown };
+              percent_ownership?: unknown;
               representative?: boolean;
               title?: string;
             };
@@ -26433,7 +26433,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         token: string;
@@ -26455,7 +26455,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A positive integer representing how much to transfer. */
         amount?: number;
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
@@ -26504,7 +26504,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The ID of a source to transfer funds from. For most users, this should be left unspecified which will use the bank account that was set up in the dashboard for the specified currency. In test mode, this can be a test bank token (see [Testing Top-ups](https://stripe.com/docs/connect/testing#testing-top-ups)). */
           source?: string;
           /** Extra information about a top-up for the source's bank statement. Limited to 15 ASCII characters. */
@@ -26530,7 +26530,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         topup: string;
@@ -26561,7 +26561,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -26606,7 +26606,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         created?: number;
         /** Only return transfers for the destination specified by this account ID. */
         destination?: string;
@@ -26683,7 +26683,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -26737,7 +26737,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** Boolean indicating whether the application fee should be refunded when reversing this transfer. If a full transfer reversal is given, the full application fee will be refunded. Otherwise, the application fee will be refunded with an amount proportional to the amount of the transfer reversed. */
           refund_application_fee?: boolean;
         };
@@ -26759,7 +26759,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         transfer: string;
@@ -26794,7 +26794,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -26814,7 +26814,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         id: string;
@@ -26849,7 +26849,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
         };
       };
     };
@@ -26869,7 +26869,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
@@ -27159,7 +27159,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The URL of the webhook endpoint. */
           url: string;
         };
@@ -27181,7 +27181,7 @@ export interface operations {
     parameters: {
       query: {
         /** Specifies which fields in the response should be expanded. */
-        expand?: any[];
+        expand?: unknown[];
       };
       path: {
         webhook_endpoint: string;
@@ -27366,7 +27366,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: { [key: string]: unknown };
+          metadata?: unknown;
           /** The URL of the webhook endpoint. */
           url?: string;
         };

--- a/tests/v3/expected/github.additional.ts
+++ b/tests/v3/expected/github.additional.ts
@@ -5153,7 +5153,7 @@ export interface components {
           type: string;
           site_admin: boolean;
           starred_at?: string;
-        } & { [key: string]: any })
+        } & { [key: string]: unknown })
       | null;
     /** GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub. */
     integration: {
@@ -5162,7 +5162,7 @@ export interface components {
       /** The slug name of the GitHub app */
       slug?: string;
       node_id: string;
-      owner: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      owner: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** The name of the GitHub app */
       name: string;
       description: string | null;
@@ -5186,18 +5186,18 @@ export interface components {
       client_secret?: string;
       webhook_secret?: string;
       pem?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Basic Error */
     "basic-error": {
       message?: string;
       documentation_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Validation Error Simple */
     "validation-error-simple": {
       message: string;
       documentation_url: string;
       errors?: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The URL to which the payloads will be delivered. */
     "webhook-config-url": string;
     /** The media type used to serialize the payloads. Supported values include `json` and `form`. The default is `form`. */
@@ -5212,7 +5212,7 @@ export interface components {
       content_type?: components["schemas"]["webhook-config-content-type"];
       secret?: components["schemas"]["webhook-config-secret"];
       insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** An enterprise account */
     enterprise: {
       /** A short description of the enterprise. */
@@ -5230,14 +5230,14 @@ export interface components {
       created_at: string | null;
       updated_at: string | null;
       avatar_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Installation */
     installation: {
       /** The ID of the installation. */
       id: number;
       account:
         | ((Partial<components["schemas"]["simple-user"]> & Partial<components["schemas"]["enterprise"]>) & {
-            [key: string]: any;
+            [key: string]: unknown;
           })
         | null;
       /** Describe whether all repositories have been selected or there's a selection involved */
@@ -5258,7 +5258,7 @@ export interface components {
         statuses?: string;
         issues?: string;
         organization_administration?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       events: string[];
       created_at: string;
       updated_at: string;
@@ -5266,10 +5266,10 @@ export interface components {
       has_multiple_single_files?: boolean;
       single_file_paths?: string[];
       app_slug: string;
-      suspended_by?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      suspended_by?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       suspended_at?: string | null;
       contact_email?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The permissions granted to the user-to-server access token. */
     "app-permissions": {
       /** The level of permission to grant the access token for GitHub Actions workflows, workflow runs, and artifacts. Can be one of: `read` or `write`. */
@@ -5332,7 +5332,7 @@ export interface components {
       organization_user_blocking?: "read" | "write";
       /** The level of permission to grant the access token to manage team discussions and related comments. Can be one of: `read` or `write`. */
       team_discussions?: "read" | "write";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** License Simple */
     "license-simple": {
       key: string;
@@ -5341,7 +5341,7 @@ export interface components {
       spdx_id: string | null;
       node_id: string;
       html_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A git repository */
     repository: {
       /** Unique identifier of the repository */
@@ -5350,7 +5350,7 @@ export interface components {
       /** The name of the repository. */
       name: string;
       full_name: string;
-      license: (components["schemas"]["license-simple"] & { [key: string]: any }) | null;
+      license: (components["schemas"]["license-simple"] & { [key: string]: unknown }) | null;
       forks: number;
       permissions?: {
         admin: boolean;
@@ -5358,8 +5358,8 @@ export interface components {
         triage?: boolean;
         push: boolean;
         maintain?: boolean;
-      } & { [key: string]: any };
-      owner: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      } & { [key: string]: unknown };
+      owner: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** Whether the repository is private or public. */
       private: boolean;
       html_url: string;
@@ -5464,7 +5464,7 @@ export interface components {
               received_events_url?: string;
               type?: string;
               site_admin?: boolean;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             private?: boolean;
             html_url?: string;
             description?: string;
@@ -5536,7 +5536,7 @@ export interface components {
               admin?: boolean;
               push?: boolean;
               pull?: boolean;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             allow_rebase_merge?: boolean;
             temp_clone_token?: string;
             allow_squash_merge?: boolean;
@@ -5544,7 +5544,7 @@ export interface components {
             allow_merge_commit?: boolean;
             subscribers_count?: number;
             network_count?: number;
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
       temp_clone_token?: string;
       /** Whether to allow squash merges for pull requests. */
@@ -5559,7 +5559,7 @@ export interface components {
       watchers: number;
       master_branch?: string;
       starred_at?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Authentication token for a GitHub App installed on a user or org. */
     "installation-token": {
       token: string;
@@ -5569,13 +5569,13 @@ export interface components {
         contents?: string;
         metadata?: string;
         single_file?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       repository_selection?: "all" | "selected";
       repositories?: components["schemas"]["repository"][];
       single_file?: string;
       has_multiple_single_files?: boolean;
       single_file_paths?: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Validation Error */
     "validation-error": {
       message: string;
@@ -5586,9 +5586,9 @@ export interface components {
         message?: string;
         code: string;
         index?: number;
-        value?: ((string | null) | (number | null) | (string[] | null)) & { [key: string]: any };
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+        value?: ((string | null) | (number | null) | (string[] | null)) & { [key: string]: unknown };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     /** The authorization associated with an OAuth Access. */
     "application-grant": {
       id: number;
@@ -5597,12 +5597,12 @@ export interface components {
         client_id: string;
         name: string;
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       created_at: string;
       updated_at: string;
       scopes: string[];
-      user?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      user?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     "scoped-installation": {
       permissions: components["schemas"]["app-permissions"];
       /** Describe whether all repositories have been selected or there's a selection involved */
@@ -5612,7 +5612,7 @@ export interface components {
       single_file_paths?: string[];
       repositories_url: string;
       account: components["schemas"]["simple-user"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The authorization for an OAuth app, GitHub App, or a Personal Access Token. */
     authorization: {
       id: number;
@@ -5626,15 +5626,15 @@ export interface components {
         client_id: string;
         name: string;
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       note: string | null;
       note_url: string | null;
       updated_at: string;
       created_at: string;
       fingerprint: string | null;
-      user?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      installation?: (components["schemas"]["scoped-installation"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      user?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      installation?: (components["schemas"]["scoped-installation"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     /** Code Of Conduct */
     "code-of-conduct": {
       key: string;
@@ -5642,7 +5642,7 @@ export interface components {
       url: string;
       body?: string;
       html_url: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Content Reference attachments allow you to provide context around URLs posted in comments */
     "content-reference-attachment": {
       /** The ID of the attachment */
@@ -5653,7 +5653,7 @@ export interface components {
       body: string;
       /** The node_id of the content attachment */
       node_id?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The policy that controls the organizations in the enterprise that are allowed to run GitHub Actions. Can be one of: `all`, `none`, or `selected`. */
     "enabled-organizations": "all" | "none" | "selected";
     /** The permissions policy that controls the actions that are allowed to run. Can be one of: `all`, `local_only`, or `selected`. */
@@ -5666,7 +5666,7 @@ export interface components {
       selected_organizations_url?: string;
       allowed_actions: components["schemas"]["allowed-actions"];
       selected_actions_url?: components["schemas"]["selected-actions-url"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Organization Simple */
     "organization-simple": {
       login: string;
@@ -5681,7 +5681,7 @@ export interface components {
       public_members_url: string;
       avatar_url: string;
       description: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "selected-actions": {
       /** Whether GitHub-owned actions are allowed. For example, this includes the actions in the `actions` organization. */
       github_owned_allowed: boolean;
@@ -5689,7 +5689,7 @@ export interface components {
       verified_allowed: boolean;
       /** Specifies a list of string-matching patterns to allow specific action(s). Wildcards, tags, and SHAs are allowed. For example, `monalisa/octocat@*`, `monalisa/octocat@v2`, `monalisa/*`." */
       patterns_allowed: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "runner-groups-enterprise": {
       id: number;
       name: string;
@@ -5698,7 +5698,7 @@ export interface components {
       selected_organizations_url?: string;
       runners_url: string;
       allows_public_repositories: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A self hosted runner */
     runner: {
       /** The id of the runner. */
@@ -5717,15 +5717,15 @@ export interface components {
         name?: string;
         /** The type of label. Read-only labels are applied automatically when the runner is configured. */
         type?: "read-only" | "custom";
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     /** Runner Application */
     "runner-application": {
       os: string;
       architecture: string;
       download_url: string;
       filename: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Authentication Token */
     "authentication-token": {
       /** The token used for authentication */
@@ -5738,7 +5738,7 @@ export interface components {
       single_file?: string | null;
       /** Describe whether all repositories have been selected or there's a selection involved */
       repository_selection?: "all" | "selected";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "audit-log-event": {
       /** The time the audit log event occurred, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time). */
       "@timestamp"?: number;
@@ -5751,15 +5751,15 @@ export interface components {
       /** The username of the account being blocked. */
       blocked_user?: string;
       business?: string;
-      config?: any[];
-      config_was?: any[];
+      config?: unknown[];
+      config_was?: unknown[];
       content_type?: string;
       /** The time the audit log event was recorded, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time). */
       created_at?: number;
       deploy_key_fingerprint?: string;
       emoji?: string;
-      events?: any[];
-      events_were?: any[];
+      events?: unknown[];
+      events_were?: unknown[];
       explanation?: string;
       fingerprint?: string;
       hook_id?: number;
@@ -5786,7 +5786,7 @@ export interface components {
       user?: string;
       /** The repository visibility, for example `public` or `private`. */
       visibility?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "actions-billing-usage": {
       /** The sum of the free and paid GitHub Actions minutes used. */
       total_minutes_used: number;
@@ -5801,8 +5801,8 @@ export interface components {
         MACOS?: number;
         /** Total minutes used on Windows runner machines. */
         WINDOWS?: number;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     "packages-billing-usage": {
       /** Sum of the free and paid storage space (GB) for GitHuub Packages. */
       total_gigabytes_bandwidth_used: number;
@@ -5810,7 +5810,7 @@ export interface components {
       total_paid_gigabytes_bandwidth_used: number;
       /** Free storage space (GB) for GitHub Packages. */
       included_gigabytes_bandwidth: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "combined-billing-usage": {
       /** Numbers of days left in billing cycle. */
       days_left_in_billing_cycle: number;
@@ -5818,7 +5818,7 @@ export interface components {
       estimated_paid_storage_for_month: number;
       /** Estimated sum of free and paid storage space (GB) used in billing cycle. */
       estimated_storage_for_month: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Actor */
     actor: {
       id: number;
@@ -5827,7 +5827,7 @@ export interface components {
       gravatar_id: string | null;
       url: string;
       avatar_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Color-coded labels help you categorize and filter your issues (just like labels in Gmail). */
     label: {
       id: number;
@@ -5840,7 +5840,7 @@ export interface components {
       /** 6-character hex code, without the leading #, identifying the color */
       color: string;
       default: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A collection of related issues and pull requests. */
     milestone: {
       url: string;
@@ -5855,14 +5855,14 @@ export interface components {
       /** The title of the milestone. */
       title: string;
       description: string | null;
-      creator: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      creator: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       open_issues: number;
       closed_issues: number;
       created_at: string;
       updated_at: string;
       closed_at: string | null;
       due_on: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** How the author is associated with the repository. */
     author_association:
       | "COLLABORATOR"
@@ -5887,11 +5887,11 @@ export interface components {
       state: string;
       title: string;
       body?: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       labels: components["schemas"]["label"][];
-      assignee: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      assignee: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       assignees?: components["schemas"]["simple-user"][] | null;
-      milestone: (components["schemas"]["milestone"] & { [key: string]: any }) | null;
+      milestone: (components["schemas"]["milestone"] & { [key: string]: unknown }) | null;
       locked: boolean;
       active_lock_reason?: string | null;
       comments: number;
@@ -5901,7 +5901,7 @@ export interface components {
         html_url: string | null;
         patch_url: string | null;
         url: string | null;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       closed_at: string | null;
       created_at: string;
       updated_at: string;
@@ -5910,8 +5910,8 @@ export interface components {
       body_text?: string;
       timeline_url?: string;
       repository?: components["schemas"]["repository"];
-      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     "reaction-rollup": {
       url: string;
       total_count: number;
@@ -5923,7 +5923,7 @@ export interface components {
       hooray: number;
       eyes: number;
       rocket: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Comments provide a way for people to collaborate on an issue. */
     "issue-comment": {
       /** Unique identifier of the issue comment */
@@ -5936,14 +5936,14 @@ export interface components {
       body_text?: string;
       body_html?: string;
       html_url: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       created_at: string;
       updated_at: string;
       issue_url: string;
       author_association: components["schemas"]["author_association"];
-      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: any }) | null;
+      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
       reactions?: components["schemas"]["reaction-rollup"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Event */
     event: {
       id: string;
@@ -5953,7 +5953,7 @@ export interface components {
         id: number;
         name: string;
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       org?: components["schemas"]["actor"];
       payload: {
         action: string;
@@ -5966,16 +5966,16 @@ export interface components {
           action?: string;
           sha?: string;
           html_url?: string;
-        } & { [key: string]: any })[];
-      } & { [key: string]: any };
+        } & { [key: string]: unknown })[];
+      } & { [key: string]: unknown };
       public: boolean;
       created_at: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Hypermedia Link with Type */
     "link-with-type": {
       href: string;
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Feed */
     feed: {
       timeline_url: string;
@@ -5995,8 +5995,8 @@ export interface components {
         current_user_actor?: components["schemas"]["link-with-type"];
         current_user_organization?: components["schemas"]["link-with-type"];
         current_user_organizations?: components["schemas"]["link-with-type"][];
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** Base Gist */
     "base-gist": {
       url: string;
@@ -6014,20 +6014,20 @@ export interface components {
           language?: string;
           raw_url?: string;
           size?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
       public: boolean;
       created_at: string;
       updated_at: string;
       description: string | null;
       comments: number;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       comments_url: string;
-      owner?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      owner?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       truncated?: boolean;
-      forks?: { [key: string]: unknown }[];
-      history?: { [key: string]: unknown }[];
-    } & { [key: string]: any };
+      forks?: unknown[];
+      history?: unknown[];
+    } & { [key: string]: unknown };
     /** Gist Simple */
     "gist-simple": {
       url?: string;
@@ -6048,7 +6048,7 @@ export interface components {
               size?: number;
               truncated?: boolean;
               content?: string;
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | null;
       };
       public?: boolean;
@@ -6060,7 +6060,7 @@ export interface components {
       comments_url?: string;
       owner?: components["schemas"]["simple-user"];
       truncated?: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A comment made to a gist. */
     "gist-comment": {
       id: number;
@@ -6068,28 +6068,28 @@ export interface components {
       url: string;
       /** The comment text. */
       body: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       created_at: string;
       updated_at: string;
       author_association: components["schemas"]["author_association"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Gist Commit */
     "gist-commit": {
       url: string;
       version: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       change_status: {
         total?: number;
         additions?: number;
         deletions?: number;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       committed_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Gitignore Template */
     "gitignore-template": {
       name: string;
       source: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Issues are a great way to keep track of tasks, enhancements, and bugs for your projects. */
     issue: {
       id: number;
@@ -6109,7 +6109,7 @@ export interface components {
       title: string;
       /** Contents of the issue */
       body?: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository */
       labels: ((
         | string
@@ -6121,11 +6121,11 @@ export interface components {
             description?: string | null;
             color?: string | null;
             default?: boolean;
-          } & { [key: string]: any })
-      ) & { [key: string]: any })[];
-      assignee: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+          } & { [key: string]: unknown })
+      ) & { [key: string]: unknown })[];
+      assignee: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       assignees?: components["schemas"]["simple-user"][] | null;
-      milestone: (components["schemas"]["milestone"] & { [key: string]: any }) | null;
+      milestone: (components["schemas"]["milestone"] & { [key: string]: unknown }) | null;
       locked: boolean;
       active_lock_reason?: string | null;
       comments: number;
@@ -6135,19 +6135,19 @@ export interface components {
         html_url: string | null;
         patch_url: string | null;
         url: string | null;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       closed_at: string | null;
       created_at: string;
       updated_at: string;
-      closed_by?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      closed_by?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       body_html?: string;
       body_text?: string;
       timeline_url?: string;
       repository?: components["schemas"]["repository"];
-      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: any }) | null;
+      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
       author_association: components["schemas"]["author_association"];
       reactions?: components["schemas"]["reaction-rollup"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** License */
     license: {
       key: string;
@@ -6163,7 +6163,7 @@ export interface components {
       limitations: string[];
       body: string;
       featured: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Marketplace Listing Plan */
     "marketplace-listing-plan": {
       url: string;
@@ -6179,7 +6179,7 @@ export interface components {
       unit_name: string | null;
       state: string;
       bullets: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Marketplace Purchase */
     "marketplace-purchase": {
       url: string;
@@ -6194,7 +6194,7 @@ export interface components {
             unit_count?: number | null;
             id?: number;
             plan?: components["schemas"]["marketplace-listing-plan"];
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
       marketplace_purchase: {
         billing_cycle?: string;
@@ -6205,15 +6205,15 @@ export interface components {
         free_trial_ends_on?: string | null;
         updated_at?: string;
         plan?: components["schemas"]["marketplace-listing-plan"];
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** Api Overview */
     "api-overview": {
       verifiable_password_authentication: boolean;
       ssh_key_fingerprints?: {
         SHA256_RSA?: string;
         SHA256_DSA?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       hooks?: string[];
       web?: string[];
       api?: string[];
@@ -6221,14 +6221,14 @@ export interface components {
       pages?: string[];
       importer?: string[];
       actions?: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Minimal Repository */
     "minimal-repository": {
       id: number;
       node_id: string;
       name: string;
       full_name: string;
-      owner: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      owner: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       private: boolean;
       html_url: string;
       description: string | null;
@@ -6300,8 +6300,8 @@ export interface components {
         admin?: boolean;
         push?: boolean;
         pull?: boolean;
-      } & { [key: string]: any };
-      template_repository?: (components["schemas"]["repository"] & { [key: string]: any }) | null;
+      } & { [key: string]: unknown };
+      template_repository?: (components["schemas"]["repository"] & { [key: string]: unknown }) | null;
       temp_clone_token?: string;
       delete_branch_on_merge?: boolean;
       subscribers_count?: number;
@@ -6313,12 +6313,12 @@ export interface components {
             spdx_id?: string;
             url?: string;
             node_id?: string;
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
       forks?: number;
       open_issues?: number;
       watchers?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Thread */
     thread: {
       id: string;
@@ -6328,14 +6328,14 @@ export interface components {
         url: string;
         latest_comment_url: string;
         type: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       reason: string;
       unread: boolean;
       updated_at: string;
       last_read_at: string | null;
       url: string;
       subscription_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Thread Subscription */
     "thread-subscription": {
       subscribed: boolean;
@@ -6345,7 +6345,7 @@ export interface components {
       url: string;
       thread_url?: string;
       repository_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Organization Full */
     "organization-full": {
       login: string;
@@ -6388,7 +6388,7 @@ export interface components {
         private_repos: number;
         filled_seats?: number;
         seats?: number;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       default_repository_permission?: string | null;
       members_can_create_repositories?: boolean | null;
       two_factor_requirement_enabled?: boolean | null;
@@ -6398,7 +6398,7 @@ export interface components {
       members_can_create_internal_repositories?: boolean;
       members_can_create_pages?: boolean;
       updated_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The policy that controls the repositories in the organization that are allowed to run GitHub Actions. Can be one of: `all`, `none`, or `selected`. */
     "enabled-repositories": "all" | "none" | "selected";
     "actions-organization-permissions": {
@@ -6407,7 +6407,7 @@ export interface components {
       selected_repositories_url?: string;
       allowed_actions: components["schemas"]["allowed-actions"];
       selected_actions_url?: components["schemas"]["selected-actions-url"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "runner-groups-org": {
       id: number;
       name: string;
@@ -6419,7 +6419,7 @@ export interface components {
       inherited: boolean;
       inherited_allows_public_repositories?: boolean;
       allows_public_repositories: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Secrets for GitHub Actions for an organization. */
     "organization-actions-secret": {
       /** The name of the secret. */
@@ -6429,7 +6429,7 @@ export interface components {
       /** Visibility of a secret */
       visibility: "all" | "private" | "selected";
       selected_repositories_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The public key used for setting Actions Secrets. */
     "actions-public-key": {
       /** The identifier for the key. */
@@ -6440,7 +6440,7 @@ export interface components {
       url?: string;
       title?: string;
       created_at?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Credential Authorization */
     "credential-authorization": {
       /** User login that owns the underlying credential. */
@@ -6464,7 +6464,7 @@ export interface components {
       authorized_credential_title?: string | null;
       /** The note given to the token. This will only be present when the credential is a token. */
       authorized_credential_note?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Organization Invitation */
     "organization-invitation": {
       id: number;
@@ -6479,7 +6479,7 @@ export interface components {
       invitation_team_url: string;
       node_id: string;
       invitation_teams_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Org Hook */
     "org-hook": {
       id: number;
@@ -6493,11 +6493,11 @@ export interface components {
         insecure_ssl?: string;
         content_type?: string;
         secret?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       updated_at: string;
       created_at: string;
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The type of GitHub user that can comment, open issues, or create pull requests while the interaction limit is in effect. Can be one of: `existing_users`, `contributors_only`, `collaborators_only`. */
     "interaction-group": "existing_users" | "contributors_only" | "collaborators_only";
     /** Interaction limit settings. */
@@ -6505,14 +6505,14 @@ export interface components {
       limit: components["schemas"]["interaction-group"];
       origin: string;
       expires_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The duration of the interaction restriction. Can be one of: `one_day`, `three_days`, `one_week`, `one_month`, `six_months`. Default: `one_day`. */
     "interaction-expiry": "one_day" | "three_days" | "one_week" | "one_month" | "six_months";
     /** Limit interactions to a specific type of user for a specified duration */
     "interaction-limit": {
       limit: components["schemas"]["interaction-group"];
       expiry?: components["schemas"]["interaction-expiry"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Groups of organization members that gives permissions on specified repositories. */
     "team-simple":
       | ({
@@ -6535,7 +6535,7 @@ export interface components {
           slug: string;
           /** Distinguished Name (DN) that team maps to within LDAP environment */
           ldap_dn?: string;
-        } & { [key: string]: any })
+        } & { [key: string]: unknown })
       | null;
     /** Groups of organization members that gives permissions on specified repositories. */
     team: {
@@ -6550,8 +6550,8 @@ export interface components {
       html_url: string;
       members_url: string;
       repositories_url: string;
-      parent?: (components["schemas"]["team-simple"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      parent?: (components["schemas"]["team-simple"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     /** Org Membership */
     "org-membership": {
       url: string;
@@ -6559,15 +6559,15 @@ export interface components {
       role: string;
       organization_url: string;
       organization: components["schemas"]["organization-simple"];
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       permissions?: {
         can_create_repository: boolean;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** A migration. */
     migration: {
       id: number;
-      owner: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      owner: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       guid: string;
       state: string;
       lock_repositories: boolean;
@@ -6578,8 +6578,8 @@ export interface components {
       updated_at: string;
       node_id: string;
       archive_url?: string;
-      exclude?: { [key: string]: unknown }[];
-    } & { [key: string]: any };
+      exclude?: unknown[];
+    } & { [key: string]: unknown };
     /** A software package */
     package: {
       /** Unique identifier of the package. */
@@ -6592,11 +6592,11 @@ export interface components {
       /** The number of versions of the package. */
       version_count: number;
       visibility: "private" | "public";
-      owner?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      repository?: (components["schemas"]["minimal-repository"] & { [key: string]: any }) | null;
+      owner?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      repository?: (components["schemas"]["minimal-repository"] & { [key: string]: unknown }) | null;
       created_at: string;
       updated_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A version of a software package */
     "package-version": {
       /** Unique identifier of the package version. */
@@ -6614,15 +6614,15 @@ export interface components {
       metadata?: {
         package_type: "npm" | "maven" | "rubygems" | "docker" | "nuget" | "container";
         container?: {
-          tags: any[];
-        } & { [key: string]: any };
+          tags: unknown[];
+        } & { [key: string]: unknown };
         docker?: {
-          tag?: any[];
+          tag?: unknown[];
         } & {
           tags: unknown;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** Projects are a way to organize columns and cards of work. */
     project: {
       owner_url: string;
@@ -6638,14 +6638,14 @@ export interface components {
       number: number;
       /** State of the project; either 'open' or 'closed' */
       state: string;
-      creator: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      creator: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       created_at: string;
       updated_at: string;
       /** The baseline permission that all organization members have on this project. Only present if owner is an organization. */
       organization_permission?: "read" | "write" | "admin" | "none";
       /** Whether or not this project can be seen by everyone. Only present if owner is an organization. */
       private?: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** External Groups to be mapped to a team for membership */
     "group-mapping": {
       /** Array of groups to be mapped to this team */
@@ -6660,8 +6660,8 @@ export interface components {
         status?: string;
         /** the time of the last sync for this group-mapping */
         synced_at?: string;
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     /** Groups of organization members that gives permissions on specified repositories. */
     "team-full": {
       /** Unique identifier of the team */
@@ -6680,7 +6680,7 @@ export interface components {
       permission: string;
       members_url: string;
       repositories_url: string;
-      parent?: (components["schemas"]["team-simple"] & { [key: string]: any }) | null;
+      parent?: (components["schemas"]["team-simple"] & { [key: string]: unknown }) | null;
       members_count: number;
       repos_count: number;
       created_at: string;
@@ -6688,10 +6688,10 @@ export interface components {
       organization: components["schemas"]["organization-full"];
       /** Distinguished Name (DN) that team maps to within LDAP environment */
       ldap_dn?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A team discussion is a persistent record of a free-form conversation within a team. */
     "team-discussion": {
-      author: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      author: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** The main text of the discussion. */
       body: string;
       body_html: string;
@@ -6715,10 +6715,10 @@ export interface components {
       updated_at: string;
       url: string;
       reactions?: components["schemas"]["reaction-rollup"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A reply to a discussion within a team. */
     "team-discussion-comment": {
-      author: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      author: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** The main text of the comment. */
       body: string;
       body_html: string;
@@ -6734,23 +6734,23 @@ export interface components {
       updated_at: string;
       url: string;
       reactions?: components["schemas"]["reaction-rollup"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Reactions to conversations provide a way to help people express their feelings more simply and effectively. */
     reaction: {
       id: number;
       node_id: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** The reaction to use */
       content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       created_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Team Membership */
     "team-membership": {
       url: string;
       /** The role of the user in the team. */
       role: "member" | "maintainer";
       state: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A team's access to a project. */
     "team-project": {
       owner_url: string;
@@ -6774,8 +6774,8 @@ export interface components {
         read: boolean;
         write: boolean;
         admin: boolean;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** A team's access to a repository. */
     "team-repository": {
       /** Unique identifier of the repository */
@@ -6784,7 +6784,7 @@ export interface components {
       /** The name of the repository. */
       name: string;
       full_name: string;
-      license: (components["schemas"]["license-simple"] & { [key: string]: any }) | null;
+      license: (components["schemas"]["license-simple"] & { [key: string]: unknown }) | null;
       forks: number;
       permissions?: {
         admin: boolean;
@@ -6792,8 +6792,8 @@ export interface components {
         triage?: boolean;
         push: boolean;
         maintain?: boolean;
-      } & { [key: string]: any };
-      owner: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      } & { [key: string]: unknown };
+      owner: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** Whether the repository is private or public. */
       private: boolean;
       html_url: string;
@@ -6873,7 +6873,7 @@ export interface components {
       updated_at: string | null;
       /** Whether to allow rebase merges for pull requests. */
       allow_rebase_merge?: boolean;
-      template_repository?: (components["schemas"]["repository"] & { [key: string]: any }) | null;
+      template_repository?: (components["schemas"]["repository"] & { [key: string]: unknown }) | null;
       temp_clone_token?: string;
       /** Whether to allow squash merges for pull requests. */
       allow_squash_merge?: boolean;
@@ -6886,7 +6886,7 @@ export interface components {
       open_issues: number;
       watchers: number;
       master_branch?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Project cards represent a scope of work. */
     "project-card": {
       url: string;
@@ -6894,7 +6894,7 @@ export interface components {
       id: number;
       node_id: string;
       note: string | null;
-      creator: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      creator: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       created_at: string;
       updated_at: string;
       /** Whether or not the card is archived */
@@ -6902,7 +6902,7 @@ export interface components {
       column_url: string;
       content_url?: string;
       project_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Project columns contain cards of work. */
     "project-column": {
       url: string;
@@ -6915,17 +6915,17 @@ export interface components {
       name: string;
       created_at: string;
       updated_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Repository Collaborator Permission */
     "repository-collaborator-permission": {
       permission: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     "rate-limit": {
       limit: number;
       remaining: number;
       reset: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Rate Limit Overview */
     "rate-limit-overview": {
       resources: {
@@ -6935,23 +6935,23 @@ export interface components {
         source_import?: components["schemas"]["rate-limit"];
         integration_manifest?: components["schemas"]["rate-limit"];
         code_scanning_upload?: components["schemas"]["rate-limit"];
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       rate: components["schemas"]["rate-limit"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Code of Conduct Simple */
     "code-of-conduct-simple": {
       url: string;
       key: string;
       name: string;
       html_url: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Full Repository */
     "full-repository": {
       id: number;
       node_id: string;
       name: string;
       full_name: string;
-      owner: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      owner: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       private: boolean;
       html_url: string;
       description: string | null;
@@ -7025,17 +7025,17 @@ export interface components {
         admin: boolean;
         pull: boolean;
         push: boolean;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       allow_rebase_merge?: boolean;
-      template_repository?: (components["schemas"]["repository"] & { [key: string]: any }) | null;
+      template_repository?: (components["schemas"]["repository"] & { [key: string]: unknown }) | null;
       temp_clone_token?: string | null;
       allow_squash_merge?: boolean;
       delete_branch_on_merge?: boolean;
       allow_merge_commit?: boolean;
       subscribers_count: number;
       network_count: number;
-      license: (components["schemas"]["license-simple"] & { [key: string]: any }) | null;
-      organization?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      license: (components["schemas"]["license-simple"] & { [key: string]: unknown }) | null;
+      organization?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       parent?: components["schemas"]["repository"];
       source?: components["schemas"]["repository"];
       forks: number;
@@ -7045,7 +7045,7 @@ export interface components {
       /** Whether anonymous git access is allowed. */
       anonymous_access_enabled?: boolean;
       code_of_conduct?: components["schemas"]["code-of-conduct-simple"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** An artifact */
     artifact: {
       id: number;
@@ -7061,7 +7061,7 @@ export interface components {
       created_at: string | null;
       expires_at: string;
       updated_at: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Information of a job execution in a workflow run */
     job: {
       /** The id of the job. */
@@ -7097,16 +7097,16 @@ export interface components {
         started_at?: string | null;
         /** The time that the job finished, in ISO 8601 format. */
         completed_at?: string | null;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       check_run_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Whether GitHub Actions is enabled on the repository. */
     "actions-enabled": boolean;
     "actions-repository-permissions": {
       enabled: components["schemas"]["actions-enabled"];
       allowed_actions: components["schemas"]["allowed-actions"];
       selected_actions_url?: components["schemas"]["selected-actions-url"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "pull-request-minimal": {
       id: number;
       number: number;
@@ -7118,8 +7118,8 @@ export interface components {
           id: number;
           url: string;
           name: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
       base: {
         ref: string;
         sha: string;
@@ -7127,9 +7127,9 @@ export interface components {
           id: number;
           url: string;
           name: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** Simple Commit */
     "simple-commit": {
       id: string;
@@ -7140,15 +7140,15 @@ export interface components {
         | ({
             name: string;
             email: string;
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
       committer:
         | ({
             name: string;
             email: string;
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** An invocation of a workflow */
     "workflow-run": {
       /** The ID of the workflow run. */
@@ -7190,7 +7190,7 @@ export interface components {
       repository: components["schemas"]["minimal-repository"];
       head_repository: components["schemas"]["minimal-repository"];
       head_repository_id?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** An entry in the reviews log for environment deployments */
     "environment-approvals": {
       /** The list of environments that were approved or rejected */
@@ -7206,13 +7206,13 @@ export interface components {
         created_at?: string;
         /** The time that the environment was last updated, in ISO 8601 format. */
         updated_at?: string;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       /** Whether deployment to the environment(s) was approved or rejected */
       state: "approved" | "rejected";
       user: components["schemas"]["simple-user"];
       /** The comment submitted with the deployment review */
       comment: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The type of reviewer. Must be one of: `User` or `Team` */
     "deployment-reviewer-type": "User" | "Team";
     /** Details of a deployment that is waiting for protection rules to pass */
@@ -7225,7 +7225,7 @@ export interface components {
         name?: string;
         url?: string;
         html_url?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** The set duration of the wait timer */
       wait_timer: number;
       /** The time that the wait timer began. */
@@ -7236,10 +7236,10 @@ export interface components {
       reviewers: ({
         type?: components["schemas"]["deployment-reviewer-type"];
         reviewer?: (Partial<components["schemas"]["simple-user"]> & Partial<components["schemas"]["team-simple"]>) & {
-          [key: string]: any;
+          [key: string]: unknown;
         };
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     /** A request for a specific ref(branch,sha,tag) to be deployed */
     deployment: {
       url: string;
@@ -7256,7 +7256,7 @@ export interface components {
       /** Name for the target deployment environment. */
       environment: string;
       description: string | null;
-      creator: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      creator: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       created_at: string;
       updated_at: string;
       statuses_url: string;
@@ -7265,33 +7265,33 @@ export interface components {
       transient_environment?: boolean;
       /** Specifies if the given environment is one that end-users directly interact with. Default: false. */
       production_environment?: boolean;
-      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     /** Workflow Run Usage */
     "workflow-run-usage": {
       billable: {
         UBUNTU?: {
           total_ms: number;
           jobs: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         MACOS?: {
           total_ms: number;
           jobs: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         WINDOWS?: {
           total_ms: number;
           jobs: number;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
       run_duration_ms: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Set secrets for GitHub Actions. */
     "actions-secret": {
       /** The name of the secret. */
       name: string;
       created_at: string;
       updated_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A GitHub Actions workflow */
     workflow: {
       id: number;
@@ -7305,26 +7305,26 @@ export interface components {
       html_url: string;
       badge_url: string;
       deleted_at?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Workflow Usage */
     "workflow-usage": {
       billable: {
         UBUNTU?: {
           total_ms?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         MACOS?: {
           total_ms?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         WINDOWS?: {
           total_ms?: number;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** Protected Branch Admin Enforced */
     "protected-branch-admin-enforced": {
       url: string;
       enabled: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Protected Branch Pull Request Review */
     "protected-branch-pull-request-review": {
       url?: string;
@@ -7336,11 +7336,11 @@ export interface components {
         url?: string;
         users_url?: string;
         teams_url?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       dismiss_stale_reviews: boolean;
       require_code_owner_reviews: boolean;
       required_approving_review_count?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Branch Restriction Policy */
     "branch-restriction-policy": {
       url: string;
@@ -7366,7 +7366,7 @@ export interface components {
         received_events_url?: string;
         type?: string;
         site_admin?: boolean;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       teams: ({
         id?: number;
         node_id?: string;
@@ -7380,7 +7380,7 @@ export interface components {
         members_url?: string;
         repositories_url?: string;
         parent?: string | null;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       apps: ({
         id?: number;
         slug?: string;
@@ -7408,7 +7408,7 @@ export interface components {
           organizations_url?: string;
           received_events_url?: string;
           type?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         name?: string;
         description?: string;
         external_url?: string;
@@ -7420,10 +7420,10 @@ export interface components {
           contents?: string;
           issues?: string;
           single_file?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         events?: string[];
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     /** Branch Protection */
     "branch-protection": {
       url?: string;
@@ -7432,46 +7432,46 @@ export interface components {
         enforcement_level: string;
         contexts: string[];
         contexts_url?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       enforce_admins?: components["schemas"]["protected-branch-admin-enforced"];
       required_pull_request_reviews?: components["schemas"]["protected-branch-pull-request-review"];
       restrictions?: components["schemas"]["branch-restriction-policy"];
       required_linear_history?: {
         enabled?: boolean;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       allow_force_pushes?: {
         enabled?: boolean;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       allow_deletions?: {
         enabled?: boolean;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       enabled: boolean;
       name?: string;
       protection_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Short Branch */
     "short-branch": {
       name: string;
       commit: {
         sha: string;
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       protected: boolean;
       protection?: components["schemas"]["branch-protection"];
       protection_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Metaproperties for Git author/committer information. */
     "git-user": {
       name?: string;
       email?: string;
       date?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     verification: {
       verified: boolean;
       reason: string;
       payload: string | null;
       signature: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Commit */
     commit: {
       url: string;
@@ -7481,28 +7481,28 @@ export interface components {
       comments_url: string;
       commit: {
         url: string;
-        author: (components["schemas"]["git-user"] & { [key: string]: any }) | null;
-        committer: (components["schemas"]["git-user"] & { [key: string]: any }) | null;
+        author: (components["schemas"]["git-user"] & { [key: string]: unknown }) | null;
+        committer: (components["schemas"]["git-user"] & { [key: string]: unknown }) | null;
         message: string;
         comment_count: number;
         tree: {
           sha: string;
           url: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         verification?: components["schemas"]["verification"];
-      } & { [key: string]: any };
-      author: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      committer: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      } & { [key: string]: unknown };
+      author: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      committer: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       parents: ({
         sha: string;
         url: string;
         html_url?: string;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       stats?: {
         additions?: number;
         deletions?: number;
         total?: number;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       files?: ({
         filename?: string;
         additions?: number;
@@ -7515,8 +7515,8 @@ export interface components {
         sha?: string;
         contents_url?: string;
         previous_filename?: string;
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     /** Branch With Protection */
     "branch-with-protection": {
       name: string;
@@ -7524,20 +7524,20 @@ export interface components {
       _links: {
         html: string;
         self: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       protected: boolean;
       protection: components["schemas"]["branch-protection"];
       protection_url: string;
       pattern?: string;
       required_approving_review_count?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Status Check Policy */
     "status-check-policy": {
       url: string;
       strict: boolean;
       contexts: string[];
       contexts_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Branch protections protect branches */
     "protected-branch": {
       url: string;
@@ -7553,12 +7553,12 @@ export interface components {
           teams_url: string;
           users: components["schemas"]["simple-user"][];
           teams: components["schemas"]["team"][];
-        } & { [key: string]: any };
-      } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
       required_signatures?: {
         url: string;
         enabled: boolean;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       enforce_admins?: {
         url: string;
         enabled: boolean;
@@ -7573,7 +7573,7 @@ export interface components {
         enabled: boolean;
       };
       restrictions?: components["schemas"]["branch-restriction-policy"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A deployment created as the result of an Actions check run from a workflow that references an environment */
     "deployment-simple": {
       url: string;
@@ -7594,8 +7594,8 @@ export interface components {
       transient_environment?: boolean;
       /** Specifies if the given environment is one that end-users directly interact with. Default: false. */
       production_environment?: boolean;
-      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     /** A check performed on the code of a given code change */
     "check-run": {
       /** The id of the check. */
@@ -7620,18 +7620,18 @@ export interface components {
         text: string | null;
         annotations_count: number;
         annotations_url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** The name of the check. */
       name: string;
       check_suite:
         | ({
             id: number;
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
-      app: (components["schemas"]["integration"] & { [key: string]: any }) | null;
+      app: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
       pull_requests: components["schemas"]["pull-request-minimal"][];
       deployment?: components["schemas"]["deployment-simple"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Check Annotation */
     "check-annotation": {
       path: string;
@@ -7644,7 +7644,7 @@ export interface components {
       message: string | null;
       raw_details: string | null;
       blob_href: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A suite of checks performed on the code of a given code change */
     "check-suite": {
       id: number;
@@ -7660,24 +7660,24 @@ export interface components {
       before: string | null;
       after: string | null;
       pull_requests: components["schemas"]["pull-request-minimal"][] | null;
-      app: (components["schemas"]["integration"] & { [key: string]: any }) | null;
+      app: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
       repository: components["schemas"]["minimal-repository"];
       created_at: string | null;
       updated_at: string | null;
       head_commit: components["schemas"]["simple-commit"];
       latest_check_runs_count: number;
       check_runs_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Check suite configuration preferences for a repository. */
     "check-suite-preference": {
       preferences: {
         auto_trigger_checks?: ({
           app_id: number;
           setting: boolean;
-        } & { [key: string]: any })[];
-      } & { [key: string]: any };
+        } & { [key: string]: unknown })[];
+      } & { [key: string]: unknown };
       repository: components["schemas"]["repository"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The name of the tool used to generate the code scanning analysis. */
     "code-scanning-analysis-tool-name": string;
     /** The GUID of the tool used to generate the code scanning analysis, if provided in the uploaded SARIF data. */
@@ -7709,14 +7709,14 @@ export interface components {
       severity?: ("none" | "note" | "warning" | "error") | null;
       /** A short description of the rule used to detect the alert. */
       description?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The version of the tool used to generate the code scanning analysis. */
     "code-scanning-analysis-tool-version": string | null;
     "code-scanning-analysis-tool": {
       name?: components["schemas"]["code-scanning-analysis-tool-name"];
       version?: components["schemas"]["code-scanning-analysis-tool-version"];
       guid?: components["schemas"]["code-scanning-analysis-tool-guid"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Identifies the configuration under which the analysis was executed. For example, in GitHub Actions this includes the workflow filename and job name. */
     "code-scanning-analysis-analysis-key": string;
     /** Identifies the variable values associated with the environment in which the analysis that generated this alert instance was performed, such as the language that was analyzed. */
@@ -7728,7 +7728,7 @@ export interface components {
       end_line?: number;
       start_column?: number;
       end_column?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A classification of the file. For example to identify it as generated. */
     "code-scanning-alert-classification": ("source" | "generated" | "test" | "library") | null;
     "code-scanning-alert-instance": {
@@ -7739,7 +7739,7 @@ export interface components {
       commit_sha?: string;
       message?: {
         text?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       location?: components["schemas"]["code-scanning-alert-location"];
       html_url?: string;
       /**
@@ -7747,7 +7747,7 @@ export interface components {
        * For example identifying it as documentation, or a generated file.
        */
       classifications?: components["schemas"]["code-scanning-alert-classification"][];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "code-scanning-alert-items": {
       number: components["schemas"]["alert-number"];
       created_at: components["schemas"]["alert-created-at"];
@@ -7761,7 +7761,7 @@ export interface components {
       rule: components["schemas"]["code-scanning-alert-rule-summary"];
       tool: components["schemas"]["code-scanning-analysis-tool"];
       most_recent_instance: components["schemas"]["code-scanning-alert-instance"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "code-scanning-alert-rule": {
       /** A unique identifier for the rule used to detect the alert. */
       id?: string | null;
@@ -7777,7 +7777,7 @@ export interface components {
       tags?: string[];
       /** Detailed documentation for the rule as GitHub Flavored Markdown. */
       help?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "code-scanning-alert": {
       number: components["schemas"]["alert-number"];
       created_at: components["schemas"]["alert-created-at"];
@@ -7791,7 +7791,7 @@ export interface components {
       rule: components["schemas"]["code-scanning-alert-rule"];
       tool: components["schemas"]["code-scanning-analysis-tool"];
       most_recent_instance: components["schemas"]["code-scanning-alert-instance"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Sets the state of the code scanning alert. Can be one of `open` or `dismissed`. You must provide `dismissed_reason` when you set the state to `dismissed`. */
     "code-scanning-alert-set-state": "open" | "dismissed";
     /** An identifier for the upload. */
@@ -7821,14 +7821,14 @@ export interface components {
       sarif_id: components["schemas"]["code-scanning-analysis-sarif-id"];
       tool: components["schemas"]["code-scanning-analysis-tool"];
       deletable: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Successful deletion of a code scanning analysis */
     "code-scanning-analysis-deletion": {
       /** Next deletable analysis in chain, without last analysis deletion confirmation */
       next_analysis_url: string | null;
       /** Next deletable analysis in chain, with last analysis deletion confirmation */
       confirm_delete_url: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Scim Error */
     "scim-error": {
       message?: string | null;
@@ -7837,20 +7837,20 @@ export interface components {
       status?: number;
       scimType?: string | null;
       schemas?: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A Base64 string representing the SARIF file to upload. You must first compress your SARIF file using [`gzip`](http://www.gnu.org/software/gzip/manual/gzip.html) and then translate the contents of the file into a Base64 encoding string. For more information, see "[SARIF support for code scanning](https://docs.github.com/github/finding-security-vulnerabilities-and-errors-in-your-code/sarif-support-for-code-scanning)." */
     "code-scanning-analysis-sarif-file": string;
     "code-scanning-sarifs-receipt": {
       id?: components["schemas"]["code-scanning-analysis-sarif-id"];
       /** The REST API URL for checking the status of the upload. */
       url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "code-scanning-sarifs-status": {
       /** `pending` files have not yet been processed, while `complete` means all results in the SARIF have been stored. */
       processing_status?: "pending" | "complete";
       /** The REST API URL for getting the analyses associated with the upload. */
       analyses_url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Collaborator */
     collaborator: {
       login: string;
@@ -7875,15 +7875,15 @@ export interface components {
         pull: boolean;
         push: boolean;
         admin: boolean;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** Repository invitations let you manage who you collaborate with. */
     "repository-invitation": {
       /** Unique identifier of the repository invitation. */
       id: number;
       repository: components["schemas"]["minimal-repository"];
-      invitee: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      inviter: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      invitee: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      inviter: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** The permission associated with the invitation. */
       permissions: "read" | "write" | "admin";
       created_at: string;
@@ -7893,7 +7893,7 @@ export interface components {
       url: string;
       html_url: string;
       node_id: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Commit Comment */
     "commit-comment": {
       html_url: string;
@@ -7905,25 +7905,25 @@ export interface components {
       position: number | null;
       line: number | null;
       commit_id: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       created_at: string;
       updated_at: string;
       author_association: components["schemas"]["author_association"];
       reactions?: components["schemas"]["reaction-rollup"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Branch Short */
     "branch-short": {
       name: string;
       commit: {
         sha: string;
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       protected: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Hypermedia Link */
     link: {
       href: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The status of auto merging a pull request. */
     auto_merge:
       | ({
@@ -7934,7 +7934,7 @@ export interface components {
           commit_title: string;
           /** Commit message for the merge commit. */
           commit_message: string;
-        } & { [key: string]: any })
+        } & { [key: string]: unknown })
       | null;
     /** Pull Request Simple */
     "pull-request-simple": {
@@ -7954,7 +7954,7 @@ export interface components {
       state: string;
       locked: boolean;
       title: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       body: string | null;
       labels: ({
         id?: number;
@@ -7964,15 +7964,15 @@ export interface components {
         description?: string;
         color?: string;
         default?: boolean;
-      } & { [key: string]: any })[];
-      milestone: (components["schemas"]["milestone"] & { [key: string]: any }) | null;
+      } & { [key: string]: unknown })[];
+      milestone: (components["schemas"]["milestone"] & { [key: string]: unknown }) | null;
       active_lock_reason?: string | null;
       created_at: string;
       updated_at: string;
       closed_at: string | null;
       merged_at: string | null;
       merge_commit_sha: string | null;
-      assignee: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      assignee: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       assignees?: components["schemas"]["simple-user"][] | null;
       requested_reviewers?: components["schemas"]["simple-user"][] | null;
       requested_teams?: components["schemas"]["team-simple"][] | null;
@@ -7981,15 +7981,15 @@ export interface components {
         ref: string;
         repo: components["schemas"]["repository"];
         sha: string;
-        user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      } & { [key: string]: any };
+        user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      } & { [key: string]: unknown };
       base: {
         label: string;
         ref: string;
         repo: components["schemas"]["repository"];
         sha: string;
-        user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      } & { [key: string]: any };
+        user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      } & { [key: string]: unknown };
       _links: {
         comments: components["schemas"]["link"];
         commits: components["schemas"]["link"];
@@ -7999,12 +7999,12 @@ export interface components {
         review_comments: components["schemas"]["link"];
         review_comment: components["schemas"]["link"];
         self: components["schemas"]["link"];
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       author_association: components["schemas"]["author_association"];
       auto_merge: components["schemas"]["auto_merge"];
       /** Indicates whether or not the pull request is a draft. */
       draft?: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "simple-commit-status": {
       description: string | null;
       id: number;
@@ -8017,7 +8017,7 @@ export interface components {
       url: string;
       created_at: string;
       updated_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Combined Commit Status */
     "combined-commit-status": {
       state: string;
@@ -8027,7 +8027,7 @@ export interface components {
       repository: components["schemas"]["minimal-repository"];
       commit_url: string;
       url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The status of a commit. */
     status: {
       url: string;
@@ -8041,27 +8041,27 @@ export interface components {
       created_at: string;
       updated_at: string;
       creator: components["schemas"]["simple-user"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "community-health-file": {
       url: string;
       html_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Community Profile */
     "community-profile": {
       health_percentage: number;
       description: string | null;
       documentation: string | null;
       files: {
-        code_of_conduct: (components["schemas"]["code-of-conduct-simple"] & { [key: string]: any }) | null;
-        license: (components["schemas"]["license-simple"] & { [key: string]: any }) | null;
-        contributing: (components["schemas"]["community-health-file"] & { [key: string]: any }) | null;
-        readme: (components["schemas"]["community-health-file"] & { [key: string]: any }) | null;
-        issue_template: (components["schemas"]["community-health-file"] & { [key: string]: any }) | null;
-        pull_request_template: (components["schemas"]["community-health-file"] & { [key: string]: any }) | null;
-      } & { [key: string]: any };
+        code_of_conduct: (components["schemas"]["code-of-conduct-simple"] & { [key: string]: unknown }) | null;
+        license: (components["schemas"]["license-simple"] & { [key: string]: unknown }) | null;
+        contributing: (components["schemas"]["community-health-file"] & { [key: string]: unknown }) | null;
+        readme: (components["schemas"]["community-health-file"] & { [key: string]: unknown }) | null;
+        issue_template: (components["schemas"]["community-health-file"] & { [key: string]: unknown }) | null;
+        pull_request_template: (components["schemas"]["community-health-file"] & { [key: string]: unknown }) | null;
+      } & { [key: string]: unknown };
       updated_at: string | null;
       content_reports_enabled?: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Diff Entry */
     "diff-entry": {
       sha: string;
@@ -8075,7 +8075,7 @@ export interface components {
       contents_url: string;
       patch?: string;
       previous_filename?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Commit Comparison */
     "commit-comparison": {
       url: string;
@@ -8091,7 +8091,7 @@ export interface components {
       total_commits: number;
       commits: components["schemas"]["commit"][];
       files: components["schemas"]["diff-entry"][];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Content Tree */
     "content-tree": {
       type: string;
@@ -8118,17 +8118,17 @@ export interface components {
           git: string | null;
           html: string | null;
           self: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any })[];
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown })[];
       _links: {
         git: string | null;
         html: string | null;
         self: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
     } & {
       content: unknown;
       encoding: unknown;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A list of directory items */
     "content-directory": ({
       type: string;
@@ -8145,8 +8145,8 @@ export interface components {
         git: string | null;
         html: string | null;
         self: string;
-      } & { [key: string]: any };
-    } & { [key: string]: any })[];
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown })[];
     /** Content File */
     "content-file": {
       type: string;
@@ -8164,10 +8164,10 @@ export interface components {
         git: string | null;
         html: string | null;
         self: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       target?: string;
       submodule_git_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** An object describing a symlink */
     "content-symlink": {
       type: string;
@@ -8184,8 +8184,8 @@ export interface components {
         git: string | null;
         html: string | null;
         self: string;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** An object describing a symlink */
     "content-submodule": {
       type: string;
@@ -8202,8 +8202,8 @@ export interface components {
         git: string | null;
         html: string | null;
         self: string;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** File Commit */
     "file-commit": {
       content:
@@ -8221,8 +8221,8 @@ export interface components {
               self?: string;
               git?: string;
               html?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any })
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown })
         | null;
       commit: {
         sha?: string;
@@ -8233,30 +8233,30 @@ export interface components {
           date?: string;
           name?: string;
           email?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         committer?: {
           date?: string;
           name?: string;
           email?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         message?: string;
         tree?: {
           url?: string;
           sha?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         parents?: ({
           url?: string;
           html_url?: string;
           sha?: string;
-        } & { [key: string]: any })[];
+        } & { [key: string]: unknown })[];
         verification?: {
           verified?: boolean;
           reason?: string;
           signature?: string | null;
           payload?: string | null;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** Contributor */
     contributor: {
       login?: string;
@@ -8280,7 +8280,7 @@ export interface components {
       contributions: number;
       email?: string;
       name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The status of a deployment. */
     "deployment-status": {
       url: string;
@@ -8288,7 +8288,7 @@ export interface components {
       node_id: string;
       /** The state of the status. */
       state: "error" | "failure" | "inactive" | "pending" | "success" | "queued" | "in_progress";
-      creator: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      creator: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** A short description of the status. */
       description: string;
       /** The environment of the deployment that the status is for. */
@@ -8303,8 +8303,8 @@ export interface components {
       environment_url?: string;
       /** The URL to associate with this status. */
       log_url?: string;
-      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     /** The amount of time to delay a job after the job is initially triggered. The time (in minutes) must be an integer between 0 and 43,200 (30 days). */
     "wait-timer": number;
     /** The type of deployment branch policy for this environment. To allow all branches to deploy, set to `null`. */
@@ -8314,7 +8314,7 @@ export interface components {
           protected_branches: boolean;
           /** Whether only branches that match the specified name patterns can deploy to this environment.  If `custom_branch_policies` is `true`, `protected_branches` must be `false`; if `custom_branch_policies` is `false`, `protected_branches` must be `true`. */
           custom_branch_policies: boolean;
-        } & { [key: string]: any })
+        } & { [key: string]: unknown })
       | null;
     /** Details of a deployment environment */
     environment: {
@@ -8335,7 +8335,7 @@ export interface components {
           node_id: string;
           type: string;
           wait_timer?: components["schemas"]["wait-timer"];
-        } & { [key: string]: any }
+        } & { [key: string]: unknown }
       > &
         Partial<
           {
@@ -8346,24 +8346,24 @@ export interface components {
             reviewers?: ({
               type?: components["schemas"]["deployment-reviewer-type"];
               reviewer?: (Partial<components["schemas"]["simple-user"]> &
-                Partial<components["schemas"]["team-simple"]>) & { [key: string]: any };
-            } & { [key: string]: any })[];
-          } & { [key: string]: any }
+                Partial<components["schemas"]["team-simple"]>) & { [key: string]: unknown };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown }
         > &
         Partial<
           {
             id: number;
             node_id: string;
             type: string;
-          } & { [key: string]: any }
-        >) & { [key: string]: any })[];
+          } & { [key: string]: unknown }
+        >) & { [key: string]: unknown })[];
       deployment_branch_policy?: components["schemas"]["deployment_branch_policy"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Short Blob */
     "short-blob": {
       url: string;
       sha: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Blob */
     blob: {
       content: string;
@@ -8373,7 +8373,7 @@ export interface components {
       size: number | null;
       node_id: string;
       highlighted_content?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Low-level Git commit operations within a repository */
     "git-commit": {
       /** SHA for the commit */
@@ -8388,7 +8388,7 @@ export interface components {
         email: string;
         /** Name of the git user */
         name: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** Identifying information for the git-user */
       committer: {
         /** Timestamp of the commit */
@@ -8397,28 +8397,28 @@ export interface components {
         email: string;
         /** Name of the git user */
         name: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** Message describing the purpose of the commit */
       message: string;
       tree: {
         /** SHA for the commit */
         sha: string;
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       parents: ({
         /** SHA for the commit */
         sha: string;
         url: string;
         html_url: string;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       verification: {
         verified: boolean;
         reason: string;
         signature: string | null;
         payload: string | null;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       html_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Git references within a repository */
     "git-ref": {
       ref: string;
@@ -8429,8 +8429,8 @@ export interface components {
         /** SHA for the reference */
         sha: string;
         url: string;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** Metadata for a Git tag */
     "git-tag": {
       node_id: string;
@@ -8445,14 +8445,14 @@ export interface components {
         date: string;
         email: string;
         name: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       object: {
         sha: string;
         type: string;
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       verification?: components["schemas"]["verification"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The hierarchy between files in a Git repository. */
     "git-tree": {
       sha: string;
@@ -8466,13 +8466,13 @@ export interface components {
         sha?: string;
         size?: number;
         url?: string;
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     "hook-response": {
       code: number | null;
       status: string | null;
       message: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Webhooks for repositories. */
     hook: {
       type: string;
@@ -8495,14 +8495,14 @@ export interface components {
         digest?: string;
         secret?: components["schemas"]["webhook-config-secret"];
         token?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       updated_at: string;
       created_at: string;
       url: string;
       test_url: string;
       ping_url: string;
       last_response: components["schemas"]["hook-response"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A repository import from an external source. */
     import: {
       vcs: string | null;
@@ -8541,7 +8541,7 @@ export interface components {
         vcs?: string;
         tfvc_project?: string;
         human_name?: string;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       message?: string;
       authors_count?: number | null;
       url: string;
@@ -8549,7 +8549,7 @@ export interface components {
       authors_url: string;
       repository_url: string;
       svn_root?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Porter Author */
     "porter-author": {
       id: number;
@@ -8559,29 +8559,29 @@ export interface components {
       name: string;
       url: string;
       import_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Porter Large File */
     "porter-large-file": {
       ref_name: string;
       path: string;
       oid: string;
       size: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Issue Event Label */
     "issue-event-label": {
       name: string | null;
       color: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "issue-event-dismissed-review": {
       state: string;
       review_id: number;
       dismissal_message: string | null;
       dismissal_commit_id?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Issue Event Milestone */
     "issue-event-milestone": {
       title: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Issue Event Project Card */
     "issue-event-project-card": {
       url: string;
@@ -8590,28 +8590,28 @@ export interface components {
       project_id: number;
       column_name: string;
       previous_column_name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Issue Event Rename */
     "issue-event-rename": {
       from: string;
       to: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Issue Event */
     "issue-event": {
       id: number;
       node_id: string;
       url: string;
-      actor: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      actor: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       event: string;
       commit_id: string | null;
       commit_url: string | null;
       created_at: string;
       issue?: components["schemas"]["issue-simple"];
       label?: components["schemas"]["issue-event-label"];
-      assignee?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      assigner?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      review_requester?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      requested_reviewer?: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      assignee?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      assigner?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      review_requester?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      requested_reviewer?: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       requested_team?: components["schemas"]["team"];
       dismissed_review?: components["schemas"]["issue-event-dismissed-review"];
       milestone?: components["schemas"]["issue-event-milestone"];
@@ -8619,7 +8619,7 @@ export interface components {
       rename?: components["schemas"]["issue-event-rename"];
       author_association?: components["schemas"]["author_association"];
       lock_reason?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Issue Event for Issue */
     "issue-event-for-issue": {
       id?: number;
@@ -8643,7 +8643,7 @@ export interface components {
       pull_request_url?: string;
       body_html?: string;
       body_text?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** An SSH key granting access to a single repository. */
     "deploy-key": {
       id: number;
@@ -8653,7 +8653,7 @@ export interface components {
       verified: boolean;
       created_at: string;
       read_only: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Language */
     language: { [key: string]: number };
     /** License Content */
@@ -8673,13 +8673,13 @@ export interface components {
         git: string | null;
         html: string | null;
         self: string;
-      } & { [key: string]: any };
-      license: (components["schemas"]["license-simple"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+      license: (components["schemas"]["license-simple"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     "pages-source-hash": {
       branch: string;
       path: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** The configuration for GitHub Pages for a repository. */
     page: {
       /** The API address for accessing this Page resource. */
@@ -8695,25 +8695,25 @@ export interface components {
       source?: components["schemas"]["pages-source-hash"];
       /** Whether the GitHub Pages site is publicly visible. If set to `true`, the site is accessible to anyone on the internet. If set to `false`, the site will only be accessible to users who have at least `read` access to the repository that published the site. */
       public: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Page Build */
     "page-build": {
       url: string;
       status: string;
       error: {
         message: string | null;
-      } & { [key: string]: any };
-      pusher: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      } & { [key: string]: unknown };
+      pusher: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       commit: string;
       duration: number;
       created_at: string;
       updated_at: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Page Build Status */
     "page-build-status": {
       url: string;
       status: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Pull requests let you tell others about changes you've pushed to a repository on GitHub. Once a pull request is sent, interested parties can review the set of changes, discuss potential modifications, and even push follow-up commits if necessary. */
     "pull-request": {
       url: string;
@@ -8735,7 +8735,7 @@ export interface components {
       locked: boolean;
       /** The title of the pull request. */
       title: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       body: string | null;
       labels: ({
         id?: number;
@@ -8745,15 +8745,15 @@ export interface components {
         description?: string | null;
         color?: string;
         default?: boolean;
-      } & { [key: string]: any })[];
-      milestone: (components["schemas"]["milestone"] & { [key: string]: any }) | null;
+      } & { [key: string]: unknown })[];
+      milestone: (components["schemas"]["milestone"] & { [key: string]: unknown }) | null;
       active_lock_reason?: string | null;
       created_at: string;
       updated_at: string;
       closed_at: string | null;
       merged_at: string | null;
       merge_commit_sha: string | null;
-      assignee: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      assignee: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       assignees?: components["schemas"]["simple-user"][] | null;
       requested_reviewers?: components["schemas"]["simple-user"][] | null;
       requested_teams?: components["schemas"]["team-simple"][] | null;
@@ -8814,7 +8814,7 @@ export interface components {
             subscriptions_url: string;
             type: string;
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           private: boolean;
           pulls_url: string;
           releases_url: string;
@@ -8848,7 +8848,7 @@ export interface components {
             admin: boolean;
             pull: boolean;
             push: boolean;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           temp_clone_token?: string;
           allow_merge_commit?: boolean;
           allow_squash_merge?: boolean;
@@ -8860,7 +8860,7 @@ export interface components {
                 url: string | null;
                 spdx_id: string | null;
                 node_id: string;
-              } & { [key: string]: any })
+              } & { [key: string]: unknown })
             | null;
           pushed_at: string;
           size: number;
@@ -8872,7 +8872,7 @@ export interface components {
           watchers_count: number;
           created_at: string;
           updated_at: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         sha: string;
         user: {
           avatar_url: string;
@@ -8893,8 +8893,8 @@ export interface components {
           subscriptions_url: string;
           type: string;
           url: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
       base: {
         label: string;
         ref: string;
@@ -8952,7 +8952,7 @@ export interface components {
             subscriptions_url: string;
             type: string;
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           private: boolean;
           pulls_url: string;
           releases_url: string;
@@ -8986,12 +8986,12 @@ export interface components {
             admin: boolean;
             pull: boolean;
             push: boolean;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           temp_clone_token?: string;
           allow_merge_commit?: boolean;
           allow_squash_merge?: boolean;
           allow_rebase_merge?: boolean;
-          license: (components["schemas"]["license-simple"] & { [key: string]: any }) | null;
+          license: (components["schemas"]["license-simple"] & { [key: string]: unknown }) | null;
           pushed_at: string;
           size: number;
           ssh_url: string;
@@ -9002,7 +9002,7 @@ export interface components {
           watchers_count: number;
           created_at: string;
           updated_at: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         sha: string;
         user: {
           avatar_url: string;
@@ -9023,8 +9023,8 @@ export interface components {
           subscriptions_url: string;
           type: string;
           url: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
       _links: {
         comments: components["schemas"]["link"];
         commits: components["schemas"]["link"];
@@ -9034,7 +9034,7 @@ export interface components {
         review_comments: components["schemas"]["link"];
         review_comment: components["schemas"]["link"];
         self: components["schemas"]["link"];
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       author_association: components["schemas"]["author_association"];
       auto_merge: components["schemas"]["auto_merge"];
       /** Indicates whether or not the pull request is a draft. */
@@ -9043,7 +9043,7 @@ export interface components {
       mergeable: boolean | null;
       rebaseable?: boolean | null;
       mergeable_state: string;
-      merged_by: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      merged_by: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       comments: number;
       review_comments: number;
       /** Indicates whether maintainers can modify the pull request. */
@@ -9052,7 +9052,7 @@ export interface components {
       additions: number;
       deletions: number;
       changed_files: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Pull Request Review Comments are comments on a portion of the Pull Request's diff. */
     "pull-request-review-comment": {
       /** URL for the pull request review comment */
@@ -9090,14 +9090,14 @@ export interface components {
       _links: {
         self: {
           href: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         html: {
           href: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         pull_request: {
           href: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
       /** The first line of the range for a multi-line comment. */
       start_line?: number | null;
       /** The first line of the range for a multi-line comment. */
@@ -9113,24 +9113,24 @@ export interface components {
       reactions?: components["schemas"]["reaction-rollup"];
       body_html?: string;
       body_text?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Pull Request Merge Result */
     "pull-request-merge-result": {
       sha: string;
       merged: boolean;
       message: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Pull Request Review Request */
     "pull-request-review-request": {
       users: components["schemas"]["simple-user"][];
       teams: components["schemas"]["team-simple"][];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Pull Request Reviews are reviews on pull requests. */
     "pull-request-review": {
       /** Unique identifier of the review */
       id: number;
       node_id: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       /** The text of the review. */
       body: string;
       state: string;
@@ -9139,18 +9139,18 @@ export interface components {
       _links: {
         html: {
           href: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         pull_request: {
           href: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown };
       submitted_at?: string;
       /** A commit SHA for the review. */
       commit_id: string;
       body_html?: string;
       body_text?: string;
       author_association: components["schemas"]["author_association"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Legacy Review Comment */
     "review-comment": {
       url: string;
@@ -9164,7 +9164,7 @@ export interface components {
       commit_id: string;
       original_commit_id: string;
       in_reply_to_id?: number;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       body: string;
       created_at: string;
       updated_at: string;
@@ -9175,7 +9175,7 @@ export interface components {
         self: components["schemas"]["link"];
         html: components["schemas"]["link"];
         pull_request: components["schemas"]["link"];
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       body_text?: string;
       body_html?: string;
       /** The side of the first line of the range for a multi-line comment. */
@@ -9190,7 +9190,7 @@ export interface components {
       start_line?: number | null;
       /** The original first line of the range for a multi-line comment. */
       original_start_line?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Data related to a release. */
     "release-asset": {
       url: string;
@@ -9207,8 +9207,8 @@ export interface components {
       download_count: number;
       created_at: string;
       updated_at: string;
-      uploader: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      uploader: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     /** A release. */
     release: {
       url: string;
@@ -9235,7 +9235,7 @@ export interface components {
       assets: components["schemas"]["release-asset"][];
       body_html?: string;
       body_text?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Sets the state of the secret scanning alert. Can be either `open` or `resolved`. You must provide `resolution` when you set the state to `resolved`. */
     "secret-scanning-alert-state": "open" | "resolved";
     /** **Required when the `state` is `resolved`.** The reason for resolving the alert. Can be one of `false_positive`, `wont_fix`, `revoked`, or `used_in_tests`. */
@@ -9254,12 +9254,12 @@ export interface components {
       secret_type?: string;
       /** The secret that was detected. */
       secret?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Stargazer */
     stargazer: {
       starred_at: string;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     /** Code Frequency Stat */
     "code-frequency-stat": number[];
     /** Commit Activity */
@@ -9267,22 +9267,22 @@ export interface components {
       days: number[];
       total: number;
       week: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Contributor Activity */
     "contributor-activity": {
-      author: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      author: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       total: number;
       weeks: ({
         w?: string;
         a?: number;
         d?: number;
         c?: number;
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     "participation-stats": {
       all: number[];
       owner: number[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Repository invitations let you manage who you collaborate with. */
     "repository-subscription": {
       /** Determines if notifications should be received from this repository. */
@@ -9293,52 +9293,52 @@ export interface components {
       created_at: string;
       url: string;
       repository_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Tag */
     tag: {
       name: string;
       commit: {
         sha: string;
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       zipball_url: string;
       tarball_url: string;
       node_id: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A topic aggregates entities that are related to a subject. */
     topic: {
       names: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     traffic: {
       timestamp: string;
       uniques: number;
       count: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Clone Traffic */
     "clone-traffic": {
       count: number;
       uniques: number;
       clones: components["schemas"]["traffic"][];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Content Traffic */
     "content-traffic": {
       path: string;
       title: string;
       count: number;
       uniques: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Referrer Traffic */
     "referrer-traffic": {
       referrer: string;
       count: number;
       uniques: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** View Traffic */
     "view-traffic": {
       count: number;
       uniques: number;
       views: components["schemas"]["traffic"][];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "scim-group-list-enterprise": {
       schemas: string[];
       totalResults: number;
@@ -9353,15 +9353,15 @@ export interface components {
           value?: string;
           $ref?: string;
           display?: string;
-        } & { [key: string]: any })[];
+        } & { [key: string]: unknown })[];
         meta?: {
           resourceType?: string;
           created?: string;
           lastModified?: string;
           location?: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     "scim-enterprise-group": {
       schemas: string[];
       id: string;
@@ -9371,14 +9371,14 @@ export interface components {
         value?: string;
         $ref?: string;
         display?: string;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       meta?: {
         resourceType?: string;
         created?: string;
         lastModified?: string;
         location?: string;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     "scim-user-list-enterprise": {
       schemas: string[];
       totalResults: number;
@@ -9392,24 +9392,24 @@ export interface components {
         name?: {
           givenName?: string;
           familyName?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         emails?: ({
           value?: string;
           primary?: boolean;
           type?: string;
-        } & { [key: string]: any })[];
+        } & { [key: string]: unknown })[];
         groups?: ({
           value?: string;
-        } & { [key: string]: any })[];
+        } & { [key: string]: unknown })[];
         active?: boolean;
         meta?: {
           resourceType?: string;
           created?: string;
           lastModified?: string;
           location?: string;
-        } & { [key: string]: any };
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+        } & { [key: string]: unknown };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     "scim-enterprise-user": {
       schemas: string[];
       id: string;
@@ -9418,23 +9418,23 @@ export interface components {
       name?: {
         givenName?: string;
         familyName?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       emails?: ({
         value?: string;
         type?: string;
         primary?: boolean;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       groups?: ({
         value?: string;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       active?: boolean;
       meta?: {
         resourceType?: string;
         created?: string;
         lastModified?: string;
         location?: string;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /** SCIM /Users provisioning endpoints */
     "scim-user": {
       /** SCIM schema used. */
@@ -9451,12 +9451,12 @@ export interface components {
         givenName: string | null;
         familyName: string | null;
         formatted?: string | null;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** user emails */
       emails: ({
         value: string;
         primary?: boolean;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       /** The active status of the User. */
       active: boolean;
       meta: {
@@ -9464,21 +9464,21 @@ export interface components {
         created?: string;
         lastModified?: string;
         location?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** The ID of the organization. */
       organization_id?: number;
       /** Set of operations to be performed */
       operations?: ({
         op: "add" | "remove" | "replace";
         path?: string;
-        value?: (string | { [key: string]: unknown } | { [key: string]: unknown }[]) & { [key: string]: any };
-      } & { [key: string]: any })[];
+        value?: (string | { [key: string]: unknown } | unknown[]) & { [key: string]: unknown };
+      } & { [key: string]: unknown })[];
       /** associated groups */
       groups?: ({
         value?: string;
         display?: string;
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     /** SCIM User List */
     "scim-user-list": {
       /** SCIM schema used. */
@@ -9487,7 +9487,7 @@ export interface components {
       itemsPerPage: number;
       startIndex: number;
       Resources: components["schemas"]["scim-user"][];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "search-result-text-matches": ({
       object_url?: string;
       object_type?: string | null;
@@ -9496,8 +9496,8 @@ export interface components {
       matches?: ({
         text?: string;
         indices?: number[];
-      } & { [key: string]: any })[];
-    } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown })[];
     /** Code Search Result Item */
     "code-search-result-item": {
       name: string;
@@ -9513,7 +9513,7 @@ export interface components {
       last_modified_at?: string;
       line_numbers?: string[];
       text_matches?: components["schemas"]["search-result-text-matches"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Commit Search Result Item */
     "commit-search-result-item": {
       url: string;
@@ -9525,29 +9525,29 @@ export interface components {
           name: string;
           email: string;
           date: string;
-        } & { [key: string]: any };
-        committer: (components["schemas"]["git-user"] & { [key: string]: any }) | null;
+        } & { [key: string]: unknown };
+        committer: (components["schemas"]["git-user"] & { [key: string]: unknown }) | null;
         comment_count: number;
         message: string;
         tree: {
           sha: string;
           url: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         url: string;
         verification?: components["schemas"]["verification"];
-      } & { [key: string]: any };
-      author: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      committer: (components["schemas"]["git-user"] & { [key: string]: any }) | null;
+      } & { [key: string]: unknown };
+      author: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      committer: (components["schemas"]["git-user"] & { [key: string]: unknown }) | null;
       parents: ({
         url?: string;
         html_url?: string;
         sha?: string;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       repository: components["schemas"]["minimal-repository"];
       score: number;
       node_id: string;
       text_matches?: components["schemas"]["search-result-text-matches"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Issue Search Result Item */
     "issue-search-result-item": {
       url: string;
@@ -9563,7 +9563,7 @@ export interface components {
       locked: boolean;
       active_lock_reason?: string | null;
       assignees?: components["schemas"]["simple-user"][] | null;
-      user: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      user: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       labels: ({
         id?: number;
         node_id?: string;
@@ -9572,10 +9572,10 @@ export interface components {
         color?: string;
         default?: boolean;
         description?: string | null;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       state: string;
-      assignee: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
-      milestone: (components["schemas"]["milestone"] & { [key: string]: any }) | null;
+      assignee: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
+      milestone: (components["schemas"]["milestone"] & { [key: string]: unknown }) | null;
       comments: number;
       created_at: string;
       updated_at: string;
@@ -9587,7 +9587,7 @@ export interface components {
         html_url: string | null;
         patch_url: string | null;
         url: string | null;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       body?: string;
       score: number;
       author_association: components["schemas"]["author_association"];
@@ -9596,8 +9596,8 @@ export interface components {
       body_html?: string;
       body_text?: string;
       timeline_url?: string;
-      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      performed_via_github_app?: (components["schemas"]["integration"] & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     /** Label Search Result Item */
     "label-search-result-item": {
       id: number;
@@ -9609,14 +9609,14 @@ export interface components {
       description: string | null;
       score: number;
       text_matches?: components["schemas"]["search-result-text-matches"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Repo Search Result Item */
     "repo-search-result-item": {
       id: number;
       node_id: string;
       name: string;
       full_name: string;
-      owner: (components["schemas"]["simple-user"] & { [key: string]: any }) | null;
+      owner: (components["schemas"]["simple-user"] & { [key: string]: unknown }) | null;
       private: boolean;
       html_url: string;
       description: string | null;
@@ -9688,19 +9688,19 @@ export interface components {
       archived: boolean;
       /** Returns whether or not this repository disabled. */
       disabled: boolean;
-      license: (components["schemas"]["license-simple"] & { [key: string]: any }) | null;
+      license: (components["schemas"]["license-simple"] & { [key: string]: unknown }) | null;
       permissions?: {
         admin: boolean;
         pull: boolean;
         push: boolean;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       text_matches?: components["schemas"]["search-result-text-matches"];
       temp_clone_token?: string;
       allow_merge_commit?: boolean;
       allow_squash_merge?: boolean;
       allow_rebase_merge?: boolean;
       delete_branch_on_merge?: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Topic Search Result Item */
     "topic-search-result-item": {
       name: string;
@@ -9724,8 +9724,8 @@ export interface components {
               name?: string;
               topic_id?: number;
               relation_type?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any })[]
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown })[]
         | null;
       aliases?:
         | ({
@@ -9734,10 +9734,10 @@ export interface components {
               name?: string;
               topic_id?: number;
               relation_type?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any })[]
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown })[]
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** User Search Result Item */
     "user-search-result-item": {
       login: string;
@@ -9774,7 +9774,7 @@ export interface components {
       blog?: string | null;
       company?: string | null;
       suspended_at?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Private User */
     "private-user": {
       login: string;
@@ -9820,11 +9820,11 @@ export interface components {
         name: string;
         space: number;
         private_repos: number;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       suspended_at?: string | null;
       business_plus?: boolean;
       ldap_dn?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Public User */
     "public-user": {
       login: string;
@@ -9864,7 +9864,7 @@ export interface components {
         name: string;
         space: number;
         private_repos: number;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       suspended_at?: string | null;
       private_gists?: number;
       total_private_repos?: number;
@@ -9878,7 +9878,7 @@ export interface components {
       primary: boolean;
       verified: boolean;
       visibility: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A unique encryption key */
     "gpg-key": {
       id: number;
@@ -9888,14 +9888,14 @@ export interface components {
       emails: ({
         email?: string;
         verified?: boolean;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       subkeys: ({
         id?: number;
         primary_key_id?: number;
         key_id?: string;
         public_key?: string;
-        emails?: { [key: string]: unknown }[];
-        subkeys?: { [key: string]: unknown }[];
+        emails?: unknown[];
+        subkeys?: unknown[];
         can_sign?: boolean;
         can_encrypt_comms?: boolean;
         can_encrypt_storage?: boolean;
@@ -9903,7 +9903,7 @@ export interface components {
         created_at?: string;
         expires_at?: string | null;
         raw_key?: string | null;
-      } & { [key: string]: any })[];
+      } & { [key: string]: unknown })[];
       can_sign: boolean;
       can_encrypt_comms: boolean;
       can_encrypt_storage: boolean;
@@ -9911,7 +9911,7 @@ export interface components {
       created_at: string;
       expires_at: string | null;
       raw_key: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Key */
     key: {
       key_id: string;
@@ -9922,7 +9922,7 @@ export interface components {
       created_at: string;
       verified: boolean;
       read_only: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "marketplace-account": {
       url: string;
       id: number;
@@ -9931,7 +9931,7 @@ export interface components {
       login: string;
       email?: string | null;
       organization_billing_email?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** User Marketplace Purchase */
     "user-marketplace-purchase": {
       billing_cycle: string;
@@ -9942,24 +9942,24 @@ export interface components {
       updated_at: string | null;
       account: components["schemas"]["marketplace-account"];
       plan: components["schemas"]["marketplace-listing-plan"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Starred Repository */
     "starred-repository": {
       starred_at: string;
       repo: components["schemas"]["repository"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Hovercard */
     hovercard: {
       contexts: ({
         message: string;
         octicon: string;
-      } & { [key: string]: any })[];
-    } & { [key: string]: any };
+      } & { [key: string]: unknown })[];
+    } & { [key: string]: unknown };
     /** Key Simple */
     "key-simple": {
       id: number;
       key: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
   };
   responses: {
     /** Resource Not Found */
@@ -9980,7 +9980,7 @@ export interface components {
         "application/json": {
           message: string;
           documentation_url: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
     /** Forbidden */
@@ -10016,7 +10016,7 @@ export interface components {
           code?: string;
           message?: string;
           documentation_url?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
     /** Forbidden Gist */
@@ -10027,10 +10027,10 @@ export interface components {
             reason?: string;
             created_at?: string;
             html_url?: string | null;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           message?: string;
           documentation_url?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
     /** Moved Permanently */
@@ -10233,7 +10233,7 @@ export interface components {
     /** The id of the workflow run */
     "run-id": number;
     /** The ID of the workflow. You can also pass the workflow file name as a string. */
-    "workflow-id": (number | string) & { [key: string]: any };
+    "workflow-id": (number | string) & { [key: string]: unknown };
     /** The name of the branch. */
     branch: string;
     /** check_run_id parameter */
@@ -10343,7 +10343,7 @@ export interface operations {
             user_organizations_url: string;
             user_repositories_url: string;
             user_search_url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -10381,7 +10381,7 @@ export interface operations {
               client_secret: string;
               webhook_secret: string;
               pem: string;
-            } & { [key: string]: any }) & { [key: string]: any };
+            } & { [key: string]: unknown }) & { [key: string]: unknown };
         };
       };
       404: components["responses"]["not_found"];
@@ -10424,7 +10424,7 @@ export interface operations {
           content_type?: components["schemas"]["webhook-config-content-type"];
           secret?: components["schemas"]["webhook-config-secret"];
           insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -10529,7 +10529,7 @@ export interface operations {
           /** List of repository IDs that the token should have access to */
           repository_ids?: number[];
           permissions?: components["schemas"]["app-permissions"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -10658,7 +10658,7 @@ export interface operations {
         "application/json": {
           /** The OAuth access token used to authenticate to the GitHub API. */
           access_token?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -10705,7 +10705,7 @@ export interface operations {
         "application/json": {
           /** The access_token of the OAuth application. */
           access_token: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -10727,7 +10727,7 @@ export interface operations {
         "application/json": {
           /** The OAuth access token used to authenticate to the GitHub API. */
           access_token?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -10753,7 +10753,7 @@ export interface operations {
         "application/json": {
           /** The access_token of the OAuth application. */
           access_token: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -10791,7 +10791,7 @@ export interface operations {
           /** The list of repository names to scope the user-to-server access token to. `repository_ids` may not be specified if `repositories` is specified. */
           repository_ids?: number[];
           permissions?: components["schemas"]["app-permissions"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -10812,7 +10812,7 @@ export interface operations {
       /** response */
       200: {
         content: {
-          "application/json": (components["schemas"]["authorization"] & { [key: string]: any }) | null;
+          "application/json": (components["schemas"]["authorization"] & { [key: string]: unknown }) | null;
         };
       };
       404: components["responses"]["not_found"];
@@ -10951,7 +10951,7 @@ export interface operations {
           client_secret?: string;
           /** A unique string to distinguish an authorization from others created for the same client ID and user. */
           fingerprint?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11010,7 +11010,7 @@ export interface operations {
           note_url?: string;
           /** A unique string to distinguish an authorization from others created for the same client ID and user. */
           fingerprint?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11063,7 +11063,7 @@ export interface operations {
           note?: string;
           /** A URL to remind you what app the OAuth token is for. */
           note_url?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11141,7 +11141,7 @@ export interface operations {
           note_url?: string;
           /** A unique string to distinguish an authorization from others created for the same client ID and user. */
           fingerprint?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11210,7 +11210,7 @@ export interface operations {
           title: string;
           /** The body of the attachment */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11269,7 +11269,7 @@ export interface operations {
         "application/json": {
           enabled_organizations: components["schemas"]["enabled-organizations"];
           allowed_actions?: components["schemas"]["allowed-actions"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11298,7 +11298,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             organizations: components["schemas"]["organization-simple"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -11324,7 +11324,7 @@ export interface operations {
         "application/json": {
           /** List of organization IDs to enable for GitHub Actions. */
           selected_organization_ids: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11434,7 +11434,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             runner_groups: components["schemas"]["runner-groups-enterprise"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -11470,7 +11470,7 @@ export interface operations {
           selected_organization_ids?: number[];
           /** List of runner IDs to add to the runner group. */
           runners?: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11545,7 +11545,7 @@ export interface operations {
           name?: string;
           /** Visibility of a runner group. You can select all organizations or select individual organizations. Can be one of: `all` or `selected` */
           visibility?: "selected" | "all";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11576,7 +11576,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             organizations: components["schemas"]["organization-simple"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -11604,7 +11604,7 @@ export interface operations {
         "application/json": {
           /** List of organization IDs that can access the runner group. */
           selected_organization_ids: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11678,7 +11678,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             runners: components["schemas"]["runner"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -11706,7 +11706,7 @@ export interface operations {
         "application/json": {
           /** List of runner IDs to add to the runner group. */
           runners: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -11779,7 +11779,7 @@ export interface operations {
           "application/json": {
             total_count?: number;
             runners?: components["schemas"]["runner"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -12124,10 +12124,10 @@ export interface operations {
             [key: string]: {
               /** Content of the file */
               content: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
           };
-          public?: (boolean | ("true" | "false")) & { [key: string]: any };
-        } & { [key: string]: any };
+          public?: (boolean | ("true" | "false")) & { [key: string]: unknown };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -12245,7 +12245,7 @@ export interface operations {
               description?: string;
               /** Names of files to be updated */
               files?: { [key: string]: Partial<{ [key: string]: unknown }> };
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | null;
       };
     };
@@ -12302,7 +12302,7 @@ export interface operations {
         "application/json": {
           /** The comment text. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -12367,7 +12367,7 @@ export interface operations {
         "application/json": {
           /** The comment text. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -12576,7 +12576,7 @@ export interface operations {
             total_count: number;
             repositories: components["schemas"]["repository"][];
             repository_selection?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -12713,7 +12713,7 @@ export interface operations {
           mode?: "markdown" | "gfm";
           /** The repository context to use when creating references in `gfm` mode. */
           context?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -12992,7 +12992,7 @@ export interface operations {
         content: {
           "application/json": {
             message?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** response */
@@ -13008,7 +13008,7 @@ export interface operations {
           last_read_at?: string;
           /** Whether the notification has been read. */
           read?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13099,7 +13099,7 @@ export interface operations {
         "application/json": {
           /** Whether to block all notifications from a thread. */
           ignored?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13210,7 +13210,7 @@ export interface operations {
           "application/json": (
             | components["schemas"]["validation-error"]
             | components["schemas"]["validation-error-simple"]
-          ) & { [key: string]: any };
+          ) & { [key: string]: unknown };
         };
       };
     };
@@ -13299,7 +13299,7 @@ export interface operations {
            */
           members_can_create_private_pages?: boolean;
           blog?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13345,7 +13345,7 @@ export interface operations {
         "application/json": {
           enabled_repositories: components["schemas"]["enabled-repositories"];
           allowed_actions?: components["schemas"]["allowed-actions"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13373,7 +13373,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             repositories: components["schemas"]["repository"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -13398,7 +13398,7 @@ export interface operations {
         "application/json": {
           /** List of repository IDs to enable for GitHub Actions. */
           selected_repository_ids: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13507,7 +13507,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             runner_groups: components["schemas"]["runner-groups-org"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -13544,7 +13544,7 @@ export interface operations {
           selected_repository_ids?: number[];
           /** List of runner IDs to add to the runner group. */
           runners?: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13622,7 +13622,7 @@ export interface operations {
           name?: string;
           /** Visibility of a runner group. You can select all repositories, select individual repositories, or all private repositories. Can be one of: `all`, `selected`, or `private`. */
           visibility?: "selected" | "all" | "private";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13648,7 +13648,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             repositories: components["schemas"]["repository"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -13677,7 +13677,7 @@ export interface operations {
         "application/json": {
           /** List of repository IDs that can access the runner group. */
           selected_repository_ids: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13755,7 +13755,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             runners: components["schemas"]["runner"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -13784,7 +13784,7 @@ export interface operations {
         "application/json": {
           /** List of runner IDs to add to the runner group. */
           runners: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -13860,7 +13860,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             runners: components["schemas"]["runner"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -14003,7 +14003,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             secrets: components["schemas"]["organization-actions-secret"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -14149,7 +14149,7 @@ export interface operations {
           visibility?: "all" | "private" | "selected";
           /** An array of repository ids that can access the organization secret. You can only provide a list of repository ids when the `visibility` is set to `selected`. You can manage the list of selected repositories using the [List selected repositories for an organization secret](https://docs.github.com/rest/reference/actions#list-selected-repositories-for-an-organization-secret), [Set selected repositories for an organization secret](https://docs.github.com/rest/reference/actions#set-selected-repositories-for-an-organization-secret), and [Remove selected repository from an organization secret](https://docs.github.com/rest/reference/actions#remove-selected-repository-from-an-organization-secret) endpoints. */
           selected_repository_ids?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -14183,7 +14183,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             repositories: components["schemas"]["minimal-repository"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -14206,7 +14206,7 @@ export interface operations {
         "application/json": {
           /** An array of repository ids that can access the organization secret. You can only provide a list of repository ids when the `visibility` is set to `selected`. You can add and remove individual repositories using the [Set selected repositories for an organization secret](https://docs.github.com/rest/reference/actions#set-selected-repositories-for-an-organization-secret) and [Remove selected repository from an organization secret](https://docs.github.com/rest/reference/actions#remove-selected-repository-from-an-organization-secret) endpoints. */
           selected_repository_ids?: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -14491,12 +14491,12 @@ export interface operations {
             insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
             username?: string;
             password?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
           events?: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
           active?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -14558,13 +14558,13 @@ export interface operations {
             content_type?: components["schemas"]["webhook-config-content-type"];
             secret?: components["schemas"]["webhook-config-secret"];
             insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
           events?: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
           active?: boolean;
           name?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -14616,7 +14616,7 @@ export interface operations {
           content_type?: components["schemas"]["webhook-config-content-type"];
           secret?: components["schemas"]["webhook-config-secret"];
           insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -14675,7 +14675,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             installations: components["schemas"]["installation"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -14791,7 +14791,7 @@ export interface operations {
           role?: "admin" | "direct_member" | "billing_manager";
           /** Specify IDs for the teams you want to invite new members to. */
           team_ids?: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -15017,7 +15017,7 @@ export interface operations {
            * \* `member` - The user will become a non-owner member of the organization.
            */
           role?: "admin" | "member";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -15090,7 +15090,7 @@ export interface operations {
           /** Indicates whether attachments should be excluded from the migration (to reduce migration archive file size). */
           exclude_attachments?: boolean;
           exclude?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -15248,7 +15248,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       404: components["responses"]["not_found"];
@@ -15271,7 +15271,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -15521,7 +15521,7 @@ export interface operations {
           name: string;
           /** The description of the project. */
           body?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -15690,7 +15690,7 @@ export interface operations {
           allow_rebase_merge?: boolean;
           /** Either `true` to allow automatically deleting head branches when pull requests are merged, or `false` to prevent automatic deletion. */
           delete_branch_on_merge?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -15867,7 +15867,7 @@ export interface operations {
           permission?: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -15960,7 +15960,7 @@ export interface operations {
           permission?: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number | null;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16027,7 +16027,7 @@ export interface operations {
           body: string;
           /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
           private?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16102,7 +16102,7 @@ export interface operations {
           title?: string;
           /** The discussion post's body text. */
           body?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16167,7 +16167,7 @@ export interface operations {
         "application/json": {
           /** The discussion comment's body text. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16243,7 +16243,7 @@ export interface operations {
         "application/json": {
           /** The discussion comment's body text. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16308,7 +16308,7 @@ export interface operations {
         "application/json": {
           /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the team discussion comment. */
           content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16392,7 +16392,7 @@ export interface operations {
         "application/json": {
           /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the team discussion. */
           content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16550,8 +16550,8 @@ export interface operations {
               code?: string;
               field?: string;
               resource?: string;
-            } & { [key: string]: any })[];
-          } & { [key: string]: any };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -16564,7 +16564,7 @@ export interface operations {
            * \* `maintainer` - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
            */
           role?: "member" | "maintainer";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16670,7 +16670,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -16686,7 +16686,7 @@ export interface operations {
                * Default: the team's `permission` attribute will be used to determine what permission to grant the team on this project. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/rest/overview/resources-in-the-rest-api#http-verbs)."
                */
               permission?: "read" | "write" | "admin";
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | null;
       };
     };
@@ -16806,7 +16806,7 @@ export interface operations {
            * If no permission is specified, the team's `permission` attribute will be used to determine what permission to grant the team on this repository.
            */
           permission?: "pull" | "push" | "admin" | "maintain" | "triage";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16888,8 +16888,8 @@ export interface operations {
             group_name: string;
             /** Description of the IdP group. */
             group_description: string;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -16961,7 +16961,7 @@ export interface operations {
             message?: string;
             documentation_url?: string;
             errors?: string[];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       404: components["responses"]["not_found"];
@@ -16994,7 +16994,7 @@ export interface operations {
           note?: string | null;
           /** Whether or not the card is archived */
           archived?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17025,8 +17025,8 @@ export interface operations {
               message?: string;
               resource?: string;
               field?: string;
-            } & { [key: string]: any })[];
-          } & { [key: string]: any };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown };
         };
       };
       422: components["responses"]["validation_failed"];
@@ -17040,8 +17040,8 @@ export interface operations {
             errors?: ({
               code?: string;
               message?: string;
-            } & { [key: string]: any })[];
-          } & { [key: string]: any };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -17052,7 +17052,7 @@ export interface operations {
           position: string;
           /** The unique identifier of the column the card should be moved to */
           column_id?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17114,7 +17114,7 @@ export interface operations {
         "application/json": {
           /** Name of the project column */
           name: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17174,7 +17174,7 @@ export interface operations {
           "application/json": (
             | components["schemas"]["validation-error"]
             | components["schemas"]["validation-error-simple"]
-          ) & { [key: string]: any };
+          ) & { [key: string]: unknown };
         };
       };
       /** Service Unavailable */
@@ -17187,8 +17187,8 @@ export interface operations {
             errors?: ({
               code?: string;
               message?: string;
-            } & { [key: string]: any })[];
-          } & { [key: string]: any };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -17198,14 +17198,14 @@ export interface operations {
           | ({
               /** The project card's note */
               note: string | null;
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | ({
               /** The unique identifier of the content associated with the card */
               content_id: number;
               /** The piece of content associated with the card */
               content_type: string;
-            } & { [key: string]: any })
-        ) & { [key: string]: any };
+            } & { [key: string]: unknown })
+        ) & { [key: string]: unknown };
       };
     };
   };
@@ -17233,7 +17233,7 @@ export interface operations {
         "application/json": {
           /** The position of the column in a project */
           position: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17275,7 +17275,7 @@ export interface operations {
             message?: string;
             documentation_url?: string;
             errors?: string[];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       404: components["responses"]["not_found"];
@@ -17305,7 +17305,7 @@ export interface operations {
             message?: string;
             documentation_url?: string;
             errors?: string[];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Response if the authenticated user does not have access to the project */
@@ -17326,7 +17326,7 @@ export interface operations {
           organization_permission?: "read" | "write" | "admin" | "none";
           /** Whether or not this project can be seen by everyone. */
           private?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17389,7 +17389,7 @@ export interface operations {
         "application/json": {
           /** The permission to grant the collaborator. */
           permission?: "read" | "write" | "admin";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17483,7 +17483,7 @@ export interface operations {
         "application/json": {
           /** Name of the project column */
           name: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17573,7 +17573,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       404: components["responses"]["not_found"];
@@ -17634,7 +17634,7 @@ export interface operations {
           delete_branch_on_merge?: boolean;
           /** `true` to archive this repository. **Note**: You cannot unarchive repositories through the API. */
           archived?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17660,7 +17660,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             artifacts: components["schemas"]["artifact"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -17804,7 +17804,7 @@ export interface operations {
         "application/json": {
           enabled: components["schemas"]["actions-enabled"];
           allowed_actions?: components["schemas"]["allowed-actions"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -17877,7 +17877,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             runners: components["schemas"]["runner"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -18037,7 +18037,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             workflow_runs: components["schemas"]["workflow-run"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -18123,7 +18123,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             artifacts: components["schemas"]["artifact"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -18173,7 +18173,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             jobs: components["schemas"]["job"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -18267,7 +18267,7 @@ export interface operations {
           state: "approved" | "rejected";
           /** A comment to accompany the deployment review */
           comment: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -18331,7 +18331,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             secrets: components["schemas"]["actions-secret"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -18471,7 +18471,7 @@ export interface operations {
           encrypted_value?: string;
           /** ID of the key you used to encrypt the secret. */
           key_id?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -18512,7 +18512,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             workflows: components["schemas"]["workflow"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -18582,7 +18582,7 @@ export interface operations {
           ref: string;
           /** Input keys and values configured in the workflow file. The maximum number of properties is 10. Any default properties configured in the workflow file will be used when `inputs` are omitted. */
           inputs?: { [key: string]: string };
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -18641,7 +18641,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             workflow_runs: components["schemas"]["workflow-run"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -18852,7 +18852,7 @@ export interface operations {
                 strict: boolean;
                 /** The list of status checks to require in order to merge into this branch */
                 contexts: string[];
-              } & { [key: string]: any })
+              } & { [key: string]: unknown })
             | null;
           /** Enforce all configured restrictions for administrators. Set to `true` to enforce required status checks for repository administrators. Set to `null` to disable. */
           enforce_admins: boolean | null;
@@ -18865,14 +18865,14 @@ export interface operations {
                   users?: string[];
                   /** The list of team `slug`s with dismissal access */
                   teams?: string[];
-                } & { [key: string]: any };
+                } & { [key: string]: unknown };
                 /** Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit. */
                 dismiss_stale_reviews?: boolean;
                 /** Blocks merging pull requests until [code owners](https://help.github.com/articles/about-code-owners/) review them. */
                 require_code_owner_reviews?: boolean;
                 /** Specify the number of reviewers required to approve pull requests. Use a number between 1 and 6. */
                 required_approving_review_count?: number;
-              } & { [key: string]: any })
+              } & { [key: string]: unknown })
             | null;
           /** Restrict who can push to the protected branch. User, app, and team `restrictions` are only available for organization-owned repositories. Set to `null` to disable. */
           restrictions:
@@ -18883,7 +18883,7 @@ export interface operations {
                 teams: string[];
                 /** The list of app `slug`s with push access */
                 apps?: string[];
-              } & { [key: string]: any })
+              } & { [key: string]: unknown })
             | null;
           /** Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch. Set to `true` to enforce a linear commit history. Set to `false` to disable a linear commit Git history. Your repository must allow squash merging or rebase merging before you can enable a linear commit history. Default: `false`. For more information, see "[Requiring a linear commit history](https://help.github.com/github/administering-a-repository/requiring-a-linear-commit-history)" in the GitHub Help documentation. */
           required_linear_history?: boolean;
@@ -18891,7 +18891,7 @@ export interface operations {
           allow_force_pushes?: boolean | null;
           /** Allows deletion of the protected branch by anyone with write access to the repository. Set to `false` to prevent deletion of the protected branch. Default: `false`. For more information, see "[Enabling force pushes to a protected branch](https://help.github.com/en/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)" in the GitHub Help documentation. */
           allow_deletions?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19042,14 +19042,14 @@ export interface operations {
             users?: string[];
             /** The list of team `slug`s with dismissal access */
             teams?: string[];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Set to `true` if you want to automatically dismiss approving reviews when someone pushes a new commit. */
           dismiss_stale_reviews?: boolean;
           /** Blocks merging pull requests until [code owners](https://help.github.com/articles/about-code-owners/) have reviewed. */
           require_code_owner_reviews?: boolean;
           /** Specifies the number of reviewers required to approve pull requests. Use a number between 1 and 6. */
           required_approving_review_count?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19189,7 +19189,7 @@ export interface operations {
           strict?: boolean;
           /** The list of status checks to require in order to merge into this branch */
           contexts?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19238,7 +19238,7 @@ export interface operations {
         "application/json": {
           /** contexts parameter */
           contexts: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19268,7 +19268,7 @@ export interface operations {
         "application/json": {
           /** contexts parameter */
           contexts: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19297,7 +19297,7 @@ export interface operations {
         "application/json": {
           /** contexts parameter */
           contexts: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19402,7 +19402,7 @@ export interface operations {
         "application/json": {
           /** apps parameter */
           apps: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19438,7 +19438,7 @@ export interface operations {
         "application/json": {
           /** apps parameter */
           apps: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19474,7 +19474,7 @@ export interface operations {
         "application/json": {
           /** apps parameter */
           apps: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19534,7 +19534,7 @@ export interface operations {
         "application/json": {
           /** teams parameter */
           teams: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19570,7 +19570,7 @@ export interface operations {
         "application/json": {
           /** teams parameter */
           teams: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19606,7 +19606,7 @@ export interface operations {
         "application/json": {
           /** teams parameter */
           teams: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19666,7 +19666,7 @@ export interface operations {
         "application/json": {
           /** users parameter */
           users: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19702,7 +19702,7 @@ export interface operations {
         "application/json": {
           /** users parameter */
           users: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19738,7 +19738,7 @@ export interface operations {
         "application/json": {
           /** users parameter */
           users: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19784,7 +19784,7 @@ export interface operations {
         "application/json": {
           /** The new name of the branch. */
           new_name: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19817,12 +19817,12 @@ export interface operations {
             status?: "completed";
           } & {
             conclusion: unknown;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
           Partial<
             {
               status?: "queued" | "in_progress";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           >) & {
           /** The name of the check. For example, "code-coverage". */
           name: string;
@@ -19879,7 +19879,7 @@ export interface operations {
               title?: string;
               /** Details about this annotation. The maximum size is 64 KB. */
               raw_details?: string;
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             /** Adds images to the output displayed in the GitHub pull request UI. See the [`images` object](https://docs.github.com/rest/reference/checks#images-object) description for details. */
             images?: ({
               /** The alternative text for the image. */
@@ -19888,8 +19888,8 @@ export interface operations {
               image_url: string;
               /** A short image description. */
               caption?: string;
-            } & { [key: string]: any })[];
-          } & { [key: string]: any };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown };
           /** Displays a button on GitHub that can be clicked to alert your app to do additional tasks. For example, a code linting app can display a button that automatically fixes detected errors. The button created in this object is displayed after the check run completes. When a user clicks the button, GitHub sends the [`check_run.requested_action` webhook](https://docs.github.com/webhooks/event-payloads/#check_run) to your app. Each action includes a `label`, `identifier` and `description`. A maximum of three actions are accepted. See the [`actions` object](https://docs.github.com/rest/reference/checks#actions-object) description. To learn more about check runs and requested actions, see "[Check runs and requested actions](https://docs.github.com/rest/reference/checks#check-runs-and-requested-actions)." To learn more about check runs and requested actions, see "[Check runs and requested actions](https://docs.github.com/rest/reference/checks#check-runs-and-requested-actions)." */
           actions?: ({
             /** The text to be displayed on a button in the web UI. The maximum size is 20 characters. */
@@ -19898,8 +19898,8 @@ export interface operations {
             description: string;
             /** A reference for the action on the integrator's system. The maximum size is 20 characters. */
             identifier: string;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -19955,12 +19955,12 @@ export interface operations {
             status?: "completed";
           } & {
             conclusion: unknown;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
           Partial<
             {
               status?: "queued" | "in_progress";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           >) & {
           /** The name of the check. For example, "code-coverage". */
           name?: string;
@@ -20015,7 +20015,7 @@ export interface operations {
               title?: string;
               /** Details about this annotation. The maximum size is 64 KB. */
               raw_details?: string;
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             /** Adds images to the output displayed in the GitHub pull request UI. See the [`images` object](https://docs.github.com/rest/reference/checks#annotations-object-1) description for details. */
             images?: ({
               /** The alternative text for the image. */
@@ -20024,8 +20024,8 @@ export interface operations {
               image_url: string;
               /** A short image description. */
               caption?: string;
-            } & { [key: string]: any })[];
-          } & { [key: string]: any };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown };
           /** Possible further actions the integrator can perform, which a user may trigger. Each action includes a `label`, `identifier` and `description`. A maximum of three actions are accepted. See the [`actions` object](https://docs.github.com/rest/reference/checks#actions-object) description. To learn more about check runs and requested actions, see "[Check runs and requested actions](https://docs.github.com/rest/reference/checks#check-runs-and-requested-actions)." */
           actions?: ({
             /** The text to be displayed on a button in the web UI. The maximum size is 20 characters. */
@@ -20034,8 +20034,8 @@ export interface operations {
             description: string;
             /** A reference for the action on the integrator's system. The maximum size is 20 characters. */
             identifier: string;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -20090,7 +20090,7 @@ export interface operations {
         "application/json": {
           /** The sha of the head commit. */
           head_sha: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -20119,8 +20119,8 @@ export interface operations {
             app_id: number;
             /** Set to `true` to enable automatic creation of CheckSuite events upon pushes to the repository, or `false` to disable them. */
             setting: boolean;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -20181,7 +20181,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             check_runs: components["schemas"]["check-run"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -20302,7 +20302,7 @@ export interface operations {
         "application/json": {
           state: components["schemas"]["code-scanning-alert-set-state"];
           dismissed_reason?: components["schemas"]["code-scanning-alert-dismissed-reason"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -20576,7 +20576,7 @@ export interface operations {
           started_at?: string;
           /** The name of the tool used to generate the code scanning analysis. If this parameter is not used, the tool name defaults to "API". If the uploaded SARIF contains a tool GUID, this will be available for filtering using the `tool_guid` parameter of operations such as `GET /repos/{owner}/{repo}/code-scanning/alerts`. */
           tool_name?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -20705,7 +20705,7 @@ export interface operations {
            */
           permission?: "pull" | "push" | "admin" | "maintain" | "triage";
           permissions?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -20826,7 +20826,7 @@ export interface operations {
         "application/json": {
           /** The contents of the comment */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -20891,7 +20891,7 @@ export interface operations {
         "application/json": {
           /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the commit comment. */
           content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -21071,7 +21071,7 @@ export interface operations {
           position?: number;
           /** **Deprecated**. Use **position** parameter instead. Line number in the file to comment on. */
           line?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -21195,7 +21195,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             check_runs: components["schemas"]["check-run"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -21232,7 +21232,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             check_suites: components["schemas"]["check-suite"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -21469,7 +21469,7 @@ export interface operations {
             | components["schemas"]["content-file"]
             | components["schemas"]["content-symlink"]
             | components["schemas"]["content-submodule"]
-          ) & { [key: string]: any };
+          ) & { [key: string]: unknown };
         };
       };
       302: components["responses"]["found"];
@@ -21522,7 +21522,7 @@ export interface operations {
             /** The email of the author or committer of the commit. You'll receive a `422` status code if `email` is omitted. */
             email: string;
             date?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The author of the file. Default: The `committer` or the authenticated user if you omit `committer`. */
           author?: {
             /** The name of the author or committer of the commit. You'll receive a `422` status code if `name` is omitted. */
@@ -21530,8 +21530,8 @@ export interface operations {
             /** The email of the author or committer of the commit. You'll receive a `422` status code if `email` is omitted. */
             email: string;
             date?: string;
-          } & { [key: string]: any };
-        } & { [key: string]: any };
+          } & { [key: string]: unknown };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -21580,15 +21580,15 @@ export interface operations {
             name?: string;
             /** The email of the author (or committer) of the commit */
             email?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** object containing information about the author. */
           author?: {
             /** The name of the author (or committer) of the commit */
             name?: string;
             /** The email of the author (or committer) of the commit */
             email?: string;
-          } & { [key: string]: any };
-        } & { [key: string]: any };
+          } & { [key: string]: unknown };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -21724,7 +21724,7 @@ export interface operations {
         content: {
           "application/json": {
             message?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** response */
@@ -21733,7 +21733,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       422: components["responses"]["validation_failed"];
@@ -21749,7 +21749,7 @@ export interface operations {
           auto_merge?: boolean;
           /** The [status](https://docs.github.com/rest/reference/repos#statuses) contexts to verify against commit status checks. If you omit this parameter, GitHub verifies all unique contexts before creating a deployment. To bypass checking entirely, pass an empty array. Defaults to all unique contexts. */
           required_contexts?: string[];
-          payload?: ({ [key: string]: any } | string) & { [key: string]: any };
+          payload?: ({ [key: string]: unknown } | string) & { [key: string]: unknown };
           /** Name for the target deployment environment (e.g., `production`, `staging`, `qa`). */
           environment?: string;
           /** Short description of the deployment. */
@@ -21765,7 +21765,7 @@ export interface operations {
            */
           production_environment?: boolean;
           created_at?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -21894,7 +21894,7 @@ export interface operations {
            * **Note:** This parameter requires you to use the [`application/vnd.github.ant-man-preview+json`](https://docs.github.com/rest/overview/api-previews#enhanced-deployments) custom media type.
            */
           auto_inactive?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -21950,8 +21950,8 @@ export interface operations {
           /** A custom webhook event name. */
           event_type: string;
           /** JSON payload with extra information about the webhook event that your action or worklow may use. */
-          client_payload?: { [key: string]: any };
-        } & { [key: string]: any };
+          client_payload?: { [key: string]: unknown };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -21975,7 +21975,7 @@ export interface operations {
             /** The number of environments in this repository */
             total_count?: number;
             environments?: components["schemas"]["environment"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -22040,9 +22040,9 @@ export interface operations {
             type?: components["schemas"]["deployment-reviewer-type"];
             /** The id of the user or team who can review the deployment */
             id?: number;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           deployment_branch_policy?: components["schemas"]["deployment_branch_policy"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22138,7 +22138,7 @@ export interface operations {
         "application/json": {
           /** Optional parameter to specify the organization name if forking into an organization. */
           organization?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22171,7 +22171,7 @@ export interface operations {
           content: string;
           /** The encoding used for `content`. Currently, `"utf-8"` and `"base64"` are supported. */
           encoding?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22269,7 +22269,7 @@ export interface operations {
             email?: string;
             /** Indicates when this commit was authored (or committed). This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
             date?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Information about the person who is making the commit. By default, `committer` will use the information set in `author`. See the `author` and `committer` object below for details. */
           committer?: {
             /** The name of the author (or committer) of the commit */
@@ -22278,10 +22278,10 @@ export interface operations {
             email?: string;
             /** Indicates when this commit was authored (or committed). This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
             date?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The [PGP signature](https://en.wikipedia.org/wiki/Pretty_Good_Privacy) of the commit. GitHub adds the signature to the `gpgsig` header of the created commit. For a commit signature to be verifiable by Git or GitHub, it must be an ASCII-armored detached PGP signature over the string commit as it would be written to the object database. To pass a `signature` parameter, you need to first manually create a valid PGP signature, which can be complicated. You may find it easier to [use the command line](https://git-scm.com/book/id/v2/Git-Tools-Signing-Your-Work) to create signed commits. */
           signature?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22422,7 +22422,7 @@ export interface operations {
           /** The SHA1 value for this reference. */
           sha: string;
           key?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22466,7 +22466,7 @@ export interface operations {
           sha: string;
           /** Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this out or setting it to `false` will make sure you're not overwriting work. */
           force?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22540,8 +22540,8 @@ export interface operations {
             email?: string;
             /** When this object was tagged. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
             date?: string;
-          } & { [key: string]: any };
-        } & { [key: string]: any };
+          } & { [key: string]: unknown };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22642,13 +22642,13 @@ export interface operations {
              * **Note:** Use either `tree.sha` or `content` to specify the contents of the entry. Using both `tree.sha` and `content` will return an error.
              */
             content?: string;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           /**
            * The SHA1 of an existing Git tree object which will be used as the base for the new tree. If provided, a new Git tree object will be created from entries in the Git tree object pointed to by `base_tree` and entries defined in the `tree` parameter. Entries defined in the `tree` parameter will overwrite items from `base_tree` with the same `path`. If you're creating new changes on a branch, then normally you'd set `base_tree` to the SHA1 of the Git tree object of the current latest commit on the branch you're working on.
            * If not provided, GitHub will create a new Git tree object from only the entries defined in the `tree` parameter. If you create a new commit pointing to such a tree, then all files which were a part of the parent commit's tree and were not defined in the `tree` parameter will be listed as deleted by the new commit.
            */
           base_tree?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22742,12 +22742,12 @@ export interface operations {
             insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
             token?: string;
             digest?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. */
           events?: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
           active?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22814,7 +22814,7 @@ export interface operations {
             insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
             address?: string;
             room?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events. */
           events?: string[];
           /** Determines a list of events to be added to the list of events that the Hook triggers for. */
@@ -22823,7 +22823,7 @@ export interface operations {
           remove_events?: string[];
           /** Determines if notifications are sent when the webhook is triggered. Set to `true` to send notifications. */
           active?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -22877,7 +22877,7 @@ export interface operations {
           content_type?: components["schemas"]["webhook-config-content-type"];
           secret?: components["schemas"]["webhook-config-secret"];
           insecure_ssl?: components["schemas"]["webhook-config-insecure-ssl"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23002,7 +23002,7 @@ export interface operations {
           vcs_password?: string;
           /** For a tfvc import, the name of the project that is being imported. */
           tfvc_project?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23047,7 +23047,7 @@ export interface operations {
           vcs_password?: string;
           vcs?: string;
           tfvc_project?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23104,7 +23104,7 @@ export interface operations {
           /** The new Git author name. */
           name?: string;
           remote_id?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23147,7 +23147,7 @@ export interface operations {
         "application/json": {
           /** Can be one of `opt_in` (large files will be stored using Git LFS) or `opt_out` (large files will be removed during the import). */
           use_lfs: "opt_in" | "opt_out";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23290,7 +23290,7 @@ export interface operations {
         "application/json": {
           /** The permissions that the associated user will have on the repository. Valid values are `read`, `write`, `maintain`, `triage`, and `admin`. */
           permissions?: "read" | "write" | "maintain" | "triage" | "admin";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23378,12 +23378,12 @@ export interface operations {
       content: {
         "application/json": {
           /** The title of the issue. */
-          title: (string | number) & { [key: string]: any };
+          title: (string | number) & { [key: string]: unknown };
           /** The contents of the issue. */
           body?: string;
           /** Login for the user that this issue should be assigned to. _NOTE: Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise. **This field is deprecated.**_ */
           assignee?: string | null;
-          milestone?: ((string | number) & { [key: string]: any }) | null;
+          milestone?: ((string | number) & { [key: string]: unknown }) | null;
           /** Labels to associate with this issue. _NOTE: Only users with push access can set labels for new issues. Labels are silently dropped otherwise._ */
           labels?: ((
             | string
@@ -23392,11 +23392,11 @@ export interface operations {
                 name?: string;
                 description?: string | null;
                 color?: string | null;
-              } & { [key: string]: any })
-          ) & { [key: string]: any })[];
+              } & { [key: string]: unknown })
+          ) & { [key: string]: unknown })[];
           /** Logins for Users to assign to this issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._ */
           assignees?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23488,7 +23488,7 @@ export interface operations {
         "application/json": {
           /** The contents of the comment. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23553,7 +23553,7 @@ export interface operations {
         "application/json": {
           /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the issue comment. */
           content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23684,14 +23684,14 @@ export interface operations {
       content: {
         "application/json": {
           /** The title of the issue. */
-          title?: ((string | number) & { [key: string]: any }) | null;
+          title?: ((string | number) & { [key: string]: unknown }) | null;
           /** The contents of the issue. */
           body?: string | null;
           /** Login for the user that this issue should be assigned to. **This field is deprecated.** */
           assignee?: string | null;
           /** State of the issue. Either `open` or `closed`. */
           state?: "open" | "closed";
-          milestone?: ((string | number) & { [key: string]: any }) | null;
+          milestone?: ((string | number) & { [key: string]: unknown }) | null;
           /** Labels to associate with this issue. Pass one or more Labels to _replace_ the set of Labels on this Issue. Send an empty array (`[]`) to clear all Labels from the Issue. _NOTE: Only users with push access can set labels for issues. Labels are silently dropped otherwise._ */
           labels?: ((
             | string
@@ -23700,11 +23700,11 @@ export interface operations {
                 name?: string;
                 description?: string | null;
                 color?: string | null;
-              } & { [key: string]: any })
-          ) & { [key: string]: any })[];
+              } & { [key: string]: unknown })
+          ) & { [key: string]: unknown })[];
           /** Logins for Users to assign to this issue. Pass one or more user logins to _replace_ the set of assignees on this Issue. Send an empty array (`[]`) to clear all assignees from the Issue. _NOTE: Only users with push access can set assignees for new issues. Assignees are silently dropped otherwise._ */
           assignees?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23731,7 +23731,7 @@ export interface operations {
         "application/json": {
           /** Usernames of people to assign this issue to. _NOTE: Only users with push access can add assignees to an issue. Assignees are silently ignored otherwise._ */
           assignees?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23758,7 +23758,7 @@ export interface operations {
         "application/json": {
           /** Usernames of assignees to remove from an issue. _NOTE: Only users with push access can remove assignees from an issue. Assignees are silently ignored otherwise._ */
           assignees?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23822,7 +23822,7 @@ export interface operations {
         "application/json": {
           /** The contents of the comment. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23903,7 +23903,7 @@ export interface operations {
         "application/json": {
           /** The names of the labels to add to the issue. You can pass an empty array to remove all labels. **Note:** Alternatively, you can pass a single label as a `string` or an `array` of labels directly, but GitHub recommends passing an object with the `labels` key. */
           labels?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -23931,7 +23931,7 @@ export interface operations {
         "application/json": {
           /** The name of the label to add to the issue. Must contain at least one label. **Note:** Alternatively, you can pass a single label as a `string` or an `array` of labels directly, but GitHub recommends passing an object with the `labels` key. */
           labels: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24006,7 +24006,7 @@ export interface operations {
                * \* `spam`
                */
               lock_reason?: "off-topic" | "too heated" | "resolved" | "spam";
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | null;
       };
     };
@@ -24084,7 +24084,7 @@ export interface operations {
         "application/json": {
           /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the issue. */
           content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24192,7 +24192,7 @@ export interface operations {
            * Deploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository. For more information, see "[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)" and "[Permission levels for a user account repository](https://help.github.com/articles/permission-levels-for-a-user-account-repository/)."
            */
           read_only?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24283,7 +24283,7 @@ export interface operations {
           color?: string;
           /** A short description of the label. */
           description?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24343,7 +24343,7 @@ export interface operations {
           color?: string;
           /** A short description of the label. */
           description?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24406,7 +24406,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Merge conflict response */
@@ -24415,7 +24415,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       422: components["responses"]["validation_failed"];
@@ -24429,7 +24429,7 @@ export interface operations {
           head: string;
           /** Commit message to use for the merge commit. If omitted, a default message will be used. */
           commit_message?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24494,7 +24494,7 @@ export interface operations {
           description?: string;
           /** The milestone due date. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
           due_on?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24560,7 +24560,7 @@ export interface operations {
           description?: string;
           /** The milestone due date. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
           due_on?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24638,7 +24638,7 @@ export interface operations {
         "application/json": {
           /** Describes the last point that notifications were checked. Anything updated since this time will not be marked as read. If you omit this parameter, all notifications are marked as read. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. Default: The current timestamp. */
           last_read_at?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24687,9 +24687,9 @@ export interface operations {
                 branch: string;
                 /** The repository directory that includes the source files for the Pages site. Allowed paths are `/` or `/docs`. */
                 path: "/" | "/docs";
-              } & { [key: string]: any }
-            >) & { [key: string]: any };
-        } & { [key: string]: any };
+              } & { [key: string]: unknown }
+            >) & { [key: string]: unknown };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24721,8 +24721,8 @@ export interface operations {
             branch: string;
             /** The repository directory that includes the source files for the Pages site. Allowed paths are `/` or `/docs`. Default: `/` */
             path?: "/" | "/docs";
-          } & { [key: string]: any };
-        } & { [key: string]: any };
+          } & { [key: string]: unknown };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24877,7 +24877,7 @@ export interface operations {
           name: string;
           /** The description of the project. */
           body?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -24962,7 +24962,7 @@ export interface operations {
           /** Indicates whether the pull request is a draft. See "[Draft Pull Requests](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)" in the GitHub Help documentation to learn more. */
           draft?: boolean;
           issue?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25055,7 +25055,7 @@ export interface operations {
         "application/json": {
           /** The text of the reply to the review comment. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25120,7 +25120,7 @@ export interface operations {
         "application/json": {
           /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the pull request review comment. */
           content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25217,7 +25217,7 @@ export interface operations {
           base?: string;
           /** Indicates whether [maintainers can modify](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request. */
           maintainer_can_modify?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25302,7 +25302,7 @@ export interface operations {
           /** **Required when using multi-line comments**. To create multi-line comments, you must use the `comfort-fade` preview header. The `start_side` is the starting side of the diff that the comment applies to. Can be `LEFT` or `RIGHT`. To learn more about multi-line comments, see "[Commenting on a pull request](https://help.github.com/en/articles/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request)" in the GitHub Help documentation. See `side` in this table for additional context. */
           start_side?: "LEFT" | "RIGHT" | "side";
           in_reply_to?: number;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25338,7 +25338,7 @@ export interface operations {
         "application/json": {
           /** The text of the review comment. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25433,7 +25433,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Response if sha was provided and pull request head did not match */
@@ -25442,7 +25442,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       422: components["responses"]["validation_failed"];
@@ -25459,7 +25459,7 @@ export interface operations {
               sha?: string;
               /** Merge method to use. Possible values are `merge`, `squash` or `rebase`. Default is `merge`. */
               merge_method?: "merge" | "squash" | "rebase";
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | null;
       };
     };
@@ -25515,7 +25515,7 @@ export interface operations {
           reviewers?: string[];
           /** An array of team `slug`s that will be requested. */
           team_reviewers?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25539,7 +25539,7 @@ export interface operations {
           reviewers: string[];
           /** An array of team `slug`s that will be removed. */
           team_reviewers?: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25616,8 +25616,8 @@ export interface operations {
             side?: string;
             start_line?: number;
             start_side?: string;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25666,7 +25666,7 @@ export interface operations {
         "application/json": {
           /** The body text of the pull request review. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25746,7 +25746,7 @@ export interface operations {
           /** The message for the pull request review dismissal */
           message: string;
           event?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25778,7 +25778,7 @@ export interface operations {
           body?: string;
           /** The review action you want to perform. The review actions include: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`. When you leave this blank, the API returns _HTTP 422 (Unrecognizable entity)_ and sets the review action state to `PENDING`, which means you will need to re-submit the pull request review using a review action. */
           event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25798,7 +25798,7 @@ export interface operations {
           "application/json": {
             message?: string;
             url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       403: components["responses"]["forbidden"];
@@ -25811,7 +25811,7 @@ export interface operations {
           | ({
               /** The expected SHA of the pull request's HEAD ref. This is the most recent commit on the pull request's branch. If the expected SHA does not match the pull request's HEAD, you will receive a `422 Unprocessable Entity` status. You can use the "[List commits](https://docs.github.com/rest/reference/repos#list-commits)" endpoint to find the most recent commit SHA. Default: SHA of the pull request's current HEAD ref. */
               expected_head_sha?: string;
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | null;
       };
     };
@@ -25911,7 +25911,7 @@ export interface operations {
           draft?: boolean;
           /** `true` to identify the release as a prerelease. `false` to identify the release as a full release. */
           prerelease?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -25977,7 +25977,7 @@ export interface operations {
           /** An alternate short description of the asset. Used in place of the filename. */
           label?: string;
           state?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -26090,7 +26090,7 @@ export interface operations {
           draft?: boolean;
           /** `true` to identify the release as a prerelease, `false` to identify the release as a full release. */
           prerelease?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -26256,7 +26256,7 @@ export interface operations {
         "application/json": {
           state: components["schemas"]["secret-scanning-alert-state"];
           resolution?: components["schemas"]["secret-scanning-alert-resolution"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -26439,7 +26439,7 @@ export interface operations {
           description?: string;
           /** A string label to differentiate this status from the status of other systems. This field is case-insensitive. */
           context?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -26509,7 +26509,7 @@ export interface operations {
           subscribed?: boolean;
           /** Determines if all notifications should be blocked from this repository. */
           ignored?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -26632,7 +26632,7 @@ export interface operations {
         "application/json": {
           /** An array of topics to add to the repository. Pass one or more topics to _replace_ the set of existing topics. Send an empty array (`[]`) to clear all topics from the repository. **Note:** Topic `names` cannot contain uppercase letters. */
           names: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -26739,7 +26739,7 @@ export interface operations {
           new_owner: string;
           /** ID of the team or teams to add to the repository. Teams can only be added to organization-owned repositories. */
           team_ids?: number[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -26844,7 +26844,7 @@ export interface operations {
           include_all_branches?: boolean;
           /** Either `true` to create a new private repository or `false` to create a new public one. */
           private?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -26897,7 +26897,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             secrets: components["schemas"]["actions-secret"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -27040,7 +27040,7 @@ export interface operations {
           encrypted_value?: string;
           /** ID of the key you used to encrypt the secret. */
           key_id?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27113,8 +27113,8 @@ export interface operations {
           members?: ({
             /** The SCIM user ID for a user. */
             value: string;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27169,8 +27169,8 @@ export interface operations {
           members?: ({
             /** The SCIM user ID for a user. */
             value: string;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27218,7 +27218,7 @@ export interface operations {
           schemas: string[];
           /** Array of [SCIM operations](https://tools.ietf.org/html/rfc7644#section-3.5.2). */
           Operations: { [key: string]: unknown }[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27298,7 +27298,7 @@ export interface operations {
             givenName: string;
             /** The last name of the user. */
             familyName: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** List of user emails. */
           emails: ({
             /** The email address. */
@@ -27307,12 +27307,12 @@ export interface operations {
             type: string;
             /** Whether this email address is the primary address. */
             primary: boolean;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           /** List of SCIM group IDs the user is a member of. */
           groups?: ({
             value?: string;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27373,7 +27373,7 @@ export interface operations {
             givenName: string;
             /** The last name of the user. */
             familyName: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** List of user emails. */
           emails: ({
             /** The email address. */
@@ -27382,12 +27382,12 @@ export interface operations {
             type: string;
             /** Whether this email address is the primary address. */
             primary: boolean;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           /** List of SCIM group IDs the user is a member of. */
           groups?: ({
             value?: string;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27450,7 +27450,7 @@ export interface operations {
           schemas: string[];
           /** Array of [SCIM operations](https://tools.ietf.org/html/rfc7644#section-3.5.2). */
           Operations: { [key: string]: unknown }[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27539,18 +27539,18 @@ export interface operations {
             givenName: string;
             familyName: string;
             formatted?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** user emails */
           emails: ({
             value: string;
             primary?: boolean;
             type?: string;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           schemas?: string[];
           externalId?: string;
           groups?: string[];
           active?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27615,14 +27615,14 @@ export interface operations {
             givenName: string;
             familyName: string;
             formatted?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** user emails */
           emails: ({
             type?: string;
             value: string;
             primary?: boolean;
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27701,15 +27701,15 @@ export interface operations {
                   externalId?: string | null;
                   givenName?: string | null;
                   familyName?: string | null;
-                } & { [key: string]: any })
+                } & { [key: string]: unknown })
               | ({
                   value?: string;
                   primary?: boolean;
-                } & { [key: string]: any })[]
+                } & { [key: string]: unknown })[]
               | string
-            ) & { [key: string]: any };
-          } & { [key: string]: any })[];
-        } & { [key: string]: any };
+            ) & { [key: string]: unknown };
+          } & { [key: string]: unknown })[];
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -27756,7 +27756,7 @@ export interface operations {
             total_count: number;
             incomplete_results: boolean;
             items: components["schemas"]["code-search-result-item"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -27798,7 +27798,7 @@ export interface operations {
             total_count: number;
             incomplete_results: boolean;
             items: components["schemas"]["commit-search-result-item"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -27853,7 +27853,7 @@ export interface operations {
             total_count: number;
             incomplete_results: boolean;
             items: components["schemas"]["issue-search-result-item"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -27894,7 +27894,7 @@ export interface operations {
             total_count: number;
             incomplete_results: boolean;
             items: components["schemas"]["label-search-result-item"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -27941,7 +27941,7 @@ export interface operations {
             total_count: number;
             incomplete_results: boolean;
             items: components["schemas"]["repo-search-result-item"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -27975,7 +27975,7 @@ export interface operations {
             total_count: number;
             incomplete_results: boolean;
             items: components["schemas"]["topic-search-result-item"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -28016,7 +28016,7 @@ export interface operations {
             total_count: number;
             incomplete_results: boolean;
             items: components["schemas"]["user-search-result-item"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -28110,7 +28110,7 @@ export interface operations {
           permission?: "pull" | "push" | "admin";
           /** The ID of a team to set as the parent team. */
           parent_team_id?: number | null;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28173,7 +28173,7 @@ export interface operations {
           body: string;
           /** Private posts are only visible to team members, organization owners, and team maintainers. Public posts are visible to all members of the organization. Set to `true` to create a private post. */
           private?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28242,7 +28242,7 @@ export interface operations {
           title?: string;
           /** The discussion post's body text. */
           body?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28303,7 +28303,7 @@ export interface operations {
         "application/json": {
           /** The discussion comment's body text. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28373,7 +28373,7 @@ export interface operations {
         "application/json": {
           /** The discussion comment's body text. */
           body: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28434,7 +28434,7 @@ export interface operations {
         "application/json": {
           /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the team discussion comment. */
           content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28493,7 +28493,7 @@ export interface operations {
         "application/json": {
           /** The [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types) to add to the team discussion. */
           content: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28615,9 +28615,9 @@ export interface operations {
               code?: string;
               field?: string;
               resource?: string;
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -28712,9 +28712,9 @@ export interface operations {
               code?: string;
               field?: string;
               resource?: string;
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -28727,7 +28727,7 @@ export interface operations {
            * \* `maintainer` - a team maintainer. Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
            */
           role?: "member" | "maintainer";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28828,7 +28828,7 @@ export interface operations {
           "application/json": {
             message?: string;
             documentation_url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       404: components["responses"]["not_found"];
@@ -28846,7 +28846,7 @@ export interface operations {
            * Default: the team's `permission` attribute will be used to determine what permission to grant the team on this project. Note that, if you choose not to pass any parameters, you'll need to set `Content-Length` to zero when calling out to this endpoint. For more information, see "[HTTP verbs](https://docs.github.com/rest/overview/resources-in-the-rest-api#http-verbs)."
            */
           permission?: "read" | "write" | "admin";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -28955,7 +28955,7 @@ export interface operations {
            * If no permission is specified, the team's `permission` attribute will be used to determine what permission to grant the team on this repository.
            */
           permission?: "pull" | "push" | "admin";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -29038,9 +29038,9 @@ export interface operations {
             id?: string;
             name?: string;
             description?: string;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           synced_at?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -29082,7 +29082,7 @@ export interface operations {
       200: {
         content: {
           "application/json": (components["schemas"]["private-user"] | components["schemas"]["public-user"]) & {
-            [key: string]: any;
+            [key: string]: unknown;
           };
         };
       };
@@ -29126,7 +29126,7 @@ export interface operations {
           hireable?: boolean;
           /** The new short biography of the user. */
           bio?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -29221,7 +29221,7 @@ export interface operations {
           email: string;
           /** Denotes whether an email is publically visible. */
           visibility: "public" | "private";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -29271,10 +29271,10 @@ export interface operations {
           | ({
               /** Adds one or more email addresses to your GitHub account. Must contain at least one email address. **Note:** Alternatively, you can pass a single email address or an `array` of emails addresses directly, but we recommend that you pass an object using the `emails` key. */
               emails: string[];
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | string[]
           | string
-        ) & { [key: string]: any };
+        ) & { [key: string]: unknown };
       };
     };
   };
@@ -29296,10 +29296,10 @@ export interface operations {
           | ({
               /** Email addresses associated with the GitHub user account. */
               emails: string[];
-            } & { [key: string]: any })
+            } & { [key: string]: unknown })
           | string[]
           | string
-        ) & { [key: string]: any };
+        ) & { [key: string]: unknown };
       };
     };
   };
@@ -29450,7 +29450,7 @@ export interface operations {
         "application/json": {
           /** A GPG key in ASCII-armored format. */
           armored_public_key: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -29519,7 +29519,7 @@ export interface operations {
           "application/json": {
             total_count: number;
             installations: components["schemas"]["installation"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -29559,7 +29559,7 @@ export interface operations {
             total_count: number;
             repository_selection?: string;
             repositories: components["schemas"]["repository"][];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       304: components["responses"]["not_modified"];
@@ -29739,7 +29739,7 @@ export interface operations {
           title?: string;
           /** The public SSH key to add to your GitHub account. */
           key: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -29890,7 +29890,7 @@ export interface operations {
         "application/json": {
           /** The state that the membership should be in. Only `"active"` will be accepted. */
           state: "active";
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -29942,7 +29942,7 @@ export interface operations {
           /** Exclude attributes from the API response to improve performance */
           exclude?: "repositories"[];
           repositories: string[];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -30308,7 +30308,7 @@ export interface operations {
           name: string;
           /** Body of the project */
           body?: string | null;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -30452,7 +30452,7 @@ export interface operations {
           has_downloads?: boolean;
           /** Whether this repository acts as a template that can be used to generate new repositories. */
           is_template?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -30691,7 +30691,7 @@ export interface operations {
       200: {
         content: {
           "application/json": (components["schemas"]["private-user"] | components["schemas"]["public-user"]) & {
-            [key: string]: any;
+            [key: string]: unknown;
           };
         };
       };

--- a/tests/v3/expected/github.immutable.ts
+++ b/tests/v3/expected/github.immutable.ts
@@ -5184,7 +5184,7 @@ export interface components {
       readonly client_secret?: string;
       readonly webhook_secret?: string;
       readonly pem?: string;
-    } & { readonly [key: string]: any };
+    } & { readonly [key: string]: unknown };
     /** Basic Error */
     readonly "basic-error": {
       readonly message?: string;
@@ -5745,15 +5745,15 @@ export interface components {
       /** The username of the account being blocked. */
       readonly blocked_user?: string;
       readonly business?: string;
-      readonly config?: readonly any[];
-      readonly config_was?: readonly any[];
+      readonly config?: readonly unknown[];
+      readonly config_was?: readonly unknown[];
       readonly content_type?: string;
       /** The time the audit log event was recorded, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time). */
       readonly created_at?: number;
       readonly deploy_key_fingerprint?: string;
       readonly emoji?: string;
-      readonly events?: readonly any[];
-      readonly events_were?: readonly any[];
+      readonly events?: readonly unknown[];
+      readonly events_were?: readonly unknown[];
       readonly explanation?: string;
       readonly fingerprint?: string;
       readonly hook_id?: number;
@@ -6019,8 +6019,8 @@ export interface components {
       readonly comments_url: string;
       readonly owner?: components["schemas"]["simple-user"] | null;
       readonly truncated?: boolean;
-      readonly forks?: readonly { readonly [key: string]: unknown }[];
-      readonly history?: readonly { readonly [key: string]: unknown }[];
+      readonly forks?: readonly unknown[];
+      readonly history?: readonly unknown[];
     };
     /** Gist Simple */
     readonly "gist-simple": {
@@ -6564,7 +6564,7 @@ export interface components {
       readonly updated_at: string;
       readonly node_id: string;
       readonly archive_url?: string;
-      readonly exclude?: readonly { readonly [key: string]: unknown }[];
+      readonly exclude?: readonly unknown[];
     };
     /** A software package */
     readonly package: {
@@ -6600,10 +6600,10 @@ export interface components {
       readonly metadata?: {
         readonly package_type: "npm" | "maven" | "rubygems" | "docker" | "nuget" | "container";
         readonly container?: {
-          readonly tags: readonly any[];
+          readonly tags: readonly unknown[];
         };
         readonly docker?: {
-          readonly tag?: readonly any[];
+          readonly tag?: readonly unknown[];
         } & {
           tags: unknown;
         };
@@ -9436,7 +9436,7 @@ export interface components {
       readonly operations?: readonly {
         readonly op: "add" | "remove" | "replace";
         readonly path?: string;
-        readonly value?: string | { readonly [key: string]: unknown } | readonly { readonly [key: string]: unknown }[];
+        readonly value?: string | { readonly [key: string]: unknown } | readonly unknown[];
       }[];
       /** associated groups */
       readonly groups?: readonly {
@@ -9859,8 +9859,8 @@ export interface components {
         readonly primary_key_id?: number;
         readonly key_id?: string;
         readonly public_key?: string;
-        readonly emails?: readonly { readonly [key: string]: unknown }[];
-        readonly subkeys?: readonly { readonly [key: string]: unknown }[];
+        readonly emails?: readonly unknown[];
+        readonly subkeys?: readonly unknown[];
         readonly can_sign?: boolean;
         readonly can_encrypt_comms?: boolean;
         readonly can_encrypt_storage?: boolean;
@@ -10346,7 +10346,7 @@ export interface operations {
               readonly client_secret: string;
               readonly webhook_secret: string;
               readonly pem: string;
-            } & { readonly [key: string]: any });
+            } & { readonly [key: string]: unknown });
         };
       };
       readonly 404: components["responses"]["not_found"];
@@ -19769,12 +19769,12 @@ export interface operations {
             readonly status?: "completed";
           } & {
             conclusion: unknown;
-          } & { readonly [key: string]: any }
+          } & { readonly [key: string]: unknown }
         > &
           Partial<
             {
               readonly status?: "queued" | "in_progress";
-            } & { readonly [key: string]: any }
+            } & { readonly [key: string]: unknown }
           >) & {
           /** The name of the check. For example, "code-coverage". */
           readonly name: string;
@@ -19907,12 +19907,12 @@ export interface operations {
             readonly status?: "completed";
           } & {
             conclusion: unknown;
-          } & { readonly [key: string]: any }
+          } & { readonly [key: string]: unknown }
         > &
           Partial<
             {
               readonly status?: "queued" | "in_progress";
-            } & { readonly [key: string]: any }
+            } & { readonly [key: string]: unknown }
           >) & {
           /** The name of the check. For example, "code-coverage". */
           readonly name?: string;
@@ -21700,7 +21700,7 @@ export interface operations {
           readonly auto_merge?: boolean;
           /** The [status](https://docs.github.com/rest/reference/repos#statuses) contexts to verify against commit status checks. If you omit this parameter, GitHub verifies all unique contexts before creating a deployment. To bypass checking entirely, pass an empty array. Defaults to all unique contexts. */
           readonly required_contexts?: readonly string[];
-          readonly payload?: { readonly [key: string]: any } | string;
+          readonly payload?: { readonly [key: string]: unknown } | string;
           /** Name for the target deployment environment (e.g., `production`, `staging`, `qa`). */
           readonly environment?: string;
           /** Short description of the deployment. */
@@ -21901,7 +21901,7 @@ export interface operations {
           /** A custom webhook event name. */
           readonly event_type: string;
           /** JSON payload with extra information about the webhook event that your action or worklow may use. */
-          readonly client_payload?: { readonly [key: string]: any };
+          readonly client_payload?: { readonly [key: string]: unknown };
         };
       };
     };

--- a/tests/v3/expected/github.ts
+++ b/tests/v3/expected/github.ts
@@ -5184,7 +5184,7 @@ export interface components {
       client_secret?: string;
       webhook_secret?: string;
       pem?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Basic Error */
     "basic-error": {
       message?: string;
@@ -5743,15 +5743,15 @@ export interface components {
       /** The username of the account being blocked. */
       blocked_user?: string;
       business?: string;
-      config?: any[];
-      config_was?: any[];
+      config?: unknown[];
+      config_was?: unknown[];
       content_type?: string;
       /** The time the audit log event was recorded, given as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time). */
       created_at?: number;
       deploy_key_fingerprint?: string;
       emoji?: string;
-      events?: any[];
-      events_were?: any[];
+      events?: unknown[];
+      events_were?: unknown[];
       explanation?: string;
       fingerprint?: string;
       hook_id?: number;
@@ -6017,8 +6017,8 @@ export interface components {
       comments_url: string;
       owner?: components["schemas"]["simple-user"] | null;
       truncated?: boolean;
-      forks?: { [key: string]: unknown }[];
-      history?: { [key: string]: unknown }[];
+      forks?: unknown[];
+      history?: unknown[];
     };
     /** Gist Simple */
     "gist-simple": {
@@ -6562,7 +6562,7 @@ export interface components {
       updated_at: string;
       node_id: string;
       archive_url?: string;
-      exclude?: { [key: string]: unknown }[];
+      exclude?: unknown[];
     };
     /** A software package */
     package: {
@@ -6598,10 +6598,10 @@ export interface components {
       metadata?: {
         package_type: "npm" | "maven" | "rubygems" | "docker" | "nuget" | "container";
         container?: {
-          tags: any[];
+          tags: unknown[];
         };
         docker?: {
-          tag?: any[];
+          tag?: unknown[];
         } & {
           tags: unknown;
         };
@@ -9432,7 +9432,7 @@ export interface components {
       operations?: {
         op: "add" | "remove" | "replace";
         path?: string;
-        value?: string | { [key: string]: unknown } | { [key: string]: unknown }[];
+        value?: string | { [key: string]: unknown } | unknown[];
       }[];
       /** associated groups */
       groups?: {
@@ -9855,8 +9855,8 @@ export interface components {
         primary_key_id?: number;
         key_id?: string;
         public_key?: string;
-        emails?: { [key: string]: unknown }[];
-        subkeys?: { [key: string]: unknown }[];
+        emails?: unknown[];
+        subkeys?: unknown[];
         can_sign?: boolean;
         can_encrypt_comms?: boolean;
         can_encrypt_storage?: boolean;
@@ -10342,7 +10342,7 @@ export interface operations {
               client_secret: string;
               webhook_secret: string;
               pem: string;
-            } & { [key: string]: any });
+            } & { [key: string]: unknown });
         };
       };
       404: components["responses"]["not_found"];
@@ -19765,12 +19765,12 @@ export interface operations {
             status?: "completed";
           } & {
             conclusion: unknown;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
           Partial<
             {
               status?: "queued" | "in_progress";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           >) & {
           /** The name of the check. For example, "code-coverage". */
           name: string;
@@ -19903,12 +19903,12 @@ export interface operations {
             status?: "completed";
           } & {
             conclusion: unknown;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
           Partial<
             {
               status?: "queued" | "in_progress";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           >) & {
           /** The name of the check. For example, "code-coverage". */
           name?: string;
@@ -21696,7 +21696,7 @@ export interface operations {
           auto_merge?: boolean;
           /** The [status](https://docs.github.com/rest/reference/repos#statuses) contexts to verify against commit status checks. If you omit this parameter, GitHub verifies all unique contexts before creating a deployment. To bypass checking entirely, pass an empty array. Defaults to all unique contexts. */
           required_contexts?: string[];
-          payload?: { [key: string]: any } | string;
+          payload?: { [key: string]: unknown } | string;
           /** Name for the target deployment environment (e.g., `production`, `staging`, `qa`). */
           environment?: string;
           /** Short description of the deployment. */
@@ -21897,7 +21897,7 @@ export interface operations {
           /** A custom webhook event name. */
           event_type: string;
           /** JSON payload with extra information about the webhook event that your action or worklow may use. */
-          client_payload?: { [key: string]: any };
+          client_payload?: { [key: string]: unknown };
         };
       };
     };

--- a/tests/v3/expected/manifold.additional.ts
+++ b/tests/v3/expected/manifold.additional.ts
@@ -684,19 +684,19 @@ export interface components {
       location: components["schemas"]["Location"];
       name: string;
       priority: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     Region: {
       id: components["schemas"]["ID"];
       type: "region";
       version: number;
       body: components["schemas"]["RegionBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     CreateRegion: {
       body: components["schemas"]["RegionBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     UpdateRegion: {
       name: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     ProviderBody: {
       owner_id?: components["schemas"]["OptionalFlexID"];
       team_id?: components["schemas"]["OptionalID"];
@@ -705,7 +705,7 @@ export interface components {
       logo_url?: components["schemas"]["LogoURL"];
       support_email?: string;
       documentation_url?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     UpdateProviderBody: {
       owner_id?: components["schemas"]["OptionalFlexID"];
       team_id?: components["schemas"]["OptionalID"];
@@ -714,24 +714,24 @@ export interface components {
       logo_url?: components["schemas"]["OptionalLogoURL"];
       support_email?: string | null;
       documentation_url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     Provider: {
       id: components["schemas"]["ID"];
       version: number;
       type: "provider";
       body: components["schemas"]["ProviderBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     CreateProvider: {
       body: components["schemas"]["ProviderBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     UpdateProvider: {
       id: components["schemas"]["ID"];
       body: components["schemas"]["UpdateProviderBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     UpdateProduct: {
       id: components["schemas"]["ID"];
       body: components["schemas"]["UpdateProductBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     UpdateProductBody: {
       name?: components["schemas"]["Name"];
       label?: components["schemas"]["Label"];
@@ -763,17 +763,17 @@ export interface components {
               sso?: boolean | null;
               plan_change?: boolean | null;
               credential?: ("none" | "single" | "multiple" | "unknown") | null;
-            } & { [key: string]: any };
-          } & { [key: string]: any })
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown })
         | null;
       /** An array of platform ids to restrict this product for. */
       platform_ids?: components["schemas"]["ID"][] | null;
       tags?: components["schemas"]["ProductTags"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     UpdatePlan: {
       id: components["schemas"]["ID"];
       body: components["schemas"]["UpdatePlanBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     UpdatePlanBody: {
       name?: components["schemas"]["Name"];
       label?: components["schemas"]["Label"];
@@ -793,7 +793,7 @@ export interface components {
       trial_days?: number | null;
       /** Dollar value in cents */
       cost?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A feature type represents the different aspects of a product that are
      * offered, these features can manifest differently depending on the plan.
@@ -822,7 +822,7 @@ export interface components {
        */
       measurable?: boolean;
       values?: components["schemas"]["FeatureValuesList"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A list of allowable values for the feature.
      * To define values for a boolean feature type, only `true` is required,
@@ -861,9 +861,9 @@ export interface components {
         formula?: components["schemas"]["PriceFormula"];
         /** Description explains how a feature is calculated to the user. */
         description?: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       numeric_details?: components["schemas"]["FeatureNumericDetails"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Optional container for additional details relating to numeric features.
      * This is required if the feature is measurable and numeric.
@@ -886,7 +886,7 @@ export interface components {
           /** Applied to the end of the number for display, for example the ‘GB’ in ‘20 GB’. */
           suffix?: string | null;
           cost_ranges?: components["schemas"]["FeatureNumericRange"][] | null;
-        } & { [key: string]: any })
+        } & { [key: string]: unknown })
       | null;
     FeatureNumericRange: {
       /**
@@ -901,17 +901,17 @@ export interface components {
        * numeric value set in the feature to determine the cost.
        */
       cost_multiple?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     FeatureValue: {
       feature: components["schemas"]["Label"];
       value: components["schemas"]["FeatureValueLabel"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     ValueProp: {
       /** Heading of a value proposition. */
       header: string;
       /** Body of a value proposition. */
       body: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Image URL used for Product listings.
      *
@@ -960,8 +960,8 @@ export interface components {
          * product, it is just used to inform consumers through our clients.
          */
         featured?: boolean;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /**
      * Provider Only, implies that the product should only be provisionable by the
      *   provider; so members of the provider team, no one else should be allowed.
@@ -1001,7 +1001,7 @@ export interface components {
        * * `unknown`: The credential type is unknown.
        */
       credential?: "none" | "single" | "multiple" | "unknown";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     ProductBody: {
       provider_id: components["schemas"]["ID"];
       label: components["schemas"]["Label"];
@@ -1025,30 +1025,30 @@ export interface components {
       terms: {
         url?: string | null;
         provided: boolean;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       feature_types: components["schemas"]["FeatureType"][];
       billing: {
         type: "monthly-prorated" | "monthly-anniversary" | "annual-anniversary";
         currency: "usd";
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       integration: {
         provisioning: components["schemas"]["ProductProvisioning"];
         base_url: string;
         sso_url?: string | null;
         version: "v1";
         features: components["schemas"]["ProductIntegrationFeatures"];
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       tags?: components["schemas"]["ProductTags"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     Product: {
       id: components["schemas"]["ID"];
       version: number;
       type: "product";
       body: components["schemas"]["ProductBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     CreateProduct: {
       body: components["schemas"]["ProductBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Array of Plan IDs that this Plan can be resized to, if null all will be assumed */
     PlanResizeList: components["schemas"]["ID"][] | null;
     PlanBody: {
@@ -1070,7 +1070,7 @@ export interface components {
       trial_days?: number;
       /** Dollar value in cents. */
       cost: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     PlanState: "hidden" | "available" | "grandfathered" | "unlisted";
     ExpandedPlanBody: components["schemas"]["PlanBody"] &
       ({
@@ -1082,35 +1082,35 @@ export interface components {
         defaultCost?: number;
         /** A boolean flag that indicates if a plan has customizable features. */
         customizable?: boolean;
-      } & { [key: string]: any }) & { [key: string]: any };
+      } & { [key: string]: unknown }) & { [key: string]: unknown };
     ExpandedFeature: components["schemas"]["FeatureType"] &
       ({
         /** The string value set for the feature on the plan, this should only be used if the value property is null. */
         value_string: string;
         value: components["schemas"]["FeatureValueDetails"];
-      } & { [key: string]: any }) & { [key: string]: any };
+      } & { [key: string]: unknown }) & { [key: string]: unknown };
     Plan: {
       id: components["schemas"]["ID"];
       version: number;
       type: "plan";
       body: components["schemas"]["PlanBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     ExpandedPlan: {
       id: components["schemas"]["ID"];
       version: number;
       type: "plan";
       body: components["schemas"]["ExpandedPlanBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     CreatePlan: {
       body: components["schemas"]["PlanBody"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Unexpected error */
     Error: {
       /** The error type */
       type: string;
       /** Explanation of the errors */
       message: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Describes how a feature cost should be calculated. An empty
      * string defaults to the normal price calculation using the value cost.
@@ -1142,7 +1142,7 @@ export interface components {
       body: components["schemas"]["ProductBody"];
       plans?: components["schemas"]["ExpandedPlan"][];
       provider: components["schemas"]["Provider"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
   };
   parameters: {
     /** Filter results to only include those that have this label. */

--- a/tests/v3/expected/null-in-enum.additional.ts
+++ b/tests/v3/expected/null-in-enum.additional.ts
@@ -19,19 +19,19 @@ export interface components {
     /** Enum with null and nullable */
     MyType: {
       myField?: ("foo" | "bar") | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Enum with null */
     MyTypeNotNullable: {
       myField?: "foo" | "bar" | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Enum with null */
     MyTypeNotNullableNotNull: {
       myField?: "foo" | "bar";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Enum with null */
     MyTypeMixed: {
       myField?: "foo" | 2 | false | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
   };
 }
 

--- a/tests/v3/expected/petstore-openapitools.additional.ts
+++ b/tests/v3/expected/petstore-openapitools.additional.ts
@@ -74,12 +74,12 @@ export interface components {
       /** Order Status */
       status?: "placed" | "approved" | "delivered";
       complete?: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A category for a pet */
     Category: {
       id?: number;
       name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A User who is purchasing from the pet store */
     User: {
       id?: number;
@@ -91,12 +91,12 @@ export interface components {
       phone?: string;
       /** User Status */
       userStatus?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A tag for a pet */
     Tag: {
       id?: number;
       name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A pet for sale in the pet store */
     Pet: {
       id?: number;
@@ -106,13 +106,13 @@ export interface components {
       tags?: components["schemas"]["Tag"][];
       /** pet status in the store */
       status?: "available" | "pending" | "sold";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** Describes the result of uploading an image resource */
     ApiResponse: {
       code?: number;
       type?: string;
       message?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
   };
   requestBodies: {
     /** List of user object */
@@ -244,7 +244,7 @@ export interface operations {
           name?: string;
           /** Updated status of the pet */
           status?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -285,7 +285,7 @@ export interface operations {
           additionalMetadata?: string;
           /** file to upload */
           file?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };

--- a/tests/v3/expected/petstore.additional.ts
+++ b/tests/v3/expected/petstore.additional.ts
@@ -73,11 +73,11 @@ export interface components {
       /** Order Status */
       status?: "placed" | "approved" | "delivered";
       complete?: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     Category: {
       id?: number;
       name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     User: {
       id?: number;
       username?: string;
@@ -88,11 +88,11 @@ export interface components {
       phone?: string;
       /** User Status */
       userStatus?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     Tag: {
       id?: number;
       name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     Pet: {
       id?: number;
       category?: components["schemas"]["Category"];
@@ -101,12 +101,12 @@ export interface components {
       tags?: components["schemas"]["Tag"][];
       /** pet status in the store */
       status?: "available" | "pending" | "sold";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     ApiResponse: {
       code?: number;
       type?: string;
       message?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
   };
 }
 
@@ -221,7 +221,7 @@ export interface operations {
           name?: string;
           /** Updated status of the pet */
           status?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };
@@ -264,7 +264,7 @@ export interface operations {
           additionalMetadata?: string;
           /** file to upload */
           file?: string;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };

--- a/tests/v3/expected/reference-to-properties.additional.ts
+++ b/tests/v3/expected/reference-to-properties.additional.ts
@@ -13,7 +13,7 @@ export interface components {
   schemas: {
     Pet: {
       name: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
   };
 }
 
@@ -26,7 +26,7 @@ export interface operations {
       content: {
         "application/json": {
           name?: components["schemas"]["Pet"]["name"];
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
       };
     };
   };

--- a/tests/v3/expected/stripe.additional.ts
+++ b/tests/v3/expected/stripe.additional.ts
@@ -1492,7 +1492,9 @@ export interface components {
      */
     account: {
       /** Business information about the account. */
-      business_profile?: (Partial<components["schemas"]["account_business_profile"]> & { [key: string]: any }) | null;
+      business_profile?:
+        | (Partial<components["schemas"]["account_business_profile"]> & { [key: string]: unknown })
+        | null;
       /** The business type. */
       business_type?: ("company" | "government_entity" | "individual" | "non_profit") | null;
       capabilities?: components["schemas"]["account_capabilities"];
@@ -1513,7 +1515,7 @@ export interface components {
       external_accounts?: {
         /** The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards. */
         data: ((Partial<components["schemas"]["bank_account"]> & Partial<components["schemas"]["card"]>) & {
-          [key: string]: any;
+          [key: string]: unknown;
         })[];
         /** True if this list has another page of items after this one that can be fetched. */
         has_more: boolean;
@@ -1521,7 +1523,7 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** Unique identifier for the object. */
       id: string;
       individual?: components["schemas"]["person"];
@@ -1533,21 +1535,21 @@ export interface components {
       payouts_enabled?: boolean;
       requirements?: components["schemas"]["account_requirements"];
       /** Options for customizing how the account functions within Stripe. */
-      settings?: (Partial<components["schemas"]["account_settings"]> & { [key: string]: any }) | null;
+      settings?: (Partial<components["schemas"]["account_settings"]> & { [key: string]: unknown }) | null;
       tos_acceptance?: components["schemas"]["account_tos_acceptance"];
       /** The Stripe account type. Can be `standard`, `express`, or `custom`. */
       type?: "custom" | "express" | "standard";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_branding_settings: {
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) An icon for the account. Must be square and at least 128px x 128px. */
-      icon?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      icon?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) A logo for the account that will be used in Checkout instead of the icon and without the account's name next to it if provided. Must be at least 128px x 128px. */
-      logo?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      logo?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
       /** A CSS hex color value representing the primary branding color for this account */
       primary_color?: string | null;
       /** A CSS hex color value representing the secondary branding color for this account */
       secondary_color?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_business_profile: {
       /** [The merchant category code for the account](https://stripe.com/docs/connect/setting-mcc). MCCs are used to classify businesses based on the goods or services they provide. */
       mcc?: string | null;
@@ -1556,7 +1558,7 @@ export interface components {
       /** Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes. */
       product_description?: string | null;
       /** A publicly available mailing address for sending support issues to. */
-      support_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      support_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** A publicly available email address for sending support issues to. */
       support_email?: string | null;
       /** A publicly available phone number to call with support issues. */
@@ -1565,7 +1567,7 @@ export interface components {
       support_url?: string | null;
       /** The business's publicly available website. */
       url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_capabilities: {
       /** The status of the BECS Direct Debit (AU) payments capability of the account, or whether the account can directly process BECS Direct Debit (AU) charges. */
       au_becs_debit_payments?: "active" | "inactive" | "pending";
@@ -1581,7 +1583,7 @@ export interface components {
       tax_reporting_us_1099_misc?: "active" | "inactive" | "pending";
       /** The status of the transfers capability of the account, or whether your platform can transfer funds to the account. */
       transfers?: "active" | "inactive" | "pending";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_capability_requirements: {
       /** The date the fields in `currently_due` must be collected by to keep the capability enabled for the account. */
       current_deadline?: number | null;
@@ -1597,24 +1599,24 @@ export interface components {
       past_due: string[];
       /** Fields that may become required depending on the results of verification or review. An empty array unless an asynchronous verification is pending. If verification fails, the fields in this array become required and move to `currently_due` or `past_due`. */
       pending_verification: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_card_payments_settings: {
       decline_on?: components["schemas"]["account_decline_charge_on"];
       /** The default text that appears on credit card statements when a charge is made. This field prefixes any dynamic `statement_descriptor` specified on the charge. `statement_descriptor_prefix` is useful for maximizing descriptor space for the dynamic portion. */
       statement_descriptor_prefix?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_dashboard_settings: {
       /** The display name for this account. This is used on the Stripe Dashboard to differentiate between accounts. */
       display_name?: string | null;
       /** The timezone used in the Stripe Dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones). */
       timezone?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_decline_charge_on: {
       /** Whether Stripe automatically declines charges with an incorrect ZIP or postal code. This setting only applies when a ZIP or postal code is provided and they fail bank verification. */
       avs_failure: boolean;
       /** Whether Stripe automatically declines charges with an incorrect CVC. This setting only applies when a CVC is provided and it fails bank verification. */
       cvc_failure: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Account Links are the means by which a Connect platform grants a connected account permission to access
      * Stripe-hosted applications, such as Connect Onboarding.
@@ -1630,7 +1632,7 @@ export interface components {
       object: "account_link";
       /** The URL for the account link. */
       url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_payments_settings: {
       /** The default text that appears on credit card statements when a charge is made. This field prefixes any dynamic `statement_descriptor` specified on the charge. */
       statement_descriptor?: string | null;
@@ -1638,14 +1640,14 @@ export interface components {
       statement_descriptor_kana?: string | null;
       /** The Kanji variation of the default text that appears on credit card statements when a charge is made (Japan only) */
       statement_descriptor_kanji?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_payout_settings: {
       /** A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](https://stripe.com/docs/connect/account-balances) documentation for details. Default value is `true` for Express accounts and `false` for Custom accounts. */
       debit_negative_balances: boolean;
       schedule: components["schemas"]["transfer_schedule"];
       /** The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard. */
       statement_descriptor?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_requirements: {
       /** The date the fields in `currently_due` must be collected by to keep payouts enabled for the account. These fields might block payouts sooner if the next threshold is reached before these fields are collected. */
       current_deadline?: number | null;
@@ -1661,7 +1663,7 @@ export interface components {
       past_due?: string[] | null;
       /** Fields that may become required depending on the results of verification or review. An empty array unless an asynchronous verification is pending. If verification fails, the fields in this array become required and move to `currently_due` or `past_due`. */
       pending_verification?: string[] | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_requirements_error: {
       /** The code for the type of error. */
       code:
@@ -1707,14 +1709,14 @@ export interface components {
       reason: string;
       /** The specific user onboarding requirement field (in the requirements hash) that needs to be resolved. */
       requirement: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_settings: {
       branding: components["schemas"]["account_branding_settings"];
       card_payments: components["schemas"]["account_card_payments_settings"];
       dashboard: components["schemas"]["account_dashboard_settings"];
       payments: components["schemas"]["account_payments_settings"];
       payouts?: components["schemas"]["account_payout_settings"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     account_tos_acceptance: {
       /** The Unix timestamp marking when the Stripe Services Agreement was accepted by the account representative */
       date?: number | null;
@@ -1722,7 +1724,7 @@ export interface components {
       ip?: string | null;
       /** The user agent of the browser from which the Stripe Services Agreement was accepted by the account representative */
       user_agent?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     address: {
       /** City, district, suburb, town, or village. */
       city?: string | null;
@@ -1736,7 +1738,7 @@ export interface components {
       postal_code?: string | null;
       /** State, county, province, or region. */
       state?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     alipay_account: {
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -1744,7 +1746,7 @@ export interface components {
       customer?:
         | ((Partial<string> &
             Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown })
         | null;
       /** Uniquely identifies the account and will be the same across all Alipay account objects that are linked to the same Alipay account. */
       fingerprint: string;
@@ -1766,7 +1768,7 @@ export interface components {
       used: boolean;
       /** The username for the Alipay account. */
       username: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     api_errors: {
       /** For card errors, the ID of the failed charge. */
       charge?: string;
@@ -1786,7 +1788,7 @@ export interface components {
       /** The source object for errors returned on a request involving a source. */
       source?: (Partial<components["schemas"]["bank_account"]> &
         Partial<components["schemas"]["card"]> &
-        Partial<components["schemas"]["source"]>) & { [key: string]: any };
+        Partial<components["schemas"]["source"]>) & { [key: string]: unknown };
       /** The type of error returned. One of `api_connection_error`, `api_error`, `authentication_error`, `card_error`, `idempotency_error`, `invalid_request_error`, or `rate_limit_error` */
       type:
         | "api_connection_error"
@@ -1796,7 +1798,7 @@ export interface components {
         | "idempotency_error"
         | "invalid_request_error"
         | "rate_limit_error";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     apple_pay_domain: {
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -1807,7 +1809,7 @@ export interface components {
       livemode: boolean;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "apple_pay_domain";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     application: {
       /** Unique identifier for the object. */
       id: string;
@@ -1815,22 +1817,22 @@ export interface components {
       name?: string | null;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "application";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     application_fee: {
       /** ID of the Stripe account this fee was taken from. */
-      account: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any };
+      account: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown };
       /** Amount earned, in %s. */
       amount: number;
       /** Amount in %s refunded (can be less than the amount attribute on the fee if a partial refund was issued) */
       amount_refunded: number;
       /** ID of the Connect application that earned the fee. */
-      application: (Partial<string> & Partial<components["schemas"]["application"]>) & { [key: string]: any };
+      application: (Partial<string> & Partial<components["schemas"]["application"]>) & { [key: string]: unknown };
       /** Balance transaction that describes the impact of this collected application fee on your account balance (not including refunds). */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** ID of the charge that the application fee was taken from. */
-      charge: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any };
+      charge: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown };
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -1843,7 +1845,7 @@ export interface components {
       object: "application_fee";
       /** ID of the corresponding charge on the platform account, if this fee was the result of a charge using the `destination` parameter. */
       originating_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown })
         | null;
       /** Whether the fee has been fully refunded. If the fee is only partially refunded, this attribute will still be false. */
       refunded: boolean;
@@ -1857,8 +1859,8 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /**
      * This is an object representing your Stripe balance. You can retrieve it to see
      * the balance currently on your Stripe account.
@@ -1883,14 +1885,14 @@ export interface components {
       object: "balance";
       /** Funds that are not yet available in the balance, due to the 7-day rolling pay cycle. The pending balance for each currency, and for each payment type, can be found in the `source_types` property. */
       pending: components["schemas"]["balance_amount"][];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     balance_amount: {
       /** Balance amount. */
       amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       source_types?: components["schemas"]["balance_amount_by_source_type"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     balance_amount_by_source_type: {
       /** Amount for bank account. */
       bank_account?: number;
@@ -1898,7 +1900,7 @@ export interface components {
       card?: number;
       /** Amount for FPX. */
       fpx?: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Balance transactions represent funds moving through your Stripe account.
      * They're created for every type of transaction that comes into or flows out of your Stripe account balance.
@@ -1947,7 +1949,7 @@ export interface components {
             Partial<components["schemas"]["tax_deducted_at_source"]> &
             Partial<components["schemas"]["topup"]> &
             Partial<components["schemas"]["transfer"]> &
-            Partial<components["schemas"]["transfer_reversal"]>) & { [key: string]: any })
+            Partial<components["schemas"]["transfer_reversal"]>) & { [key: string]: unknown })
         | null;
       /** If the transaction's net funds are available in the Stripe balance yet. Either `available` or `pending`. */
       status: string;
@@ -1982,7 +1984,7 @@ export interface components {
         | "transfer_cancel"
         | "transfer_failure"
         | "transfer_refund";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * These bank accounts are payment methods on `Customer` objects.
      *
@@ -1994,7 +1996,7 @@ export interface components {
      */
     bank_account: {
       /** The ID of the account that the bank account is associated with. */
-      account?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any }) | null;
+      account?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown }) | null;
       /** The name of the person or business that owns the bank account. */
       account_holder_name?: string | null;
       /** The type of entity that holds the account. This can be either `individual` or `company`. */
@@ -2009,7 +2011,7 @@ export interface components {
       customer?:
         | ((Partial<string> &
             Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown })
         | null;
       /** Whether this bank account is the default external account for its currency. */
       default_for_currency?: boolean | null;
@@ -2031,17 +2033,17 @@ export interface components {
        * For external accounts, possible values are `new` and `errored`. Validations aren't run against external accounts because they're only used for payouts. This means the other statuses don't apply. If a transfer fails, the status is set to `errored` and transfers are stopped until account details are updated.
        */
       status: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     billing_details: {
       /** Billing address. */
-      address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** Email address. */
       email?: string | null;
       /** Full name. */
       name?: string | null;
       /** Billing phone number (including extension). */
       phone?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A Session describes the instantiation of the Self-serve Portal for
      * a particular customer. By visiting the Self-serve Portal's URL, the customer
@@ -2066,7 +2068,7 @@ export interface components {
       return_url: string;
       /** The short-lived URL of the session giving customers access to the self-serve portal. */
       url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     bitcoin_receiver: {
       /** True when this bitcoin receiver has received a non-zero amount of bitcoin. */
       active: boolean;
@@ -2116,12 +2118,12 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** This receiver contains uncaptured funds that can be used for a payment or refunded. */
       uncaptured_funds: boolean;
       /** Indicate if this source is used for payment. */
       used_for_payment?: boolean | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     bitcoin_transaction: {
       /** The amount of `currency` that the transaction was converted to in real-time. */
       amount: number;
@@ -2137,7 +2139,7 @@ export interface components {
       object: "bitcoin_transaction";
       /** The receiver to which this transaction was sent. */
       receiver: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * This is an object representing a capability for a Stripe account.
      *
@@ -2145,7 +2147,7 @@ export interface components {
      */
     capability: {
       /** The account for which the capability enables functionality. */
-      account: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any };
+      account: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown };
       /** The identifier for the capability. */
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
@@ -2157,7 +2159,7 @@ export interface components {
       requirements?: components["schemas"]["account_capability_requirements"];
       /** The status of the capability. Can be `active`, `inactive`, `pending`, or `unrequested`. */
       status: "active" | "disabled" | "inactive" | "pending" | "unrequested";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * You can store multiple cards on a customer in order to charge the customer
      * later. You can also store multiple debit cards on a recipient in order to
@@ -2167,7 +2169,7 @@ export interface components {
      */
     card: {
       /** The account this card belongs to. This attribute will not be in the card object if the card belongs to a customer or recipient instead. */
-      account?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any }) | null;
+      account?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown }) | null;
       /** City/District/Suburb/Town/Village. */
       address_city?: string | null;
       /** Billing address country, if provided when creating card. */
@@ -2195,7 +2197,7 @@ export interface components {
       customer?:
         | ((Partial<string> &
             Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown })
         | null;
       /** If a CVC was provided, results of the check: `pass`, `fail`, `unavailable`, or `unchecked`. */
       cvc_check?: string | null;
@@ -2222,10 +2224,10 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "card";
       /** The recipient that this card belongs to. This attribute will not be in the card object if the card belongs to a customer or account instead. */
-      recipient?: ((Partial<string> & Partial<components["schemas"]["recipient"]>) & { [key: string]: any }) | null;
+      recipient?: ((Partial<string> & Partial<components["schemas"]["recipient"]>) & { [key: string]: unknown }) | null;
       /** If the card number is tokenized, this is the method that was used. Can be `amex_express_checkout`, `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null. */
       tokenization_method?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     card_mandate_payment_method_details: { [key: string]: unknown };
     /**
      * To charge a credit or a debit card, you create a `Charge` object. You can
@@ -2240,16 +2242,18 @@ export interface components {
       /** Amount in %s refunded (can be less than the amount attribute on the charge if a partial refund was issued). */
       amount_refunded: number;
       /** ID of the Connect application that created the charge. */
-      application?: ((Partial<string> & Partial<components["schemas"]["application"]>) & { [key: string]: any }) | null;
+      application?:
+        | ((Partial<string> & Partial<components["schemas"]["application"]>) & { [key: string]: unknown })
+        | null;
       /** The application fee (if any) for the charge. [See the Connect documentation](https://stripe.com/docs/connect/direct-charges#collecting-fees) for details. */
       application_fee?:
-        | ((Partial<string> & Partial<components["schemas"]["application_fee"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["application_fee"]>) & { [key: string]: unknown })
         | null;
       /** The amount of the application fee (if any) for the charge. [See the Connect documentation](https://stripe.com/docs/connect/direct-charges#collecting-fees) for details. */
       application_fee_amount?: number | null;
       /** ID of the balance transaction that describes the impact of this charge on your account balance (not including refunds or disputes). */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       billing_details: components["schemas"]["billing_details"];
       /** The full statement descriptor that is passed to card networks, and that is displayed on your customers' credit card and bank statements. Allows you to see what the statement descriptor looks like after the static and dynamic portions are combined. */
@@ -2264,7 +2268,7 @@ export interface components {
       customer?:
         | ((Partial<string> &
             Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown })
         | null;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
       description?: string | null;
@@ -2275,11 +2279,11 @@ export interface components {
       /** Message to user further explaining reason for charge failure if available. */
       failure_message?: string | null;
       /** Information on fraud assessments for the charge. */
-      fraud_details?: (Partial<components["schemas"]["charge_fraud_details"]> & { [key: string]: any }) | null;
+      fraud_details?: (Partial<components["schemas"]["charge_fraud_details"]> & { [key: string]: unknown }) | null;
       /** Unique identifier for the object. */
       id: string;
       /** ID of the invoice this charge is for if one exists. */
-      invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: any }) | null;
+      invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: unknown }) | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
@@ -2287,22 +2291,24 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "charge";
       /** The account (if any) the charge was made on behalf of without triggering an automatic transfer. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers) for details. */
-      on_behalf_of?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any }) | null;
+      on_behalf_of?:
+        | ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown })
+        | null;
       /** ID of the order this charge is for if one exists. */
-      order?: ((Partial<string> & Partial<components["schemas"]["order"]>) & { [key: string]: any }) | null;
+      order?: ((Partial<string> & Partial<components["schemas"]["order"]>) & { [key: string]: unknown }) | null;
       /** Details about whether the payment was accepted, and why. See [understanding declines](https://stripe.com/docs/declines) for details. */
-      outcome?: (Partial<components["schemas"]["charge_outcome"]> & { [key: string]: any }) | null;
+      outcome?: (Partial<components["schemas"]["charge_outcome"]> & { [key: string]: unknown }) | null;
       /** `true` if the charge succeeded, or was successfully authorized for later capture. */
       paid: boolean;
       /** ID of the PaymentIntent associated with this charge, if one exists. */
       payment_intent?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: unknown })
         | null;
       /** ID of the payment method used in this charge. */
       payment_method?: string | null;
       /** Details about the payment method at the time of the transaction. */
       payment_method_details?:
-        | (Partial<components["schemas"]["payment_method_details"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_method_details"]> & { [key: string]: unknown })
         | null;
       /** This is the email address that the receipt for this charge was sent to. */
       receipt_email?: string | null;
@@ -2322,14 +2328,14 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** ID of the review associated with this charge if one exists. */
-      review?: ((Partial<string> & Partial<components["schemas"]["review"]>) & { [key: string]: any }) | null;
+      review?: ((Partial<string> & Partial<components["schemas"]["review"]>) & { [key: string]: unknown }) | null;
       /** Shipping information for the charge. */
-      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: any }) | null;
+      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: unknown }) | null;
       /** The transfer ID which created this charge. Only present if the charge came from another Stripe account. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details. */
       source_transfer?:
-        | ((Partial<string> & Partial<components["schemas"]["transfer"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["transfer"]>) & { [key: string]: unknown })
         | null;
       /** For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this value as the complete description of a charge on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
       statement_descriptor?: string | null;
@@ -2338,18 +2344,18 @@ export interface components {
       /** The status of the payment is either `succeeded`, `pending`, or `failed`. */
       status: string;
       /** ID of the transfer to the `destination` account (only applicable if the charge was created using the `destination` parameter). */
-      transfer?: (Partial<string> & Partial<components["schemas"]["transfer"]>) & { [key: string]: any };
+      transfer?: (Partial<string> & Partial<components["schemas"]["transfer"]>) & { [key: string]: unknown };
       /** An optional dictionary including the account to automatically transfer to as part of a destination charge. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details. */
-      transfer_data?: (Partial<components["schemas"]["charge_transfer_data"]> & { [key: string]: any }) | null;
+      transfer_data?: (Partial<components["schemas"]["charge_transfer_data"]> & { [key: string]: unknown }) | null;
       /** A string that identifies this transaction as part of a group. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details. */
       transfer_group?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     charge_fraud_details: {
       /** Assessments from Stripe. If set, the value is `fraudulent`. */
       stripe_report?: string;
       /** Assessments reported by you. If set, possible values of are `safe` and `fraudulent`. */
       user_report?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     charge_outcome: {
       /** Possible values are `approved_by_network`, `declined_by_network`, `not_sent_to_network`, and `reversed_after_approval`. The value `reversed_after_approval` indicates the payment was [blocked by Stripe](https://stripe.com/docs/declines#blocked-payments) after bank authorization, and may temporarily appear as "pending" on a cardholder's statement. */
       network_status?: string | null;
@@ -2360,18 +2366,18 @@ export interface components {
       /** Stripe's evaluation of the riskiness of the payment. Possible values for evaluated payments are between 0 and 100. For non-card payments, card-based payments predating the public assignment of risk scores, or in the event of an error during evaluation, this field will not be present. This field is only available with Radar for Fraud Teams. */
       risk_score?: number;
       /** The ID of the Radar rule that matched the payment, if applicable. */
-      rule?: (Partial<string> & Partial<components["schemas"]["rule"]>) & { [key: string]: any };
+      rule?: (Partial<string> & Partial<components["schemas"]["rule"]>) & { [key: string]: unknown };
       /** A human-readable description of the outcome type and reason, designed for you (the recipient of the payment), not your customer. */
       seller_message?: string | null;
       /** Possible values are `authorized`, `manual_review`, `issuer_declined`, `blocked`, and `invalid`. See [understanding declines](https://stripe.com/docs/declines) and [Radar reviews](https://stripe.com/docs/radar/reviews) for details. */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     charge_transfer_data: {
       /** The amount transferred to the destination account, if specified. By default, the entire charge amount is transferred to the destination account. */
       amount?: number | null;
       /** ID of an existing, connected Stripe account to transfer funds to if `transfer_data` was specified in the charge request. */
-      destination: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any };
-    } & { [key: string]: any };
+      destination: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /**
      * A Checkout Session represents your customer's session as they pay for
      * one-time purchases or subscriptions through [Checkout](https://stripe.com/docs/payments/checkout).
@@ -2408,7 +2414,7 @@ export interface components {
        * during the session unless an existing customer was provided when
        * the session was created.
        */
-      customer?: ((Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: any }) | null;
+      customer?: ((Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: unknown }) | null;
       /**
        * If provided, this value will be used when the Customer object is created.
        * If not provided, customers will be asked to enter their email address.
@@ -2456,7 +2462,7 @@ export interface components {
       object: "checkout.session";
       /** The ID of the PaymentIntent for Checkout Sessions in `payment` mode. */
       payment_intent?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: unknown })
         | null;
       /**
        * A list of the types of payment methods (e.g. card) this Checkout
@@ -2465,14 +2471,14 @@ export interface components {
       payment_method_types: string[];
       /** The ID of the SetupIntent for Checkout Sessions in `setup` mode. */
       setup_intent?:
-        | ((Partial<string> & Partial<components["schemas"]["setup_intent"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["setup_intent"]>) & { [key: string]: unknown })
         | null;
       /** Shipping information for this Checkout Session. */
-      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: any }) | null;
+      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: unknown }) | null;
       /** When set, provides configuration for Checkout to collect a shipping address from a customer. */
       shipping_address_collection?:
         | (Partial<components["schemas"]["payment_pages_payment_page_resources_shipping_address_collection"]> & {
-            [key: string]: any;
+            [key: string]: unknown;
           })
         | null;
       /**
@@ -2484,14 +2490,14 @@ export interface components {
       submit_type?: ("auto" | "book" | "donate" | "pay") | null;
       /** The ID of the subscription for Checkout Sessions in `subscription` mode. */
       subscription?:
-        | ((Partial<string> & Partial<components["schemas"]["subscription"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["subscription"]>) & { [key: string]: unknown })
         | null;
       /**
        * The URL the customer will be directed to after the payment or
        * subscription creation is successful.
        */
       success_url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     checkout_session_custom_display_item_description: {
       /** The description of the line item. */
       description?: string | null;
@@ -2499,7 +2505,7 @@ export interface components {
       images?: string[] | null;
       /** The name of the line item. */
       name: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     checkout_session_display_item: {
       /** Amount for the display item. */
       amount?: number;
@@ -2512,21 +2518,21 @@ export interface components {
       sku?: components["schemas"]["sku"];
       /** The type of display item. One of `custom`, `plan` or `sku` */
       type?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     connect_collection_transfer: {
       /** Amount transferred, in %s. */
       amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** ID of the account that funds are being collected for. */
-      destination: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any };
+      destination: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown };
       /** Unique identifier for the object. */
       id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "connect_collection_transfer";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Stripe needs to collect certain pieces of information about each account
      * created. These requirements can differ depending on the account's country. The
@@ -2551,17 +2557,17 @@ export interface components {
       /** Countries that can accept transfers from the specified country. */
       supported_transfer_countries: string[];
       verification_fields: components["schemas"]["country_spec_verification_fields"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     country_spec_verification_field_details: {
       /** Additional fields which are only required for some users. */
       additional: string[];
       /** Fields which every account must eventually provide. */
       minimum: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     country_spec_verification_fields: {
       company: components["schemas"]["country_spec_verification_field_details"];
       individual: components["schemas"]["country_spec_verification_field_details"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A coupon contains information about a percent-off or amount-off discount you
      * might want to apply to a customer. Coupons may be applied to [invoices](https://stripe.com/docs/api#invoices) or
@@ -2598,7 +2604,7 @@ export interface components {
       times_redeemed: number;
       /** Taking account of the above properties, whether this coupon can still be applied to a customer. */
       valid: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Issue a credit note to adjust an invoice's amount after the invoice is finalized.
      *
@@ -2612,17 +2618,19 @@ export interface components {
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** ID of the customer. */
-      customer: (Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: any };
+      customer: (Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: unknown };
       /** Customer balance transaction related to this credit note. */
       customer_balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["customer_balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["customer_balance_transaction"]>) & {
+            [key: string]: unknown;
+          })
         | null;
       /** The integer amount in **%s** representing the amount of the discount that was credited. */
       discount_amount: number;
       /** Unique identifier for the object. */
       id: string;
       /** ID of the invoice. */
-      invoice: (Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: any };
+      invoice: (Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: unknown };
       /** Line items that make up the credit note */
       lines: {
         /** Details about each object. */
@@ -2633,7 +2641,7 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Customer-facing text that appears on the credit note PDF. */
@@ -2651,7 +2659,7 @@ export interface components {
       /** Reason for issuing this credit note, one of `duplicate`, `fraudulent`, `order_change`, or `product_unsatisfactory` */
       reason?: ("duplicate" | "fraudulent" | "order_change" | "product_unsatisfactory") | null;
       /** Refund related to this credit note. */
-      refund?: ((Partial<string> & Partial<components["schemas"]["refund"]>) & { [key: string]: any }) | null;
+      refund?: ((Partial<string> & Partial<components["schemas"]["refund"]>) & { [key: string]: unknown }) | null;
       /** Status of this credit note, one of `issued` or `void`. Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding). */
       status: "issued" | "void";
       /** The integer amount in **%s** representing the amount of the credit note, excluding tax and discount. */
@@ -2664,7 +2672,7 @@ export interface components {
       type: "post_payment" | "pre_payment";
       /** The time that the credit note was voided. */
       voided_at?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     credit_note_line_item: {
       /** The integer amount in **%s** representing the gross amount being credited for this line item, excluding (exclusive) tax and discounts. */
       amount: number;
@@ -2692,15 +2700,15 @@ export interface components {
       unit_amount?: number | null;
       /** Same as `unit_amount`, but contains a decimal value with at most 12 decimal places. */
       unit_amount_decimal?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     credit_note_tax_amount: {
       /** The amount, in %s, of the tax. */
       amount: number;
       /** Whether this tax amount is inclusive or exclusive. */
       inclusive: boolean;
       /** The tax rate that was applied to get this tax amount. */
-      tax_rate: (Partial<string> & Partial<components["schemas"]["tax_rate"]>) & { [key: string]: any };
-    } & { [key: string]: any };
+      tax_rate: (Partial<string> & Partial<components["schemas"]["tax_rate"]>) & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /**
      * `Customer` objects allow you to perform recurring charges, and to track
      * multiple charges, that are associated with the same customer. The API allows
@@ -2711,7 +2719,7 @@ export interface components {
      */
     customer: {
       /** The customer's address. */
-      address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** Current balance, if any, being stored on the customer. If negative, the customer has credit to apply to their next invoice. If positive, the customer has an amount owed that will be added to their next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account as invoices are finalized. */
       balance?: number;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -2729,14 +2737,14 @@ export interface components {
             Partial<components["schemas"]["bank_account"]> &
             Partial<components["schemas"]["bitcoin_receiver"]> &
             Partial<components["schemas"]["card"]> &
-            Partial<components["schemas"]["source"]>) & { [key: string]: any })
+            Partial<components["schemas"]["source"]>) & { [key: string]: unknown })
         | null;
       /** When the customer's latest invoice is billed by charging automatically, delinquent is true if the invoice's latest charge is failed. When the customer's latest invoice is billed by sending an invoice, delinquent is true if the invoice is not paid by its due date. */
       delinquent?: boolean | null;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
       description?: string | null;
       /** Describes the current discount active on the customer, if there is one. */
-      discount?: (Partial<components["schemas"]["discount"]> & { [key: string]: any }) | null;
+      discount?: (Partial<components["schemas"]["discount"]> & { [key: string]: unknown }) | null;
       /** The customer's email address. */
       email?: string | null;
       /** Unique identifier for the object. */
@@ -2759,7 +2767,7 @@ export interface components {
       /** The customer's preferred locales (languages), ordered by preference. */
       preferred_locales?: string[] | null;
       /** Mailing and shipping address for the customer. Appears on invoices emailed to this customer. */
-      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: any }) | null;
+      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: unknown }) | null;
       /** The customer's payment sources, if any. */
       sources: {
         /** Details about each object. */
@@ -2767,14 +2775,14 @@ export interface components {
           Partial<components["schemas"]["bank_account"]> &
           Partial<components["schemas"]["bitcoin_receiver"]> &
           Partial<components["schemas"]["card"]> &
-          Partial<components["schemas"]["source"]>) & { [key: string]: any })[];
+          Partial<components["schemas"]["source"]>) & { [key: string]: unknown })[];
         /** True if this list has another page of items after this one that can be fetched. */
         has_more: boolean;
         /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** The customer's current subscriptions, if any. */
       subscriptions?: {
         /** Details about each object. */
@@ -2785,7 +2793,7 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** Describes the customer's tax exemption status. One of `none`, `exempt`, or `reverse`. When set to `reverse`, invoice and receipt PDFs include the text **"Reverse charge"**. */
       tax_exempt?: ("exempt" | "none" | "reverse") | null;
       /** The customer's tax IDs. */
@@ -2798,8 +2806,8 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
-    } & { [key: string]: any };
+      } & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     customer_acceptance: {
       /** The time at which the customer accepted the Mandate. */
       accepted_at?: number | null;
@@ -2807,7 +2815,7 @@ export interface components {
       online?: components["schemas"]["online_acceptance"];
       /** The type of customer acceptance information included with the Mandate. One of `online` or `offline`. */
       type: "offline" | "online";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Each customer has a [`balance`](https://stripe.com/docs/api/customers/object#customer_object-balance) value,
      * which denotes a debit or credit that's automatically applied to their next invoice upon finalization.
@@ -2822,11 +2830,13 @@ export interface components {
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** The ID of the credit note (if any) related to the transaction. */
-      credit_note?: ((Partial<string> & Partial<components["schemas"]["credit_note"]>) & { [key: string]: any }) | null;
+      credit_note?:
+        | ((Partial<string> & Partial<components["schemas"]["credit_note"]>) & { [key: string]: unknown })
+        | null;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** The ID of the customer the transaction belongs to. */
-      customer: (Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: any };
+      customer: (Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: unknown };
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
       description?: string | null;
       /** The customer's `balance` after the transaction was applied. A negative value decreases the amount due on the customer's next invoice. A positive value increases the amount due on the customer's next invoice. */
@@ -2834,7 +2844,7 @@ export interface components {
       /** Unique identifier for the object. */
       id: string;
       /** The ID of the invoice (if any) related to the transaction. */
-      invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: any }) | null;
+      invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: unknown }) | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
@@ -2852,7 +2862,7 @@ export interface components {
         | "migration"
         | "unapplied_from_invoice"
         | "unspent_receiver_credit";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_account: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2860,7 +2870,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "account";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_alipay_account: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2868,7 +2878,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "alipay_account";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_apple_pay_domain: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2876,7 +2886,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "apple_pay_domain";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_bank_account: {
       /** Three-letter [ISO code for the currency](https://stripe.com/docs/payouts) paid out to the bank account. */
       currency?: string | null;
@@ -2886,7 +2896,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "bank_account";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_bitcoin_receiver: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2894,7 +2904,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "bitcoin_receiver";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_card: {
       /** Three-letter [ISO code for the currency](https://stripe.com/docs/payouts) paid out to the bank account. */
       currency?: string | null;
@@ -2904,7 +2914,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "card";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_coupon: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2912,7 +2922,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "coupon";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_customer: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2920,15 +2930,15 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "customer";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_discount: {
       /** Always true for a deleted object */
       deleted: true;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "discount";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_external_account: (Partial<components["schemas"]["deleted_bank_account"]> &
-      Partial<components["schemas"]["deleted_card"]>) & { [key: string]: any };
+      Partial<components["schemas"]["deleted_card"]>) & { [key: string]: unknown };
     deleted_invoice: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2936,7 +2946,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "invoice";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_invoiceitem: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2944,11 +2954,11 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "invoiceitem";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_payment_source: (Partial<components["schemas"]["deleted_alipay_account"]> &
       Partial<components["schemas"]["deleted_bank_account"]> &
       Partial<components["schemas"]["deleted_bitcoin_receiver"]> &
-      Partial<components["schemas"]["deleted_card"]>) & { [key: string]: any };
+      Partial<components["schemas"]["deleted_card"]>) & { [key: string]: unknown };
     deleted_person: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2956,7 +2966,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "person";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_plan: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2964,7 +2974,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "plan";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_product: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2972,7 +2982,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "product";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "deleted_radar.value_list": {
       /** Always true for a deleted object */
       deleted: true;
@@ -2980,7 +2990,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "radar.value_list";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "deleted_radar.value_list_item": {
       /** Always true for a deleted object */
       deleted: true;
@@ -2988,7 +2998,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "radar.value_list_item";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_recipient: {
       /** Always true for a deleted object */
       deleted: true;
@@ -2996,7 +3006,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "recipient";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_sku: {
       /** Always true for a deleted object */
       deleted: true;
@@ -3004,7 +3014,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "sku";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_subscription_item: {
       /** Always true for a deleted object */
       deleted: true;
@@ -3012,7 +3022,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "subscription_item";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_tax_id: {
       /** Always true for a deleted object */
       deleted: true;
@@ -3020,7 +3030,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "tax_id";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "deleted_terminal.location": {
       /** Always true for a deleted object */
       deleted: true;
@@ -3028,7 +3038,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "terminal.location";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     "deleted_terminal.reader": {
       /** Always true for a deleted object */
       deleted: true;
@@ -3036,7 +3046,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "terminal.reader";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     deleted_webhook_endpoint: {
       /** Always true for a deleted object */
       deleted: true;
@@ -3044,7 +3054,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "webhook_endpoint";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     delivery_estimate: {
       /** If `type` is `"exact"`, `date` will be the expected delivery date in the format YYYY-MM-DD. */
       date?: string;
@@ -3054,7 +3064,7 @@ export interface components {
       latest?: string;
       /** The type of estimate. Must be either `"range"` or `"exact"`. */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A discount represents the actual application of a coupon to a particular
      * customer. It contains information about when the discount began and when it
@@ -3068,7 +3078,7 @@ export interface components {
       customer?:
         | ((Partial<string> &
             Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown })
         | null;
       /** If the coupon has a duration of `repeating`, the date that this discount will end. If the coupon has a duration of `once` or `forever`, this attribute will be null. */
       end?: number | null;
@@ -3078,7 +3088,7 @@ export interface components {
       start: number;
       /** The subscription that this coupon is applied to, if it is applied to a particular subscription. */
       subscription?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A dispute occurs when a customer questions your charge with their card issuer.
      * When this happens, you're given the opportunity to respond to the dispute with
@@ -3094,7 +3104,7 @@ export interface components {
       /** List of zero, one, or two balance transactions that show funds withdrawn and reinstated to your Stripe account as a result of this dispute. */
       balance_transactions: components["schemas"]["balance_transaction"][];
       /** ID of the charge that was disputed. */
-      charge: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any };
+      charge: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown };
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -3113,7 +3123,7 @@ export interface components {
       object: "dispute";
       /** ID of the PaymentIntent that was disputed. */
       payment_intent?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: unknown })
         | null;
       /** Reason given by cardholder for dispute. Possible values are `bank_cannot_process`, `check_returned`, `credit_not_processed`, `customer_initiated`, `debit_not_authorized`, `duplicate`, `fraudulent`, `general`, `incorrect_account_details`, `insufficient_funds`, `product_not_received`, `product_unacceptable`, `subscription_canceled`, or `unrecognized`. Read more about [dispute reasons](https://stripe.com/docs/disputes/categories). */
       reason: string;
@@ -3127,7 +3137,7 @@ export interface components {
         | "warning_needs_response"
         | "warning_under_review"
         | "won";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     dispute_evidence: {
       /** Any server or activity logs showing proof that the customer accessed or downloaded the purchased digital product. This information should include IP addresses, corresponding timestamps, and any detailed recorded activity. */
       access_activity_log?: string | null;
@@ -3135,7 +3145,7 @@ export interface components {
       billing_address?: string | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your subscription cancellation policy, as shown to the customer. */
       cancellation_policy?:
-        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown })
         | null;
       /** An explanation of how and when the customer was shown your refund policy prior to purchase. */
       cancellation_policy_disclosure?: string | null;
@@ -3143,7 +3153,7 @@ export interface components {
       cancellation_rebuttal?: string | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any communication with the customer that you feel is relevant to your case. Examples include emails proving that the customer received the product or service, or demonstrating their use of or satisfaction with the product or service. */
       customer_communication?:
-        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown })
         | null;
       /** The email address of the customer. */
       customer_email_address?: string | null;
@@ -3152,10 +3162,12 @@ export interface components {
       /** The IP address that the customer used when making the purchase. */
       customer_purchase_ip?: string | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) A relevant document or contract showing the customer's signature. */
-      customer_signature?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      customer_signature?:
+        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown })
+        | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation for the prior charge that can uniquely identify the charge, such as a receipt, shipping label, work order, etc. This document should be paired with a similar document from the disputed payment that proves the two payments are separate. */
       duplicate_charge_documentation?:
-        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown })
         | null;
       /** An explanation of the difference between the disputed charge versus the prior charge that appears to be a duplicate. */
       duplicate_charge_explanation?: string | null;
@@ -3164,9 +3176,9 @@ export interface components {
       /** A description of the product or service that was sold. */
       product_description?: string | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any receipt or message sent to the customer notifying them of the charge. */
-      receipt?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      receipt?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your refund policy, as shown to the customer. */
-      refund_policy?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      refund_policy?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
       /** Documentation demonstrating that the customer was shown your refund policy prior to purchase. */
       refund_policy_disclosure?: string | null;
       /** A justification for why the customer is not entitled to a refund. */
@@ -3175,7 +3187,7 @@ export interface components {
       service_date?: string | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof that a service was provided to the customer. This could include a copy of a signed contract, work order, or other form of written agreement. */
       service_documentation?:
-        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown })
         | null;
       /** The address to which a physical product was shipped. You should try to include as complete address information as possible. */
       shipping_address?: string | null;
@@ -3185,15 +3197,17 @@ export interface components {
       shipping_date?: string | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof that a product was shipped to the customer at the same address the customer provided to you. This could include a copy of the shipment receipt, shipping label, etc. It should show the customer's full shipping address, if possible. */
       shipping_documentation?:
-        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown })
         | null;
       /** The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas. */
       shipping_tracking_number?: string | null;
       /** (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any additional evidence or statements. */
-      uncategorized_file?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      uncategorized_file?:
+        | ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown })
+        | null;
       /** Any additional evidence or statements. */
       uncategorized_text?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     dispute_evidence_details: {
       /** Date by which evidence must be submitted in order to successfully challenge dispute. Will be null if the customer's bank or credit card company doesn't allow a response for this particular dispute. */
       due_by?: number | null;
@@ -3203,7 +3217,7 @@ export interface components {
       past_due: boolean;
       /** The number of times evidence has been submitted. Typically, you may only submit evidence once. */
       submission_count: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     ephemeral_key: {
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -3217,11 +3231,11 @@ export interface components {
       object: "ephemeral_key";
       /** The key's secret. You can use this value to make authorized requests to the Stripe API. */
       secret?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** An error response from the Stripe API */
     error: {
       error: components["schemas"]["api_errors"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Events are our way of letting you know when something interesting happens in
      * your account. When an interesting event occurs, we create a new `Event`
@@ -3270,10 +3284,10 @@ export interface components {
       /** Number of webhooks that have yet to be successfully delivered (i.e., to return a 20x response) to the URLs you've specified. */
       pending_webhooks: number;
       /** Information on the API request that instigated the event. */
-      request?: (Partial<components["schemas"]["notification_event_request"]> & { [key: string]: any }) | null;
+      request?: (Partial<components["schemas"]["notification_event_request"]> & { [key: string]: unknown }) | null;
       /** Description of the event (e.g., `invoice.created` or `charge.refunded`). */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * `Exchange Rate` objects allow you to determine the rates that Stripe is
      * currently using to convert from one currency to another. Since this number is
@@ -3294,9 +3308,9 @@ export interface components {
       object: "exchange_rate";
       /** Hash where the keys are supported currencies and the values are the exchange rate at which the base id currency converts to the key currency. */
       rates: { [key: string]: number };
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     external_account: (Partial<components["schemas"]["bank_account"]> & Partial<components["schemas"]["card"]>) & {
-      [key: string]: any;
+      [key: string]: unknown;
     };
     fee: {
       /** Amount of the fee, in cents. */
@@ -3309,7 +3323,7 @@ export interface components {
       description?: string | null;
       /** Type of the fee, one of: `application_fee`, `stripe_fee` or `tax`. */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * `Application Fee Refund` objects allow you to refund an application fee that
      * has previously been created but not yet refunded. Funds will be refunded to
@@ -3322,21 +3336,21 @@ export interface components {
       amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** ID of the application fee that was refunded. */
-      fee: (Partial<string> & Partial<components["schemas"]["application_fee"]>) & { [key: string]: any };
+      fee: (Partial<string> & Partial<components["schemas"]["application_fee"]>) & { [key: string]: unknown };
       /** Unique identifier for the object. */
       id: string;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
       metadata: { [key: string]: string };
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "fee_refund";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * This is an object representing a file hosted on Stripe's servers. The
      * file may have been uploaded by yourself using the [create file](https://stripe.com/docs/api#create_file)
@@ -3364,7 +3378,7 @@ export interface components {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "file";
@@ -3378,7 +3392,7 @@ export interface components {
       type?: string | null;
       /** The URL from which the file can be downloaded using your live secret API key. */
       url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * To share the contents of a `File` object with non-Stripe users, you can
      * create a `FileLink`. `FileLink`s contain a URL that can be used to
@@ -3392,7 +3406,7 @@ export interface components {
       /** Time at which the link expires. */
       expires_at?: number | null;
       /** The file object this link points to. */
-      file: (Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any };
+      file: (Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown };
       /** Unique identifier for the object. */
       id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
@@ -3403,7 +3417,7 @@ export interface components {
       object: "file_link";
       /** The publicly accessible URL to download the file. */
       url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     financial_reporting_finance_report_run_run_parameters: {
       /** The set of output columns requested for inclusion in the report run. */
       columns?: string[];
@@ -3421,7 +3435,7 @@ export interface components {
       reporting_category?: string;
       /** Defaults to `Etc/UTC`. The output timezone for all timestamps in the report. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones). Has no effect on `interval_start` or `interval_end`. */
       timezone?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     inventory: {
       /** The count of inventory available. Will be present if and only if `type` is `finite`. */
       quantity?: number | null;
@@ -3429,7 +3443,7 @@ export interface components {
       type: string;
       /** An indicator of the inventory available. Possible values are `in_stock`, `limited`, and `out_of_stock`. Will be present if and only if `type` is `bucket`. */
       value?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Invoices are statements of amounts owed by a customer, and are either
      * generated one-off, or generated periodically from a subscription.
@@ -3497,7 +3511,7 @@ export interface components {
           )
         | null;
       /** ID of the latest charge generated for this invoice, if any. */
-      charge?: ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any }) | null;
+      charge?: ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown }) | null;
       /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions. */
       collection_method?: ("charge_automatically" | "send_invoice") | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -3509,9 +3523,9 @@ export interface components {
       /** The ID of the customer who will be billed. */
       customer: (Partial<string> &
         Partial<components["schemas"]["customer"]> &
-        Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any };
+        Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown };
       /** The customer's address. Until the invoice is finalized, this field will equal `customer.address`. Once the invoice is finalized, this field will no longer be updated. */
-      customer_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      customer_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** The customer's email. Until the invoice is finalized, this field will equal `customer.email`. Once the invoice is finalized, this field will no longer be updated. */
       customer_email?: string | null;
       /** The customer's name. Until the invoice is finalized, this field will equal `customer.name`. Once the invoice is finalized, this field will no longer be updated. */
@@ -3519,14 +3533,14 @@ export interface components {
       /** The customer's phone number. Until the invoice is finalized, this field will equal `customer.phone`. Once the invoice is finalized, this field will no longer be updated. */
       customer_phone?: string | null;
       /** The customer's shipping information. Until the invoice is finalized, this field will equal `customer.shipping`. Once the invoice is finalized, this field will no longer be updated. */
-      customer_shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: any }) | null;
+      customer_shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: unknown }) | null;
       /** The customer's tax exempt status. Until the invoice is finalized, this field will equal `customer.tax_exempt`. Once the invoice is finalized, this field will no longer be updated. */
       customer_tax_exempt?: ("exempt" | "none" | "reverse") | null;
       /** The customer's tax IDs. Until the invoice is finalized, this field will contain the same tax IDs as `customer.tax_ids`. Once the invoice is finalized, this field will no longer be updated. */
       customer_tax_ids?: components["schemas"]["invoices_resource_invoice_tax_id"][] | null;
       /** ID of the default payment method for the invoice. It must belong to the customer associated with the invoice. If not set, defaults to the subscription's default payment method, if any, or to the default payment method in the customer's invoice settings. */
       default_payment_method?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: unknown })
         | null;
       /** ID of the default payment source for the invoice. It must belong to the customer associated with the invoice and be in a chargeable state. If not set, defaults to the subscription's default source, if any, or to the customer's default source. */
       default_source?:
@@ -3535,14 +3549,14 @@ export interface components {
             Partial<components["schemas"]["bank_account"]> &
             Partial<components["schemas"]["bitcoin_receiver"]> &
             Partial<components["schemas"]["card"]> &
-            Partial<components["schemas"]["source"]>) & { [key: string]: any })
+            Partial<components["schemas"]["source"]>) & { [key: string]: unknown })
         | null;
       /** The tax rates applied to this invoice, if any. */
       default_tax_rates?: components["schemas"]["tax_rate"][] | null;
       /** An arbitrary string attached to the object. Often useful for displaying to users. Referenced as 'memo' in the Dashboard. */
       description?: string | null;
       /** Describes the current discount applied to this invoice, if there is one. */
-      discount?: (Partial<components["schemas"]["discount"]> & { [key: string]: any }) | null;
+      discount?: (Partial<components["schemas"]["discount"]> & { [key: string]: unknown }) | null;
       /** The date on which payment for this invoice is due. This value will be `null` for invoices where `collection_method=charge_automatically`. */
       due_date?: number | null;
       /** Ending customer balance after the invoice is finalized. Invoices are finalized approximately an hour after successful webhook delivery or when payment collection is attempted for the invoice. If the invoice has not been finalized yet, this will be null. */
@@ -3565,7 +3579,7 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
@@ -3580,7 +3594,7 @@ export interface components {
       paid: boolean;
       /** The PaymentIntent associated with this invoice. The PaymentIntent is generated when the invoice is finalized, and can then be used to pay the invoice. Note that voiding an invoice will cancel the PaymentIntent. */
       payment_intent?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: unknown })
         | null;
       /** End of the usage period during which invoice items were added to this invoice. */
       period_end: number;
@@ -3601,7 +3615,7 @@ export interface components {
       status_transitions: components["schemas"]["invoices_status_transitions"];
       /** The subscription that this invoice was prepared for, if any. */
       subscription?:
-        | ((Partial<string> & Partial<components["schemas"]["subscription"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["subscription"]>) & { [key: string]: unknown })
         | null;
       /** Only set for upcoming invoices that preview prorations. The time used to calculate prorations. */
       subscription_proration_date?: number;
@@ -3618,53 +3632,53 @@ export interface components {
       total_tax_amounts?: components["schemas"]["invoice_tax_amount"][] | null;
       /** Invoices are automatically paid or sent 1 hour after webhooks are delivered, or until all webhook delivery attempts have [been exhausted](https://stripe.com/docs/billing/webhooks#understand). This field tracks the time when webhooks for this invoice were successfully delivered. If the invoice had no webhooks to deliver, this will be set while the invoice is being created. */
       webhooks_delivered_at?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     invoice_item_threshold_reason: {
       /** The IDs of the line items that triggered the threshold invoice. */
       line_item_ids: string[];
       /** The quantity threshold boundary that applied to the given line item. */
       usage_gte: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     invoice_line_item_period: {
       /** End of the line item's billing period */
       end: number;
       /** Start of the line item's billing period */
       start: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     invoice_setting_custom_field: {
       /** The name of the custom field. */
       name: string;
       /** The value of the custom field. */
       value: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     invoice_setting_customer_setting: {
       /** Default custom fields to be displayed on invoices for this customer. */
       custom_fields?: components["schemas"]["invoice_setting_custom_field"][] | null;
       /** ID of a payment method that's attached to the customer, to be used as the customer's default payment method for subscriptions and invoices. */
       default_payment_method?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: unknown })
         | null;
       /** Default footer to be displayed on invoices for this customer. */
       footer?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     invoice_setting_subscription_schedule_setting: {
       /** Number of days within which a customer must pay invoices generated by this subscription schedule. This value will be `null` for subscription schedules where `billing=charge_automatically`. */
       days_until_due?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     invoice_tax_amount: {
       /** The amount, in %s, of the tax. */
       amount: number;
       /** Whether this tax amount is inclusive or exclusive. */
       inclusive: boolean;
       /** The tax rate that was applied to get this tax amount. */
-      tax_rate: (Partial<string> & Partial<components["schemas"]["tax_rate"]>) & { [key: string]: any };
-    } & { [key: string]: any };
+      tax_rate: (Partial<string> & Partial<components["schemas"]["tax_rate"]>) & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     invoice_threshold_reason: {
       /** The total invoice amount threshold boundary if it triggered the threshold invoice. */
       amount_gte?: number | null;
       /** Indicates which line items triggered a threshold invoice. */
       item_reasons: components["schemas"]["invoice_item_threshold_reason"][];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Sometimes you want to add a charge or credit to a customer, but actually
      * charge or credit the customer's card only at the end of a regular billing
@@ -3682,7 +3696,7 @@ export interface components {
       /** The ID of the customer who will be billed when this invoice item is billed. */
       customer: (Partial<string> &
         Partial<components["schemas"]["customer"]> &
-        Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any };
+        Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown };
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       date: number;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
@@ -3692,7 +3706,7 @@ export interface components {
       /** Unique identifier for the object. */
       id: string;
       /** The ID of the invoice this invoice item belongs to. */
-      invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: any }) | null;
+      invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: unknown }) | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
@@ -3701,14 +3715,14 @@ export interface components {
       object: "invoiceitem";
       period: components["schemas"]["invoice_line_item_period"];
       /** If the invoice item is a proration, the plan of the subscription that the proration was computed for. */
-      plan?: (Partial<components["schemas"]["plan"]> & { [key: string]: any }) | null;
+      plan?: (Partial<components["schemas"]["plan"]> & { [key: string]: unknown }) | null;
       /** Whether the invoice item was created automatically as a proration adjustment when the customer switched plans. */
       proration: boolean;
       /** Quantity of units for the invoice item. If the invoice item is a proration, the quantity of the subscription that the proration was computed for. */
       quantity: number;
       /** The subscription that this invoice item has been created for, if any. */
       subscription?:
-        | ((Partial<string> & Partial<components["schemas"]["subscription"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["subscription"]>) & { [key: string]: unknown })
         | null;
       /** The subscription item that this invoice item has been created for, if any. */
       subscription_item?: string;
@@ -3718,7 +3732,7 @@ export interface components {
       unit_amount?: number | null;
       /** Same as `unit_amount`, but contains a decimal value with at most 12 decimal places. */
       unit_amount_decimal?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     invoices_resource_invoice_tax_id: {
       /** The type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, or `unknown` */
       type:
@@ -3748,7 +3762,7 @@ export interface components {
         | "za_vat";
       /** The value of the tax ID. */
       value?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     invoices_status_transitions: {
       /** The time that the invoice draft was finalized. */
       finalized_at?: number | null;
@@ -3758,7 +3772,7 @@ export interface components {
       paid_at?: number | null;
       /** The time that the invoice was voided. */
       voided_at?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * This resource has been renamed to [Early Fraud
      * Warning](#early_fraud_warning_object) and will be removed in a future API
@@ -3768,7 +3782,7 @@ export interface components {
       /** An IFR is actionable if it has not received a dispute and has not been fully refunded. You may wish to proactively refund a charge that receives an IFR, in order to avoid receiving a dispute later. */
       actionable: boolean;
       /** ID of the charge this issuer fraud record is for, optionally expanded. */
-      charge: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any };
+      charge: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown };
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** The type of fraud labelled by the issuer. One of `card_never_received`, `fraudulent_card_application`, `made_with_counterfeit_card`, `made_with_lost_card`, `made_with_stolen_card`, `misc`, `unauthorized_use_of_card`. */
@@ -3783,7 +3797,7 @@ export interface components {
       object: "issuer_fraud_record";
       /** The timestamp at which the card issuer posted the issuer fraud record. */
       post_date: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * When an [issued card](https://stripe.com/docs/issuing) is used to make a purchase, an Issuing `Authorization`
      * object is created. [Authorizations](https://stripe.com/docs/issuing/purchases/authorizations) must be approved for the
@@ -3803,7 +3817,7 @@ export interface components {
       card: components["schemas"]["issuing.card"];
       /** The cardholder to whom this authorization belongs. */
       cardholder?:
-        | ((Partial<string> & Partial<components["schemas"]["issuing.cardholder"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["issuing.cardholder"]>) & { [key: string]: unknown })
         | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -3824,7 +3838,7 @@ export interface components {
       object: "issuing.authorization";
       /** The pending authorization request. This field will only be non-null during an `issuing_authorization.request` webhook. */
       pending_request?:
-        | (Partial<components["schemas"]["issuing_authorization_pending_request"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["issuing_authorization_pending_request"]> & { [key: string]: unknown })
         | null;
       /** History of every time the authorization was approved/denied (whether approved/denied by you directly or by Stripe based on your `spending_controls`). If the merchant changes the authorization by performing an [incremental authorization or partial capture](https://stripe.com/docs/issuing/purchases/authorizations), you can look at this field to see the previous states of the authorization. */
       request_history: components["schemas"]["issuing_authorization_request"][];
@@ -3835,7 +3849,7 @@ export interface components {
       verification_data: components["schemas"]["issuing_authorization_verification_data"];
       /** What, if any, digital wallet was used for this authorization. One of `apple_pay`, `google_pay`, or `samsung_pay`. */
       wallet?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders. */
     "issuing.card": {
       /** The brand of the card. */
@@ -3867,22 +3881,22 @@ export interface components {
       object: "issuing.card";
       /** The latest card that replaces this card, if any. */
       replaced_by?:
-        | ((Partial<string> & Partial<components["schemas"]["issuing.card"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["issuing.card"]>) & { [key: string]: unknown })
         | null;
       /** The card this card replaces, if any. */
       replacement_for?:
-        | ((Partial<string> & Partial<components["schemas"]["issuing.card"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["issuing.card"]>) & { [key: string]: unknown })
         | null;
       /** The reason why the previous card needed to be replaced. */
       replacement_reason?: ("damaged" | "expired" | "lost" | "stolen") | null;
       /** Where and how the card will be shipped. */
-      shipping?: (Partial<components["schemas"]["issuing_card_shipping"]> & { [key: string]: any }) | null;
+      shipping?: (Partial<components["schemas"]["issuing_card_shipping"]> & { [key: string]: unknown }) | null;
       spending_controls: components["schemas"]["issuing_card_authorization_controls"];
       /** Whether authorizations can be approved on this card. */
       status: "active" | "canceled" | "inactive";
       /** The type of the card. */
       type: "physical" | "virtual";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * An Issuing `Cardholder` object represents an individual or business entity who is [issued](https://stripe.com/docs/issuing) cards.
      *
@@ -3891,7 +3905,7 @@ export interface components {
     "issuing.cardholder": {
       billing: components["schemas"]["issuing_cardholder_address"];
       /** Additional information about a `company` cardholder. */
-      company?: (Partial<components["schemas"]["issuing_cardholder_company"]> & { [key: string]: any }) | null;
+      company?: (Partial<components["schemas"]["issuing_cardholder_company"]> & { [key: string]: unknown }) | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** The cardholder's email address. */
@@ -3899,7 +3913,9 @@ export interface components {
       /** Unique identifier for the object. */
       id: string;
       /** Additional information about an `individual` cardholder. */
-      individual?: (Partial<components["schemas"]["issuing_cardholder_individual"]> & { [key: string]: any }) | null;
+      individual?:
+        | (Partial<components["schemas"]["issuing_cardholder_individual"]> & { [key: string]: unknown })
+        | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
@@ -3913,13 +3929,13 @@ export interface components {
       requirements: components["schemas"]["issuing_cardholder_requirements"];
       /** Spending rules that give you some control over how this cardholder's cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details. */
       spending_controls?:
-        | (Partial<components["schemas"]["issuing_cardholder_authorization_controls"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["issuing_cardholder_authorization_controls"]> & { [key: string]: unknown })
         | null;
       /** Specifies whether to permit authorizations on this cardholder's cards. */
       status: "active" | "blocked" | "inactive";
       /** One of `individual` or `company`. */
       type: "company" | "individual";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * As a [card issuer](https://stripe.com/docs/issuing), you can [dispute](https://stripe.com/docs/issuing/purchases/disputes) transactions that you do not recognize, suspect to be fraudulent, or have some other issue.
      *
@@ -3932,7 +3948,7 @@ export interface components {
       livemode: boolean;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "issuing.dispute";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** When a non-stripe BIN is used, any use of an [issued card](https://stripe.com/docs/issuing) must be settled directly with the card network. The net amount owed is represented by an Issuing `Settlement` object. */
     "issuing.settlement": {
       /** The Bank Identification Number reflecting this settlement record. */
@@ -3967,7 +3983,7 @@ export interface components {
       transaction_count: number;
       /** The total transaction amount reflected in this settlement. */
       transaction_volume: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Any use of an [issued card](https://stripe.com/docs/issuing) that results in funds entering or leaving
      * your Stripe account, such as a completed purchase or refund, is represented by an Issuing
@@ -3980,17 +3996,17 @@ export interface components {
       amount: number;
       /** The `Authorization` object that led to this transaction. */
       authorization?:
-        | ((Partial<string> & Partial<components["schemas"]["issuing.authorization"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["issuing.authorization"]>) & { [key: string]: unknown })
         | null;
       /** ID of the [balance transaction](https://stripe.com/docs/api/balance_transactions) associated with this transaction. */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** The card used to make this transaction. */
-      card: (Partial<string> & Partial<components["schemas"]["issuing.card"]>) & { [key: string]: any };
+      card: (Partial<string> & Partial<components["schemas"]["issuing.card"]>) & { [key: string]: unknown };
       /** The cardholder to whom this transaction belongs. */
       cardholder?:
-        | ((Partial<string> & Partial<components["schemas"]["issuing.cardholder"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["issuing.cardholder"]>) & { [key: string]: unknown })
         | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -4011,7 +4027,7 @@ export interface components {
       object: "issuing.transaction";
       /** The nature of the transaction. */
       type: "capture" | "refund";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_authorization_merchant_data: {
       /** A categorization of the seller's type of business. See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values. */
       category: string;
@@ -4027,7 +4043,7 @@ export interface components {
       postal_code?: string | null;
       /** State where the seller is located */
       state?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_authorization_pending_request: {
       /** The additional amount Stripe will hold if the authorization is approved, in the card's [currency](https://stripe.com/docs/api#issuing_authorization_object-pending-request-currency) and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
       amount: number;
@@ -4039,7 +4055,7 @@ export interface components {
       merchant_amount: number;
       /** The local currency the merchant is requesting to authorize. */
       merchant_currency: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_authorization_request: {
       /** The authorization amount in your card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved. */
       amount: number;
@@ -4068,7 +4084,7 @@ export interface components {
         | "webhook_approved"
         | "webhook_declined"
         | "webhook_timeout";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_authorization_verification_data: {
       /** Whether the cardholder provided an address first line and if it matched the cardholder’s `billing.address.line1`. */
       address_line1_check: "match" | "mismatch" | "not_provided";
@@ -4078,7 +4094,7 @@ export interface components {
       cvc_check: "match" | "mismatch" | "not_provided";
       /** Whether the cardholder provided an expiry date and if it matched Stripe’s record. */
       expiry_check: "match" | "mismatch" | "not_provided";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_card_authorization_controls: {
       /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this card. */
       allowed_categories?:
@@ -4670,7 +4686,7 @@ export interface components {
       spending_limits?: components["schemas"]["issuing_card_spending_limit"][] | null;
       /** Currency for the amounts within spending_limits. Locked to the currency of the card. */
       spending_limits_currency?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_card_shipping: {
       address: components["schemas"]["address"];
       /** The delivery company that shipped a card. */
@@ -4689,7 +4705,7 @@ export interface components {
       tracking_url?: string | null;
       /** Packaging options. */
       type: "bulk" | "individual";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_card_spending_limit: {
       /** Maximum amount allowed to spend per time interval. */
       amount: number;
@@ -4988,10 +5004,10 @@ export interface components {
         | null;
       /** The time interval or event with which to apply this spending limit towards. */
       interval: "all_time" | "daily" | "monthly" | "per_authorization" | "weekly" | "yearly";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_cardholder_address: {
       address: components["schemas"]["address"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_cardholder_authorization_controls: {
       /** Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this cardholder's cards. */
       allowed_categories?:
@@ -5583,29 +5599,29 @@ export interface components {
       spending_limits?: components["schemas"]["issuing_cardholder_spending_limit"][] | null;
       /** Currency for the amounts within spending_limits. */
       spending_limits_currency?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_cardholder_company: {
       /** Whether the company's business ID number was provided. */
       tax_id_provided: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_cardholder_id_document: {
       /** The back of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. */
-      back?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      back?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
       /** The front of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. */
-      front?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      front?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     issuing_cardholder_individual: {
       /** The date of birth of this cardholder. */
-      dob?: (Partial<components["schemas"]["issuing_cardholder_individual_dob"]> & { [key: string]: any }) | null;
+      dob?: (Partial<components["schemas"]["issuing_cardholder_individual_dob"]> & { [key: string]: unknown }) | null;
       /** The first name of this cardholder. */
       first_name: string;
       /** The last name of this cardholder. */
       last_name: string;
       /** Government-issued ID document for this cardholder. */
       verification?:
-        | (Partial<components["schemas"]["issuing_cardholder_verification"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["issuing_cardholder_verification"]> & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_cardholder_individual_dob: {
       /** The day of birth, between 1 and 31. */
       day?: number | null;
@@ -5613,7 +5629,7 @@ export interface components {
       month?: number | null;
       /** The four-digit year of birth. */
       year?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_cardholder_requirements: {
       /** If `disabled_reason` is present, all cards will decline authorizations with `cardholder_verification_required` reason. */
       disabled_reason?: ("listed" | "rejected.listed" | "under_review") | null;
@@ -5629,7 +5645,7 @@ export interface components {
             | "individual.verification.document"
           )[]
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_cardholder_spending_limit: {
       /** Maximum amount allowed to spend per time interval. */
       amount: number;
@@ -5928,17 +5944,19 @@ export interface components {
         | null;
       /** The time interval or event with which to apply this spending limit towards. */
       interval: "all_time" | "daily" | "monthly" | "per_authorization" | "weekly" | "yearly";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     issuing_cardholder_verification: {
       /** An identifying document, either a passport or local ID card. */
-      document?: (Partial<components["schemas"]["issuing_cardholder_id_document"]> & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      document?: (Partial<components["schemas"]["issuing_cardholder_id_document"]> & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     legal_entity_company: {
       address?: components["schemas"]["address"];
       /** The Kana variation of the company's primary address (Japan only). */
-      address_kana?: (Partial<components["schemas"]["legal_entity_japan_address"]> & { [key: string]: any }) | null;
+      address_kana?: (Partial<components["schemas"]["legal_entity_japan_address"]> & { [key: string]: unknown }) | null;
       /** The Kanji variation of the company's primary address (Japan only). */
-      address_kanji?: (Partial<components["schemas"]["legal_entity_japan_address"]> & { [key: string]: any }) | null;
+      address_kanji?:
+        | (Partial<components["schemas"]["legal_entity_japan_address"]> & { [key: string]: unknown })
+        | null;
       /** Whether the company's directors have been provided. This Boolean will be `true` if you've manually indicated that all directors are provided via [the `directors_provided` parameter](https://stripe.com/docs/api/accounts/update#update_account-company-directors_provided). */
       directors_provided?: boolean;
       /** Whether the company's executives have been provided. This Boolean will be `true` if you've manually indicated that all executives are provided via [the `executives_provided` parameter](https://stripe.com/docs/api/accounts/update#update_account-company-executives_provided), or if Stripe determined that sufficient executives were provided. */
@@ -5978,22 +5996,22 @@ export interface components {
       vat_id_provided?: boolean;
       /** Information on the verification state of the company. */
       verification?:
-        | (Partial<components["schemas"]["legal_entity_company_verification"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["legal_entity_company_verification"]> & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     legal_entity_company_verification: {
       document: components["schemas"]["legal_entity_company_verification_document"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     legal_entity_company_verification_document: {
       /** The back of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`. */
-      back?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      back?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
       /** A user-displayable string describing the verification state of this document. */
       details?: string | null;
       /** One of `document_corrupt`, `document_expired`, `document_failed_copy`, `document_failed_greyscale`, `document_failed_other`, `document_failed_test_mode`, `document_fraudulent`, `document_incomplete`, `document_invalid`, `document_manipulated`, `document_not_readable`, `document_not_uploaded`, `document_type_not_supported`, or `document_too_large`. A machine-readable code specifying the verification state for this document. */
       details_code?: string | null;
       /** The front of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`. */
-      front?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      front?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     legal_entity_dob: {
       /** The day of birth, between 1 and 31. */
       day?: number | null;
@@ -6001,7 +6019,7 @@ export interface components {
       month?: number | null;
       /** The four-digit year of birth. */
       year?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     legal_entity_japan_address: {
       /** City/Ward. */
       city?: string | null;
@@ -6017,11 +6035,11 @@ export interface components {
       state?: string | null;
       /** Town/cho-me. */
       town?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     legal_entity_person_verification: {
       /** A document showing address, either a passport, local ID card, or utility bill from a well-known utility company. */
       additional_document?:
-        | (Partial<components["schemas"]["legal_entity_person_verification_document"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["legal_entity_person_verification_document"]> & { [key: string]: unknown })
         | null;
       /** A user-displayable string describing the verification state for the person. For example, this may say "Provided identity information could not be verified". */
       details?: string | null;
@@ -6030,17 +6048,17 @@ export interface components {
       document?: components["schemas"]["legal_entity_person_verification_document"];
       /** The state of verification for the person. Possible values are `unverified`, `pending`, or `verified`. */
       status: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     legal_entity_person_verification_document: {
       /** The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. */
-      back?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
+      back?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
       /** A user-displayable string describing the verification state of this document. For example, if a document is uploaded and the picture is too fuzzy, this may say "Identity document is too unclear to read". */
       details?: string | null;
       /** One of `document_corrupt`, `document_country_not_supported`, `document_expired`, `document_failed_copy`, `document_failed_other`, `document_failed_test_mode`, `document_fraudulent`, `document_failed_greyscale`, `document_incomplete`, `document_invalid`, `document_manipulated`, `document_missing_back`, `document_missing_front`, `document_not_readable`, `document_not_uploaded`, `document_photo_mismatch`, `document_too_large`, or `document_type_not_supported`. A machine-readable code specifying the verification state for this document. */
       details_code?: string | null;
       /** The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. */
-      front?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      front?: ((Partial<string> & Partial<components["schemas"]["file"]>) & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     light_account_logout: { [key: string]: unknown };
     line_item: {
       /** The amount, in %s. */
@@ -6063,7 +6081,7 @@ export interface components {
       object: "line_item";
       period: components["schemas"]["invoice_line_item_period"];
       /** The plan of the subscription, if the line item is a subscription or a proration. */
-      plan?: (Partial<components["schemas"]["plan"]> & { [key: string]: any }) | null;
+      plan?: (Partial<components["schemas"]["plan"]> & { [key: string]: unknown }) | null;
       /** Whether this is a proration. */
       proration: boolean;
       /** The quantity of the subscription, if the line item is a subscription or a proration. */
@@ -6078,7 +6096,7 @@ export interface components {
       tax_rates?: components["schemas"]["tax_rate"][] | null;
       /** A string identifying the type of the source of this line item, either an `invoiceitem` or a `subscription`. */
       type: "invoiceitem" | "subscription";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     login_link: {
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -6086,7 +6104,7 @@ export interface components {
       object: "login_link";
       /** The URL for the login link. */
       url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A Mandate is a record of the permission a customer has given you to debit their payment method. */
     mandate: {
       customer_acceptance: components["schemas"]["customer_acceptance"];
@@ -6098,18 +6116,18 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "mandate";
       /** ID of the payment method associated with this mandate. */
-      payment_method: (Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: any };
+      payment_method: (Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: unknown };
       payment_method_details: components["schemas"]["mandate_payment_method_details"];
       single_use?: components["schemas"]["mandate_single_use"];
       /** The status of the mandate, which indicates whether it can be used to initiate a payment. */
       status: "active" | "inactive" | "pending";
       /** The type of the mandate. */
       type: "multi_use" | "single_use";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     mandate_au_becs_debit: {
       /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
       url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     mandate_multi_use: { [key: string]: unknown };
     mandate_payment_method_details: {
       au_becs_debit?: components["schemas"]["mandate_au_becs_debit"];
@@ -6117,38 +6135,38 @@ export interface components {
       sepa_debit?: components["schemas"]["mandate_sepa_debit"];
       /** The type of the payment method associated with this mandate. An additional hash is included on `payment_method_details` with a name matching this value. It contains mandate information specific to the payment method. */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     mandate_sepa_debit: {
       /** The unique reference of the mandate. */
       reference: string;
       /** The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively. */
       url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     mandate_single_use: {
       /** On a single use mandate, the amount of the payment. */
       amount: number;
       /** On a single use mandate, the currency of the payment. */
       currency: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     notification_event_data: {
       /** Object containing the API resource relevant to the event. For example, an `invoice.created` event will have a full [invoice object](https://stripe.com/docs/api#invoice_object) as the value of the object key. */
       object: { [key: string]: unknown };
       /** Object containing the names of the attributes that have changed, and their previous values (sent along only with *.updated events). */
       previous_attributes?: { [key: string]: unknown };
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     notification_event_request: {
       /** ID of the API request that caused the event. If null, the event was automatic (e.g., Stripe's automatic subscription handling). Request logs are available in the [dashboard](https://dashboard.stripe.com/logs), but currently not in the API. */
       id?: string | null;
       /** The idempotency key transmitted during the request, if any. *Note: This property is populated only for events on or after May 23, 2017*. */
       idempotency_key?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     offline_acceptance: { [key: string]: unknown };
     online_acceptance: {
       /** The IP address from which the Mandate was accepted by the customer. */
       ip_address?: string | null;
       /** The user agent of the browser from which the Mandate was accepted by the customer. */
       user_agent?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Order objects are created to handle end customers' purchases of previously
      * defined [products](https://stripe.com/docs/api#products). You can create, retrieve, and pay individual orders, as well
@@ -6166,7 +6184,7 @@ export interface components {
       /** A fee in cents that will be applied to the order and transferred to the application owner’s Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees documentation. */
       application_fee?: number | null;
       /** The ID of the payment used to pay for the order. Present if the order status is `paid`, `fulfilled`, or `refunded`. */
-      charge?: ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any }) | null;
+      charge?: ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown }) | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -6175,7 +6193,7 @@ export interface components {
       customer?:
         | ((Partial<string> &
             Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown })
         | null;
       /** The email address of the customer placing the order. */
       email?: string | null;
@@ -6202,23 +6220,23 @@ export interface components {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
       /** The shipping method that is currently selected for this order, if any. If present, it is equal to one of the `id`s of shipping methods in the `shipping_methods` array. At order creation time, if there are multiple shipping methods, Stripe will automatically selected the first method. */
       selected_shipping_method?: string | null;
       /** The shipping address for the order. Present if the order is for goods to be shipped. */
-      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: any }) | null;
+      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: unknown }) | null;
       /** A list of supported shipping methods for this order. The desired shipping method can be specified either by updating the order, or when paying it. */
       shipping_methods?: components["schemas"]["shipping_method"][] | null;
       /** Current order status. One of `created`, `paid`, `canceled`, `fulfilled`, or `returned`. More details in the [Orders Guide](https://stripe.com/docs/orders/guide#understanding-order-statuses). */
       status: string;
       /** The timestamps at which the order status was updated. */
-      status_transitions?: (Partial<components["schemas"]["status_transitions"]> & { [key: string]: any }) | null;
+      status_transitions?: (Partial<components["schemas"]["status_transitions"]> & { [key: string]: unknown }) | null;
       /** Time at which the object was last updated. Measured in seconds since the Unix epoch. */
       updated?: number | null;
       /** The user's order ID if it is different from the Stripe order ID. */
       upstream_id?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A representation of the constituent items of any given order. Can be used to
      * represent [SKUs](https://stripe.com/docs/api#skus), shipping costs, or taxes owed on the order.
@@ -6235,12 +6253,12 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "order_item";
       /** The ID of the associated object for this line item. Expandable if not null (e.g., expandable to a SKU). */
-      parent?: ((Partial<string> & Partial<components["schemas"]["sku"]>) & { [key: string]: any }) | null;
+      parent?: ((Partial<string> & Partial<components["schemas"]["sku"]>) & { [key: string]: unknown }) | null;
       /** A positive integer representing the number of instances of `parent` that are included in this order item. Applicable/present only if `type` is `sku`. */
       quantity?: number | null;
       /** The type of line item. One of `sku`, `tax`, `shipping`, or `discount`. */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A return represents the full or partial return of a number of [order items](https://stripe.com/docs/api#order_items).
      * Returns always belong to an order, and may optionally contain a refund.
@@ -6263,10 +6281,10 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "order_return";
       /** The order that this return includes items from. */
-      order?: ((Partial<string> & Partial<components["schemas"]["order"]>) & { [key: string]: any }) | null;
+      order?: ((Partial<string> & Partial<components["schemas"]["order"]>) & { [key: string]: unknown }) | null;
       /** The ID of the refund issued for this return. */
-      refund?: ((Partial<string> & Partial<components["schemas"]["refund"]>) & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      refund?: ((Partial<string> & Partial<components["schemas"]["refund"]>) & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     package_dimensions: {
       /** Height, in inches. */
       height: number;
@@ -6276,7 +6294,7 @@ export interface components {
       weight: number;
       /** Width, in inches. */
       width: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A PaymentIntent guides you through the process of collecting a payment from your customer.
      * We recommend that you create exactly one PaymentIntent for each order or
@@ -6298,7 +6316,9 @@ export interface components {
       /** Amount that was collected by this PaymentIntent. */
       amount_received?: number;
       /** ID of the Connect application that created the PaymentIntent. */
-      application?: ((Partial<string> & Partial<components["schemas"]["application"]>) & { [key: string]: any }) | null;
+      application?:
+        | ((Partial<string> & Partial<components["schemas"]["application"]>) & { [key: string]: unknown })
+        | null;
       /** The amount of the application fee (if any) for the resulting payment. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
       application_fee_amount?: number | null;
       /** Populated when `status` is `canceled`, this is the time at which the PaymentIntent was canceled. Measured in seconds since the Unix epoch. */
@@ -6327,7 +6347,7 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /**
        * The client secret of this PaymentIntent. Used for client-side retrieval using a publishable key.
        *
@@ -6351,40 +6371,42 @@ export interface components {
       customer?:
         | ((Partial<string> &
             Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown })
         | null;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
       description?: string | null;
       /** Unique identifier for the object. */
       id: string;
       /** ID of the invoice that created this PaymentIntent, if it exists. */
-      invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: any }) | null;
+      invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: unknown }) | null;
       /** The payment error encountered in the previous PaymentIntent confirmation. It will be cleared if the PaymentIntent is later updated for any reason. */
-      last_payment_error?: (Partial<components["schemas"]["api_errors"]> & { [key: string]: any }) | null;
+      last_payment_error?: (Partial<components["schemas"]["api_errors"]> & { [key: string]: unknown }) | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. For more information, see the [documentation](https://stripe.com/docs/payments/payment-intents/creating-payment-intents#storing-information-in-metadata). */
       metadata?: { [key: string]: string };
       /** If present, this property tells you what actions you need to take in order for your customer to fulfill a payment using the provided source. */
-      next_action?: (Partial<components["schemas"]["payment_intent_next_action"]> & { [key: string]: any }) | null;
+      next_action?: (Partial<components["schemas"]["payment_intent_next_action"]> & { [key: string]: unknown }) | null;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "payment_intent";
       /** The account (if any) for which the funds of the PaymentIntent are intended. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
-      on_behalf_of?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any }) | null;
+      on_behalf_of?:
+        | ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown })
+        | null;
       /** ID of the payment method used in this PaymentIntent. */
       payment_method?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: unknown })
         | null;
       /** Payment-method-specific configuration for this PaymentIntent. */
       payment_method_options?:
-        | (Partial<components["schemas"]["payment_intent_payment_method_options"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_intent_payment_method_options"]> & { [key: string]: unknown })
         | null;
       /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
       payment_method_types: string[];
       /** Email address that the receipt for the resulting payment will be sent to. */
       receipt_email?: string | null;
       /** ID of the review associated with this PaymentIntent, if any. */
-      review?: ((Partial<string> & Partial<components["schemas"]["review"]>) & { [key: string]: any }) | null;
+      review?: ((Partial<string> & Partial<components["schemas"]["review"]>) & { [key: string]: unknown }) | null;
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
@@ -6394,7 +6416,7 @@ export interface components {
        */
       setup_future_usage?: ("off_session" | "on_session") | null;
       /** Shipping information for this PaymentIntent. */
-      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: any }) | null;
+      shipping?: (Partial<components["schemas"]["shipping"]> & { [key: string]: unknown }) | null;
       /** For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
       statement_descriptor?: string | null;
       /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
@@ -6409,26 +6431,26 @@ export interface components {
         | "requires_payment_method"
         | "succeeded";
       /** The data with which to automatically create a Transfer when the payment is finalized. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
-      transfer_data?: (Partial<components["schemas"]["transfer_data"]> & { [key: string]: any }) | null;
+      transfer_data?: (Partial<components["schemas"]["transfer_data"]> & { [key: string]: unknown }) | null;
       /** A string that identifies the resulting payment as part of a group. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
       transfer_group?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_intent_next_action: {
       redirect_to_url?: components["schemas"]["payment_intent_next_action_redirect_to_url"];
       /** Type of the next action to perform, one of `redirect_to_url` or `use_stripe_sdk`. */
       type: string;
       /** When confirming a PaymentIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js. */
       use_stripe_sdk?: { [key: string]: unknown };
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_intent_next_action_redirect_to_url: {
       /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
       return_url?: string | null;
       /** The URL you must redirect your customer to in order to authenticate the payment. */
       url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_intent_payment_method_options: {
       card?: components["schemas"]["payment_intent_payment_method_options_card"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_intent_payment_method_options_card: {
       /**
        * Installment details for this payment (Mexico only).
@@ -6436,11 +6458,11 @@ export interface components {
        * For more information, see the [installments integration guide](https://stripe.com/docs/payments/installments).
        */
       installments?:
-        | (Partial<components["schemas"]["payment_method_options_card_installments"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_method_options_card_installments"]> & { [key: string]: unknown })
         | null;
       /** We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine. */
       request_three_d_secure?: ("any" | "automatic" | "challenge_only") | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * PaymentMethod objects represent your customer's payment instruments.
      * They can be used with [PaymentIntents](https://stripe.com/docs/payments/payment-intents) to collect payments or saved to
@@ -6456,7 +6478,7 @@ export interface components {
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** The ID of the Customer to which this PaymentMethod is saved. This will not be set when the PaymentMethod has not been saved to a Customer. */
-      customer?: ((Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: any }) | null;
+      customer?: ((Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: unknown }) | null;
       fpx?: components["schemas"]["payment_method_fpx"];
       /** Unique identifier for the object. */
       id: string;
@@ -6470,7 +6492,7 @@ export interface components {
       sepa_debit?: components["schemas"]["payment_method_sepa_debit"];
       /** The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type. */
       type: "au_becs_debit" | "card" | "fpx" | "ideal" | "sepa_debit";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_au_becs_debit: {
       /** Six-digit number identifying bank and branch associated with this bank account. */
       bsb_number?: string | null;
@@ -6478,12 +6500,12 @@ export interface components {
       fingerprint?: string | null;
       /** Last four digits of the bank account number. */
       last4?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_card: {
       /** Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
       brand: string;
       /** Checks on Card address and CVC if provided. */
-      checks?: (Partial<components["schemas"]["payment_method_card_checks"]> & { [key: string]: any }) | null;
+      checks?: (Partial<components["schemas"]["payment_method_card_checks"]> & { [key: string]: unknown }) | null;
       /** Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected. */
       country?: string | null;
       /** Two-digit number representing the card's expiration month. */
@@ -6496,15 +6518,17 @@ export interface components {
       funding: string;
       /** Details of the original PaymentMethod that created this object. */
       generated_from?:
-        | (Partial<components["schemas"]["payment_method_card_generated_card"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_method_card_generated_card"]> & { [key: string]: unknown })
         | null;
       /** The last four digits of the card. */
       last4: string;
       /** Contains details on how this Card maybe be used for 3D Secure authentication. */
-      three_d_secure_usage?: (Partial<components["schemas"]["three_d_secure_usage"]> & { [key: string]: any }) | null;
+      three_d_secure_usage?:
+        | (Partial<components["schemas"]["three_d_secure_usage"]> & { [key: string]: unknown })
+        | null;
       /** If this Card is part of a card wallet, this contains the details of the card wallet. */
-      wallet?: (Partial<components["schemas"]["payment_method_card_wallet"]> & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      wallet?: (Partial<components["schemas"]["payment_method_card_wallet"]> & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     payment_method_card_checks: {
       /** If a address line1 was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
       address_line1_check?: string | null;
@@ -6512,15 +6536,15 @@ export interface components {
       address_postal_code_check?: string | null;
       /** If a CVC was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
       cvc_check?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_card_generated_card: {
       /** The charge that created this object. */
       charge?: string | null;
       /** Transaction-specific details of the payment method used in the payment. */
       payment_method_details?:
-        | (Partial<components["schemas"]["payment_method_details"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_method_details"]> & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_card_present: { [key: string]: unknown };
     payment_method_card_wallet: {
       amex_express_checkout?: components["schemas"]["payment_method_card_wallet_amex_express_checkout"];
@@ -6533,31 +6557,31 @@ export interface components {
       /** The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`, `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name matching this value. It contains additional information specific to the card wallet type. */
       type: "amex_express_checkout" | "apple_pay" | "google_pay" | "masterpass" | "samsung_pay" | "visa_checkout";
       visa_checkout?: components["schemas"]["payment_method_card_wallet_visa_checkout"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_card_wallet_amex_express_checkout: { [key: string]: unknown };
     payment_method_card_wallet_apple_pay: { [key: string]: unknown };
     payment_method_card_wallet_google_pay: { [key: string]: unknown };
     payment_method_card_wallet_masterpass: {
       /** Owner's verified billing address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      billing_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      billing_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       email?: string | null;
       /** Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       name?: string | null;
       /** Owner's verified shipping address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      shipping_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      shipping_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     payment_method_card_wallet_samsung_pay: { [key: string]: unknown };
     payment_method_card_wallet_visa_checkout: {
       /** Owner's verified billing address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      billing_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      billing_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       email?: string | null;
       /** Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       name?: string | null;
       /** Owner's verified shipping address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      shipping_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      shipping_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     payment_method_details: {
       ach_credit_transfer?: components["schemas"]["payment_method_details_ach_credit_transfer"];
       ach_debit?: components["schemas"]["payment_method_details_ach_debit"];
@@ -6583,7 +6607,7 @@ export interface components {
        */
       type: string;
       wechat?: components["schemas"]["payment_method_details_wechat"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_ach_credit_transfer: {
       /** Account number to transfer funds to. */
       account_number?: string | null;
@@ -6593,7 +6617,7 @@ export interface components {
       routing_number?: string | null;
       /** SWIFT code of the bank associated with the routing number. */
       swift_code?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_ach_debit: {
       /** Type of entity that holds the account. This can be either `individual` or `company`. */
       account_holder_type?: ("company" | "individual") | null;
@@ -6607,7 +6631,7 @@ export interface components {
       last4?: string | null;
       /** Routing transit number of the bank account. */
       routing_number?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_alipay: { [key: string]: unknown };
     payment_method_details_au_becs_debit: {
       /** Bank-State-Branch number of the bank account. */
@@ -6618,7 +6642,7 @@ export interface components {
       last4?: string | null;
       /** ID of the mandate used to make this payment. */
       mandate?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_bancontact: {
       /** Bank code of bank associated with the bank account. */
       bank_code?: string | null;
@@ -6638,12 +6662,14 @@ export interface components {
        * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
        */
       verified_name?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_card: {
       /** Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
       brand?: string | null;
       /** Check results by Card networks on Card address and CVC at time of payment. */
-      checks?: (Partial<components["schemas"]["payment_method_details_card_checks"]> & { [key: string]: any }) | null;
+      checks?:
+        | (Partial<components["schemas"]["payment_method_details_card_checks"]> & { [key: string]: unknown })
+        | null;
       /** Two-letter ISO code representing the country of the card. You could use this attribute to get a sense of the international breakdown of cards you've collected. */
       country?: string | null;
       /** Two-digit number representing the card's expiration month. */
@@ -6660,17 +6686,19 @@ export interface components {
        * For more information, see the [installments integration guide](https://stripe.com/docs/payments/installments).
        */
       installments?:
-        | (Partial<components["schemas"]["payment_method_details_card_installments"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_method_details_card_installments"]> & { [key: string]: unknown })
         | null;
       /** The last four digits of the card. */
       last4?: string | null;
       /** Identifies which network this charge was processed on. Can be `amex`, `diners`, `discover`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
       network?: string | null;
       /** Populated if this transaction used 3D Secure authentication. */
-      three_d_secure?: (Partial<components["schemas"]["three_d_secure_details"]> & { [key: string]: any }) | null;
+      three_d_secure?: (Partial<components["schemas"]["three_d_secure_details"]> & { [key: string]: unknown }) | null;
       /** If this Card is part of a card wallet, this contains the details of the card wallet. */
-      wallet?: (Partial<components["schemas"]["payment_method_details_card_wallet"]> & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      wallet?:
+        | (Partial<components["schemas"]["payment_method_details_card_wallet"]> & { [key: string]: unknown })
+        | null;
+    } & { [key: string]: unknown };
     payment_method_details_card_checks: {
       /** If a address line1 was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
       address_line1_check?: string | null;
@@ -6678,13 +6706,13 @@ export interface components {
       address_postal_code_check?: string | null;
       /** If a CVC was provided, results of the check, one of `pass`, `fail`, `unavailable`, or `unchecked`. */
       cvc_check?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_card_installments: {
       /** Installment plan selected for the payment. */
       plan?:
-        | (Partial<components["schemas"]["payment_method_details_card_installments_plan"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_method_details_card_installments_plan"]> & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_card_installments_plan: {
       /** For `fixed_count` installment plans, this is the number of installment payments your customer will make to their credit card. */
       count?: number | null;
@@ -6695,7 +6723,7 @@ export interface components {
       interval?: "month" | null;
       /** Type of installment plan, one of `fixed_count`. */
       type: "fixed_count";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_card_present: {
       /** Card brand. Can be `amex`, `diners`, `discover`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
       brand?: string | null;
@@ -6723,9 +6751,9 @@ export interface components {
       read_method?: string | null;
       /** A collection of fields required to be displayed on receipts. Only required for EMV transactions. */
       receipt?:
-        | (Partial<components["schemas"]["payment_method_details_card_present_receipt"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_method_details_card_present_receipt"]> & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_card_present_receipt: {
       /** EMV tag 9F26, cryptogram generated by the integrated circuit chip. */
       application_cryptogram?: string | null;
@@ -6743,7 +6771,7 @@ export interface components {
       terminal_verification_results?: string | null;
       /** An indication of various EMV functions performed during the transaction. */
       transaction_status_information?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_card_wallet: {
       amex_express_checkout?: components["schemas"]["payment_method_details_card_wallet_amex_express_checkout"];
       apple_pay?: components["schemas"]["payment_method_details_card_wallet_apple_pay"];
@@ -6755,38 +6783,38 @@ export interface components {
       /** The type of the card wallet, one of `amex_express_checkout`, `apple_pay`, `google_pay`, `masterpass`, `samsung_pay`, or `visa_checkout`. An additional hash is included on the Wallet subhash with a name matching this value. It contains additional information specific to the card wallet type. */
       type: "amex_express_checkout" | "apple_pay" | "google_pay" | "masterpass" | "samsung_pay" | "visa_checkout";
       visa_checkout?: components["schemas"]["payment_method_details_card_wallet_visa_checkout"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_card_wallet_amex_express_checkout: { [key: string]: unknown };
     payment_method_details_card_wallet_apple_pay: { [key: string]: unknown };
     payment_method_details_card_wallet_google_pay: { [key: string]: unknown };
     payment_method_details_card_wallet_masterpass: {
       /** Owner's verified billing address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      billing_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      billing_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       email?: string | null;
       /** Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       name?: string | null;
       /** Owner's verified shipping address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      shipping_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      shipping_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     payment_method_details_card_wallet_samsung_pay: { [key: string]: unknown };
     payment_method_details_card_wallet_visa_checkout: {
       /** Owner's verified billing address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      billing_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      billing_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** Owner's verified email. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       email?: string | null;
       /** Owner's verified full name. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       name?: string | null;
       /** Owner's verified shipping address. Values are verified or provided by the wallet directly (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      shipping_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      shipping_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     payment_method_details_eps: {
       /**
        * Owner's verified full name. Values are verified or provided by EPS directly
        * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
        */
       verified_name?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_fpx: {
       /** The customer's bank. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, or `pb_enterprise`. */
       bank:
@@ -6812,7 +6840,7 @@ export interface components {
         | "uob";
       /** Unique transaction id generated by FPX for every request from the merchant */
       transaction_id?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_giropay: {
       /** Bank code of bank associated with the bank account. */
       bank_code?: string | null;
@@ -6825,7 +6853,7 @@ export interface components {
        * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
        */
       verified_name?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_ideal: {
       /** The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `sns_bank`, `triodos_bank`, or `van_lanschot`. */
       bank?:
@@ -6868,14 +6896,14 @@ export interface components {
        * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
        */
       verified_name?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_klarna: { [key: string]: unknown };
     payment_method_details_multibanco: {
       /** Entity number associated with this Multibanco payment. */
       entity?: string | null;
       /** Reference number associated with this Multibanco payment. */
       reference?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_p24: {
       /** Unique reference for this Przelewy24 payment. */
       reference?: string | null;
@@ -6884,7 +6912,7 @@ export interface components {
        * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
        */
       verified_name?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_sepa_debit: {
       /** Bank code of bank associated with the bank account. */
       bank_code?: string | null;
@@ -6898,7 +6926,7 @@ export interface components {
       last4?: string | null;
       /** ID of the mandate used to make this payment. */
       mandate?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_sofort: {
       /** Bank code of bank associated with the bank account. */
       bank_code?: string | null;
@@ -6915,7 +6943,7 @@ export interface components {
        * (if supported) at the time of authorization or settlement. They cannot be set or mutated.
        */
       verified_name?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_details_stripe_account: { [key: string]: unknown };
     payment_method_details_wechat: { [key: string]: unknown };
     payment_method_fpx: {
@@ -6941,7 +6969,7 @@ export interface components {
         | "rhb"
         | "standard_chartered"
         | "uob";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_ideal: {
       /** The customer's bank, if provided. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `sns_bank`, `triodos_bank`, or `van_lanschot`. */
       bank?:
@@ -6977,7 +7005,7 @@ export interface components {
             | "TRIONL2U"
           )
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_options_card_installments: {
       /** Installment plans that may be selected for this PaymentIntent. */
       available_plans?: components["schemas"]["payment_method_details_card_installments_plan"][] | null;
@@ -6985,9 +7013,9 @@ export interface components {
       enabled: boolean;
       /** Installment plan selected for this PaymentIntent. */
       plan?:
-        | (Partial<components["schemas"]["payment_method_details_card_installments_plan"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["payment_method_details_card_installments_plan"]> & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_method_sepa_debit: {
       /** Bank code of bank associated with the bank account. */
       bank_code?: string | null;
@@ -6999,7 +7027,7 @@ export interface components {
       fingerprint?: string | null;
       /** Last four characters of the IBAN. */
       last4?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_pages_payment_page_resources_shipping_address_collection: {
       /**
        * An array of two-letter ISO country codes representing which countries Checkout should provide as options for
@@ -7244,13 +7272,13 @@ export interface components {
         | "ZW"
         | "ZZ"
       )[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     payment_source: (Partial<components["schemas"]["account"]> &
       Partial<components["schemas"]["alipay_account"]> &
       Partial<components["schemas"]["bank_account"]> &
       Partial<components["schemas"]["bitcoin_receiver"]> &
       Partial<components["schemas"]["card"]> &
-      Partial<components["schemas"]["source"]>) & { [key: string]: any };
+      Partial<components["schemas"]["source"]>) & { [key: string]: unknown };
     /**
      * A `Payout` object is created when you receive funds from Stripe, or when you
      * initiate a payout to either a bank account or debit card of a [connected
@@ -7270,7 +7298,7 @@ export interface components {
       automatic: boolean;
       /** ID of the balance transaction that describes the impact of this payout on your account balance. */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -7284,11 +7312,11 @@ export interface components {
             Partial<components["schemas"]["bank_account"]> &
             Partial<components["schemas"]["card"]> &
             Partial<components["schemas"]["deleted_bank_account"]> &
-            Partial<components["schemas"]["deleted_card"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_card"]>) & { [key: string]: unknown })
         | null;
       /** If the payout failed or was canceled, this will be the ID of the balance transaction that reversed the initial balance transaction, and puts the funds from the failed payout back in your balance. */
       failure_balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** Error code explaining reason for payout failure if available. See [Types of payout failures](https://stripe.com/docs/api#payout_failures) for a list of failure codes. */
       failure_code?: string | null;
@@ -7312,13 +7340,13 @@ export interface components {
       status: string;
       /** Can be `bank_account` or `card`. */
       type: "bank_account" | "card";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     period: {
       /** The end date of this usage period. All usage up to and including this point in time is included. */
       end?: number | null;
       /** The start date of this usage period. All usage after this point in time is included. */
       start?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * This is an object representing a person associated with a Stripe account.
      *
@@ -7327,8 +7355,10 @@ export interface components {
     person: {
       account: string;
       address?: components["schemas"]["address"];
-      address_kana?: (Partial<components["schemas"]["legal_entity_japan_address"]> & { [key: string]: any }) | null;
-      address_kanji?: (Partial<components["schemas"]["legal_entity_japan_address"]> & { [key: string]: any }) | null;
+      address_kana?: (Partial<components["schemas"]["legal_entity_japan_address"]> & { [key: string]: unknown }) | null;
+      address_kanji?:
+        | (Partial<components["schemas"]["legal_entity_japan_address"]> & { [key: string]: unknown })
+        | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       dob?: components["schemas"]["legal_entity_dob"];
@@ -7350,10 +7380,10 @@ export interface components {
       object: "person";
       phone?: string | null;
       relationship?: components["schemas"]["person_relationship"];
-      requirements?: (Partial<components["schemas"]["person_requirements"]> & { [key: string]: any }) | null;
+      requirements?: (Partial<components["schemas"]["person_requirements"]> & { [key: string]: unknown }) | null;
       ssn_last_4_provided?: boolean;
       verification?: components["schemas"]["legal_entity_person_verification"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     person_relationship: {
       /** Whether the person is a director of the account's legal entity. Currently only required for accounts in the EU. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations. */
       director?: boolean | null;
@@ -7367,7 +7397,7 @@ export interface components {
       representative?: boolean | null;
       /** The person's title (e.g., CEO, Support Engineer). */
       title?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     person_requirements: {
       /** Fields that need to be collected to keep the person's account enabled. If not collected by the account's `current_deadline`, these fields appear in `past_due` as well, and the account is disabled. */
       currently_due: string[];
@@ -7379,7 +7409,7 @@ export interface components {
       past_due: string[];
       /** Fields that may become required depending on the results of verification or review. An empty array unless an asynchronous verification is pending. If verification fails, the fields in this array become required and move to `currently_due` or `past_due`. */
       pending_verification: string[];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Plans define the base price, currency, and billing cycle for subscriptions.
      * For example, you might have a $5/month plan
@@ -7421,19 +7451,19 @@ export interface components {
       product?:
         | ((Partial<string> &
             Partial<components["schemas"]["product"]> &
-            Partial<components["schemas"]["deleted_product"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_product"]>) & { [key: string]: unknown })
         | null;
       /** Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`. */
       tiers?: components["schemas"]["plan_tier"][] | null;
       /** Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows. */
       tiers_mode?: ("graduated" | "volume") | null;
       /** Apply a transformation to the reported usage or set quantity before computing the amount billed. Cannot be combined with `tiers`. */
-      transform_usage?: (Partial<components["schemas"]["transform_usage"]> & { [key: string]: any }) | null;
+      transform_usage?: (Partial<components["schemas"]["transform_usage"]> & { [key: string]: unknown }) | null;
       /** Default number of trial days when subscribing a customer to this plan using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan). */
       trial_period_days?: number | null;
       /** Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`. */
       usage_type: "licensed" | "metered";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     plan_tier: {
       /** Price for the entire tier. */
       flat_amount?: number | null;
@@ -7445,7 +7475,7 @@ export interface components {
       unit_amount_decimal?: string | null;
       /** Up to and including to this quantity will be contained in the tier. */
       up_to?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     platform_tax_fee: {
       /** The Connected account that incurred this charge. */
       account: string;
@@ -7457,7 +7487,7 @@ export interface components {
       source_transaction: string;
       /** The type of tax (VAT). */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Store representations of products you sell in `Product` objects, used in
      * conjunction with [SKUs](https://stripe.com/docs/api#skus). Products may be physical goods, to be shipped, or
@@ -7494,7 +7524,7 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "product";
       /** The dimensions of this product for shipping purposes. A SKU associated with this product can override this value by having its own `package_dimensions`. Only applicable to products of `type=good`. */
-      package_dimensions?: (Partial<components["schemas"]["package_dimensions"]> & { [key: string]: any }) | null;
+      package_dimensions?: (Partial<components["schemas"]["package_dimensions"]> & { [key: string]: unknown }) | null;
       /** Whether this product is a shipped good. Only applicable to products of `type=good`. */
       shippable?: boolean | null;
       /** Extra information about a product which will appear on your customer's credit card statement. In the case that multiple products are billed at once, the first statement descriptor will be used. */
@@ -7507,7 +7537,7 @@ export interface components {
       updated: number;
       /** A URL of a publicly-accessible webpage for this product. Only applicable to products of `type=good`. */
       url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * An early fraud warning indicates that the card issuer has notified us that a
      * charge may be fraudulent.
@@ -7518,7 +7548,7 @@ export interface components {
       /** An EFW is actionable if it has not received a dispute and has not been fully refunded. You may wish to proactively refund a charge that receives an EFW, in order to avoid receiving a dispute later. */
       actionable: boolean;
       /** ID of the charge this early fraud warning is for, optionally expanded. */
-      charge: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any };
+      charge: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown };
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** The type of fraud labelled by the issuer. One of `card_never_received`, `fraudulent_card_application`, `made_with_counterfeit_card`, `made_with_lost_card`, `made_with_stolen_card`, `misc`, `unauthorized_use_of_card`. */
@@ -7529,7 +7559,7 @@ export interface components {
       livemode: boolean;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "radar.early_fraud_warning";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Value lists allow you to group values together which can then be referenced in rules.
      *
@@ -7563,7 +7593,7 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
@@ -7572,7 +7602,7 @@ export interface components {
       name: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "radar.value_list";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Value list items allow you to add specific values to a given Radar value list, which can then be used in rules.
      *
@@ -7593,7 +7623,7 @@ export interface components {
       value: string;
       /** The identifier of the value list this item belongs to. */
       value_list: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     radar_review_resource_location: {
       /** The city where the payment originated. */
       city?: string | null;
@@ -7605,7 +7635,7 @@ export interface components {
       longitude?: number | null;
       /** The state/county/province/region where the payment originated. */
       region?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     radar_review_resource_session: {
       /** The browser used in this browser session (e.g., `Chrome`). */
       browser?: string | null;
@@ -7615,7 +7645,7 @@ export interface components {
       platform?: string | null;
       /** The version for the browser session (e.g., `61.0.3163.100`). */
       version?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * With `Recipient` objects, you can transfer money from your Stripe account to a
      * third-party bank account or debit card. The API allows you to create, delete,
@@ -7631,7 +7661,7 @@ export interface components {
      */
     recipient: {
       /** Hash describing the current account on the recipient, if there is one. */
-      active_account?: (Partial<components["schemas"]["bank_account"]> & { [key: string]: any }) | null;
+      active_account?: (Partial<components["schemas"]["bank_account"]> & { [key: string]: unknown }) | null;
       cards?:
         | ({
             data: components["schemas"]["card"][];
@@ -7641,12 +7671,12 @@ export interface components {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any })
+          } & { [key: string]: unknown })
         | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** The default card to use for creating transfers to this recipient. */
-      default_card?: ((Partial<string> & Partial<components["schemas"]["card"]>) & { [key: string]: any }) | null;
+      default_card?: ((Partial<string> & Partial<components["schemas"]["card"]>) & { [key: string]: unknown }) | null;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
       description?: string | null;
       email?: string | null;
@@ -7657,15 +7687,15 @@ export interface components {
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
       metadata: { [key: string]: string };
       /** The ID of the [Custom account](https://stripe.com/docs/connect/custom-accounts) this recipient was migrated to. If set, the recipient can no longer be updated, nor can transfers be made to it: use the Custom account instead. */
-      migrated_to?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any }) | null;
+      migrated_to?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown }) | null;
       /** Full, legal name of the recipient. */
       name?: string | null;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "recipient";
-      rolled_back_from?: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any };
+      rolled_back_from?: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown };
       /** Type of the recipient, one of `individual` or `corporation`. */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * `Refund` objects allow you to refund a charge that has previously been created
      * but not yet refunded. Funds will be refunded to the credit or debit card that
@@ -7678,10 +7708,10 @@ export interface components {
       amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** ID of the charge that was refunded. */
-      charge?: ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any }) | null;
+      charge?: ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown }) | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -7690,7 +7720,7 @@ export interface components {
       description?: string;
       /** If the refund failed, this balance transaction describes the adjustment made on your account balance that reverses the initial balance transaction. */
       failure_balance_transaction?: (Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & {
-        [key: string]: any;
+        [key: string]: unknown;
       };
       /** If the refund failed, the reason for refund failure if known. Possible values are `lost_or_stolen_card`, `expired_or_canceled_card`, or `unknown`. */
       failure_reason?: string;
@@ -7702,7 +7732,7 @@ export interface components {
       object: "refund";
       /** ID of the PaymentIntent that was refunded. */
       payment_intent?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: unknown })
         | null;
       /** Reason for the refund, either user-provided (`duplicate`, `fraudulent`, or `requested_by_customer`) or generated by Stripe internally (`expired_uncaptured_charge`). */
       reason?: string | null;
@@ -7710,15 +7740,15 @@ export interface components {
       receipt_number?: string | null;
       /** The transfer reversal that is associated with the refund. Only present if the charge came from another Stripe account. See the Connect documentation for details. */
       source_transfer_reversal?:
-        | ((Partial<string> & Partial<components["schemas"]["transfer_reversal"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["transfer_reversal"]>) & { [key: string]: unknown })
         | null;
       /** Status of the refund. For credit card refunds, this can be `pending`, `succeeded`, or `failed`. For other types of refunds, it can be `pending`, `succeeded`, `failed`, or `canceled`. Refer to our [refunds](https://stripe.com/docs/refunds#failed-refunds) documentation for more details. */
       status?: string | null;
       /** If the accompanying transfer was reversed, the transfer reversal object. Only applicable if the charge was created using the destination parameter. */
       transfer_reversal?:
-        | ((Partial<string> & Partial<components["schemas"]["transfer_reversal"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["transfer_reversal"]>) & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * The Report Run object represents an instance of a report type generated with
      * specific run parameters. Once the object is created, Stripe begins processing the report.
@@ -7751,7 +7781,7 @@ export interface components {
        * The file object representing the result of the report run (populated when
        *  `status=succeeded`).
        */
-      result?: (Partial<components["schemas"]["file"]> & { [key: string]: any }) | null;
+      result?: (Partial<components["schemas"]["file"]> & { [key: string]: unknown }) | null;
       /**
        * Status of this report run. This will be `pending` when the run is initially created.
        *  When the run finishes, this will be set to `succeeded` and the `result` field will be populated.
@@ -7763,7 +7793,7 @@ export interface components {
        *  `status=succeeded`). Measured in seconds since the Unix epoch.
        */
       succeeded_at?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * The Report Type resource corresponds to a particular type of report, such as
      * the "Activity summary" or "Itemized payouts" reports. These objects are
@@ -7792,7 +7822,7 @@ export interface components {
       updated: number;
       /** Version of the Report Type. Different versions report with the same ID will have the same purpose, but may take different run parameters or have different result schemas. */
       version: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     reserve_transaction: {
       amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
@@ -7803,7 +7833,7 @@ export interface components {
       id: string;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "reserve_transaction";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Reviews can be used to supplement automated fraud detection with human expertise.
      *
@@ -7814,7 +7844,7 @@ export interface components {
       /** The ZIP or postal code of the card used, if applicable. */
       billing_zip?: string | null;
       /** The charge associated with this review. */
-      charge?: ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any }) | null;
+      charge?: ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown }) | null;
       /** The reason the review was closed, or null if it has not yet been closed. One of `approved`, `refunded`, `refunded_as_fraud`, or `disputed`. */
       closed_reason?: ("approved" | "disputed" | "refunded" | "refunded_as_fraud") | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
@@ -7825,7 +7855,7 @@ export interface components {
       ip_address?: string | null;
       /** Information related to the location of the payment. Note that this information is an approximation and attempts to locate the nearest population center - it should not be used to determine a specific address. */
       ip_address_location?:
-        | (Partial<components["schemas"]["radar_review_resource_location"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["radar_review_resource_location"]> & { [key: string]: unknown })
         | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
@@ -7836,12 +7866,14 @@ export interface components {
       /** The reason the review was opened. One of `rule` or `manual`. */
       opened_reason: "manual" | "rule";
       /** The PaymentIntent ID associated with this review, if one exists. */
-      payment_intent?: (Partial<string> & Partial<components["schemas"]["payment_intent"]>) & { [key: string]: any };
+      payment_intent?: (Partial<string> & Partial<components["schemas"]["payment_intent"]>) & {
+        [key: string]: unknown;
+      };
       /** The reason the review is currently open or closed. One of `rule`, `manual`, `approved`, `refunded`, `refunded_as_fraud`, or `disputed`. */
       reason: string;
       /** Information related to the browsing session of the user who initiated the payment. */
-      session?: (Partial<components["schemas"]["radar_review_resource_session"]> & { [key: string]: any }) | null;
-    } & { [key: string]: any };
+      session?: (Partial<components["schemas"]["radar_review_resource_session"]> & { [key: string]: unknown }) | null;
+    } & { [key: string]: unknown };
     rule: {
       /** The action taken on the payment. */
       action: string;
@@ -7849,7 +7881,7 @@ export interface components {
       id: string;
       /** The predicate to evaluate the payment against. */
       predicate: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * If you have [scheduled a Sigma query](https://stripe.com/docs/sigma/scheduled-queries), you'll
      * receive a `sigma.scheduled_query_run.created` webhook each time the query
@@ -7863,7 +7895,7 @@ export interface components {
       data_load_time: number;
       error?: components["schemas"]["sigma_scheduled_query_run_error"];
       /** The file object representing the results of the query. */
-      file?: (Partial<components["schemas"]["file"]> & { [key: string]: any }) | null;
+      file?: (Partial<components["schemas"]["file"]> & { [key: string]: unknown }) | null;
       /** Unique identifier for the object. */
       id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
@@ -7878,7 +7910,7 @@ export interface components {
       status: string;
       /** Title of the query. */
       title: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A SetupIntent guides you through the process of setting up and saving a customer's payment credentials for future payments.
      * For example, you could use a SetupIntent to set up and save your customer's card without immediately collecting a payment.
@@ -7905,7 +7937,9 @@ export interface components {
      */
     setup_intent: {
       /** ID of the Connect application that created the SetupIntent. */
-      application?: ((Partial<string> & Partial<components["schemas"]["application"]>) & { [key: string]: any }) | null;
+      application?:
+        | ((Partial<string> & Partial<components["schemas"]["application"]>) & { [key: string]: unknown })
+        | null;
       /** Reason for cancellation of this SetupIntent, one of `abandoned`, `requested_by_customer`, or `duplicate`. */
       cancellation_reason?: ("abandoned" | "duplicate" | "requested_by_customer") | null;
       /**
@@ -7924,39 +7958,41 @@ export interface components {
       customer?:
         | ((Partial<string> &
             Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown })
         | null;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
       description?: string | null;
       /** Unique identifier for the object. */
       id: string;
       /** The error encountered in the previous SetupIntent confirmation. */
-      last_setup_error?: (Partial<components["schemas"]["api_errors"]> & { [key: string]: any }) | null;
+      last_setup_error?: (Partial<components["schemas"]["api_errors"]> & { [key: string]: unknown }) | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** ID of the multi use Mandate generated by the SetupIntent. */
-      mandate?: ((Partial<string> & Partial<components["schemas"]["mandate"]>) & { [key: string]: any }) | null;
+      mandate?: ((Partial<string> & Partial<components["schemas"]["mandate"]>) & { [key: string]: unknown }) | null;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
       metadata?: { [key: string]: string };
       /** If present, this property tells you what actions you need to take in order for your customer to continue payment setup. */
-      next_action?: (Partial<components["schemas"]["setup_intent_next_action"]> & { [key: string]: any }) | null;
+      next_action?: (Partial<components["schemas"]["setup_intent_next_action"]> & { [key: string]: unknown }) | null;
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "setup_intent";
       /** The account (if any) for which the setup is intended. */
-      on_behalf_of?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any }) | null;
+      on_behalf_of?:
+        | ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown })
+        | null;
       /** ID of the payment method used with this SetupIntent. */
       payment_method?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: unknown })
         | null;
       /** Payment-method-specific configuration for this SetupIntent. */
       payment_method_options?:
-        | (Partial<components["schemas"]["setup_intent_payment_method_options"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["setup_intent_payment_method_options"]> & { [key: string]: unknown })
         | null;
       /** The list of payment method types (e.g. card) that this SetupIntent is allowed to set up. */
       payment_method_types: string[];
       /** ID of the single_use Mandate generated by the SetupIntent. */
       single_use_mandate?:
-        | ((Partial<string> & Partial<components["schemas"]["mandate"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["mandate"]>) & { [key: string]: unknown })
         | null;
       /** [Status](https://stripe.com/docs/payments/intents#intent-statuses) of this SetupIntent, one of `requires_payment_method`, `requires_confirmation`, `requires_action`, `processing`, `canceled`, or `succeeded`. */
       status:
@@ -7972,27 +8008,27 @@ export interface components {
        * Use `on_session` if you intend to only reuse the payment method when the customer is in your checkout flow. Use `off_session` if your customer may or may not be in your checkout flow. If not provided, this value defaults to `off_session`.
        */
       usage: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     setup_intent_next_action: {
       redirect_to_url?: components["schemas"]["setup_intent_next_action_redirect_to_url"];
       /** Type of the next action to perform, one of `redirect_to_url` or `use_stripe_sdk`. */
       type: string;
       /** When confirming a SetupIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js. */
       use_stripe_sdk?: { [key: string]: unknown };
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     setup_intent_next_action_redirect_to_url: {
       /** If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion. */
       return_url?: string | null;
       /** The URL you must redirect your customer to in order to authenticate. */
       url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     setup_intent_payment_method_options: {
       card?: components["schemas"]["setup_intent_payment_method_options_card"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     setup_intent_payment_method_options_card: {
       /** We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine. */
       request_three_d_secure?: ("any" | "automatic" | "challenge_only") | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     shipping: {
       address?: components["schemas"]["address"];
       /** The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc. */
@@ -8003,23 +8039,23 @@ export interface components {
       phone?: string | null;
       /** The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas. */
       tracking_number?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     shipping_method: {
       /** A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the line item. */
       amount: number;
       /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
       currency: string;
       /** The estimated delivery date for the given shipping method. Can be either a specific date or a range. */
-      delivery_estimate?: (Partial<components["schemas"]["delivery_estimate"]> & { [key: string]: any }) | null;
+      delivery_estimate?: (Partial<components["schemas"]["delivery_estimate"]> & { [key: string]: unknown }) | null;
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
       description: string;
       /** Unique identifier for the object. */
       id: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     sigma_scheduled_query_run_error: {
       /** Information about the run failure. */
       message: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Stores representations of [stock keeping units](http://en.wikipedia.org/wiki/Stock_keeping_unit).
      * SKUs describe specific product variations, taking into account any combination of: attributes,
@@ -8051,14 +8087,14 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "sku";
       /** The dimensions of this SKU for shipping purposes. */
-      package_dimensions?: (Partial<components["schemas"]["package_dimensions"]> & { [key: string]: any }) | null;
+      package_dimensions?: (Partial<components["schemas"]["package_dimensions"]> & { [key: string]: unknown }) | null;
       /** The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency). */
       price: number;
       /** The ID of the product this SKU is associated with. The product must be currently active. */
-      product: (Partial<string> & Partial<components["schemas"]["product"]>) & { [key: string]: any };
+      product: (Partial<string> & Partial<components["schemas"]["product"]>) & { [key: string]: unknown };
       /** Time at which the object was last updated. Measured in seconds since the Unix epoch. */
       updated: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * `Source` objects allow you to accept a variety of payment methods. They
      * represent a customer's payment instrument, and can be used with the Stripe API
@@ -8102,7 +8138,7 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "source";
       /** Information about the owner of the payment instrument that may be used or required by particular source types. */
-      owner?: (Partial<components["schemas"]["source_owner"]> & { [key: string]: any }) | null;
+      owner?: (Partial<components["schemas"]["source_owner"]> & { [key: string]: unknown }) | null;
       p24?: components["schemas"]["source_type_p24"];
       receiver?: components["schemas"]["source_receiver_flow"];
       redirect?: components["schemas"]["source_redirect_flow"];
@@ -8136,13 +8172,13 @@ export interface components {
       /** Either `reusable` or `single_use`. Whether this source should be reusable or not. Some source types may or may not be reusable by construction, while others may leave the option at creation. If an incompatible value is passed, an error will be returned. */
       usage?: string | null;
       wechat?: components["schemas"]["source_type_wechat"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_code_verification_flow: {
       /** The number of attempts remaining to authenticate the source object with a verification code. */
       attempts_remaining: number;
       /** The status of the code verification, either `pending` (awaiting verification, `attempts_remaining` should be greater than 0), `succeeded` (successful verification) or `failed` (failed verification, cannot be verified anymore as `attempts_remaining` should be 0). */
       status: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Source mandate notifications should be created when a notification related to
      * a source mandate must be sent to the payer. They will trigger a webhook or
@@ -8168,11 +8204,11 @@ export interface components {
       status: string;
       /** The type of source this mandate notification is attached to. Should be the source type identifier code for the payment method, such as `three_d_secure`. */
       type: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_mandate_notification_bacs_debit_data: {
       /** Last 4 digits of the account number associated with the debit. */
       last4?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_mandate_notification_sepa_debit_data: {
       /** SEPA creditor ID. */
       creditor_identifier?: string;
@@ -8180,7 +8216,7 @@ export interface components {
       last4?: string;
       /** Mandate reference associated with the debit. */
       mandate_reference?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_order: {
       /** A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the order. */
       amount: number;
@@ -8191,7 +8227,7 @@ export interface components {
       /** List of items constituting the order. */
       items?: components["schemas"]["source_order_item"][] | null;
       shipping?: components["schemas"]["shipping"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_order_item: {
       /** The amount (price) for this order item. */
       amount?: number | null;
@@ -8203,10 +8239,10 @@ export interface components {
       quantity?: number;
       /** The type of this order item. Must be `sku`, `tax`, or `shipping`. */
       type?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_owner: {
       /** Owner's address. */
-      address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** Owner's email address. */
       email?: string | null;
       /** Owner's full name. */
@@ -8214,14 +8250,14 @@ export interface components {
       /** Owner's phone number (including extension). */
       phone?: string | null;
       /** Verified owner's address. Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated. */
-      verified_address?: (Partial<components["schemas"]["address"]> & { [key: string]: any }) | null;
+      verified_address?: (Partial<components["schemas"]["address"]> & { [key: string]: unknown }) | null;
       /** Verified owner's email address. Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       verified_email?: string | null;
       /** Verified owner's full name. Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       verified_name?: string | null;
       /** Verified owner's phone number (including extension). Verified values are verified or provided by the payment method directly (and if supported) at the time of authorization or settlement. They cannot be set or mutated. */
       verified_phone?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_receiver_flow: {
       /** The address of the receiver source. This is the value that should be communicated to the customer to send their funds to. */
       address?: string | null;
@@ -8235,7 +8271,7 @@ export interface components {
       refund_attributes_method: string;
       /** Type of refund attribute status, one of `missing`, `requested`, or `available`. */
       refund_attributes_status: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_redirect_flow: {
       /** The failure reason for the redirect, either `user_abort` (the customer aborted or dropped out of the redirect flow), `declined` (the authentication failed or the transaction was declined), or `processing_error` (the redirect failed due to a technical error). Present only if the redirect status is `failed`. */
       failure_reason?: string | null;
@@ -8245,7 +8281,7 @@ export interface components {
       status: string;
       /** The URL provided to you to redirect a customer to as part of a `redirect` authentication flow. */
       url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Some payment methods have no required amount that a customer must send.
      * Customers can be instructed to send any amount, and it can be made up of
@@ -8292,7 +8328,7 @@ export interface components {
         | "sofort"
         | "three_d_secure"
         | "wechat";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_transaction_ach_credit_transfer_data: {
       /** Customer data associated with the transfer. */
       customer_data?: string;
@@ -8302,7 +8338,7 @@ export interface components {
       last4?: string;
       /** Routing number associated with the transfer. */
       routing_number?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_transaction_chf_credit_transfer_data: {
       /** Reference associated with the transfer. */
       reference?: string;
@@ -8314,7 +8350,7 @@ export interface components {
       sender_iban?: string;
       /** Sender's name. */
       sender_name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_transaction_gbp_credit_transfer_data: {
       /** Bank account fingerprint associated with the Stripe owned bank account receiving the transfer. */
       fingerprint?: string;
@@ -8330,13 +8366,13 @@ export interface components {
       sender_name?: string;
       /** Sender sort code associated with the transfer. */
       sender_sort_code?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_transaction_paper_check_data: {
       /** Time at which the deposited funds will be available for use. Measured in seconds since the Unix epoch. */
       available_at?: string;
       /** Comma-separated list of invoice IDs associated with the paper check. */
       invoices?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_transaction_sepa_credit_transfer_data: {
       /** Reference associated with the transfer. */
       reference?: string;
@@ -8344,7 +8380,7 @@ export interface components {
       sender_iban?: string;
       /** Sender's name. */
       sender_name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_ach_credit_transfer: {
       account_number?: string | null;
       bank_name?: string | null;
@@ -8354,7 +8390,7 @@ export interface components {
       refund_routing_number?: string | null;
       routing_number?: string | null;
       swift_code?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_ach_debit: {
       bank_name?: string | null;
       country?: string | null;
@@ -8362,17 +8398,17 @@ export interface components {
       last4?: string | null;
       routing_number?: string | null;
       type?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_alipay: {
       data_string?: string | null;
       native_url?: string | null;
       statement_descriptor?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_au_becs_debit: {
       bsb_number?: string | null;
       fingerprint?: string | null;
       last4?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_bancontact: {
       bank_code?: string | null;
       bank_name?: string | null;
@@ -8380,7 +8416,7 @@ export interface components {
       iban_last4?: string | null;
       preferred_language?: string | null;
       statement_descriptor?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_card: {
       address_line1_check?: string | null;
       address_zip_check?: string | null;
@@ -8396,7 +8432,7 @@ export interface components {
       name?: string | null;
       three_d_secure?: string;
       tokenization_method?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_card_present: {
       application_cryptogram?: string;
       application_preferred_name?: string;
@@ -8421,23 +8457,23 @@ export interface components {
       reader?: string | null;
       terminal_verification_results?: string;
       transaction_status_information?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_eps: {
       reference?: string | null;
       statement_descriptor?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_giropay: {
       bank_code?: string | null;
       bank_name?: string | null;
       bic?: string | null;
       statement_descriptor?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_ideal: {
       bank?: string | null;
       bic?: string | null;
       iban_last4?: string | null;
       statement_descriptor?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_klarna: {
       background_image_url?: string;
       client_token?: string | null;
@@ -8464,7 +8500,7 @@ export interface components {
       redirect_url?: string;
       shipping_first_name?: string;
       shipping_last_name?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_multibanco: {
       entity?: string | null;
       reference?: string | null;
@@ -8476,10 +8512,10 @@ export interface components {
       refund_account_holder_address_state?: string | null;
       refund_account_holder_name?: string | null;
       refund_iban?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_p24: {
       reference?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_sepa_debit: {
       bank_code?: string | null;
       branch_code?: string | null;
@@ -8488,7 +8524,7 @@ export interface components {
       last4?: string | null;
       mandate_reference?: string | null;
       mandate_url?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_sofort: {
       bank_code?: string | null;
       bank_name?: string | null;
@@ -8497,7 +8533,7 @@ export interface components {
       iban_last4?: string | null;
       preferred_language?: string | null;
       statement_descriptor?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_three_d_secure: {
       address_line1_check?: string | null;
       address_zip_check?: string | null;
@@ -8516,12 +8552,12 @@ export interface components {
       name?: string | null;
       three_d_secure?: string;
       tokenization_method?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     source_type_wechat: {
       prepay_id?: string;
       qr_code_url?: string | null;
       statement_descriptor?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     status_transitions: {
       /** The time that the order was canceled. */
       canceled?: number | null;
@@ -8531,7 +8567,7 @@ export interface components {
       paid?: number | null;
       /** The time that the order was returned. */
       returned?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Subscriptions allow you to charge a customer on a recurring basis.
      *
@@ -8544,7 +8580,7 @@ export interface components {
       billing_cycle_anchor: number;
       /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period */
       billing_thresholds?:
-        | (Partial<components["schemas"]["subscription_billing_thresholds"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscription_billing_thresholds"]> & { [key: string]: unknown })
         | null;
       /** A date in the future at which the subscription will automatically get canceled */
       cancel_at?: number | null;
@@ -8563,12 +8599,12 @@ export interface components {
       /** ID of the customer who owns the subscription. */
       customer: (Partial<string> &
         Partial<components["schemas"]["customer"]> &
-        Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any };
+        Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown };
       /** Number of days a customer has to pay invoices generated by this subscription. This value will be `null` for subscriptions where `collection_method=charge_automatically`. */
       days_until_due?: number | null;
       /** ID of the default payment method for the subscription. It must belong to the customer associated with the subscription. If not set, invoices will use the default payment method in the customer's invoice settings. */
       default_payment_method?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: unknown })
         | null;
       /** ID of the default payment source for the subscription. It must belong to the customer associated with the subscription and be in a chargeable state. If not set, defaults to the customer's default source. */
       default_source?:
@@ -8577,12 +8613,12 @@ export interface components {
             Partial<components["schemas"]["bank_account"]> &
             Partial<components["schemas"]["bitcoin_receiver"]> &
             Partial<components["schemas"]["card"]> &
-            Partial<components["schemas"]["source"]>) & { [key: string]: any })
+            Partial<components["schemas"]["source"]>) & { [key: string]: unknown })
         | null;
       /** The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription. */
       default_tax_rates?: components["schemas"]["tax_rate"][] | null;
       /** Describes the current discount applied to this subscription, if there is one. When billing, a discount applied to a subscription overrides a discount applied on a customer-wide basis. */
-      discount?: (Partial<components["schemas"]["discount"]> & { [key: string]: any }) | null;
+      discount?: (Partial<components["schemas"]["discount"]> & { [key: string]: unknown }) | null;
       /** If the subscription has ended, the date the subscription ended. */
       ended_at?: number | null;
       /** Unique identifier for the object. */
@@ -8597,9 +8633,11 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** The most recent invoice this subscription has generated. */
-      latest_invoice?: ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: any }) | null;
+      latest_invoice?:
+        | ((Partial<string> & Partial<components["schemas"]["invoice"]>) & { [key: string]: unknown })
+        | null;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
       livemode: boolean;
       /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
@@ -8610,27 +8648,27 @@ export interface components {
       object: "subscription";
       /** If specified, payment collection for this subscription will be paused. */
       pause_collection?:
-        | (Partial<components["schemas"]["subscriptions_resource_pause_collection"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscriptions_resource_pause_collection"]> & { [key: string]: unknown })
         | null;
       /** Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval. */
       pending_invoice_item_interval?:
-        | (Partial<components["schemas"]["subscription_pending_invoice_item_interval"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscription_pending_invoice_item_interval"]> & { [key: string]: unknown })
         | null;
       /** You can use this [SetupIntent](https://stripe.com/docs/api/setup_intents) to collect user authentication when creating a subscription without immediate payment or updating a subscription's payment method, allowing you to optimize for off-session payments. Learn more in the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication#scenario-2). */
       pending_setup_intent?:
-        | ((Partial<string> & Partial<components["schemas"]["setup_intent"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["setup_intent"]>) & { [key: string]: unknown })
         | null;
       /** If specified, [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates) that will be applied to the subscription once the `latest_invoice` has been paid. */
       pending_update?:
-        | (Partial<components["schemas"]["subscriptions_resource_pending_update"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscriptions_resource_pending_update"]> & { [key: string]: unknown })
         | null;
       /** Hash describing the plan the customer is subscribed to. Only set if the subscription contains a single plan. */
-      plan?: (Partial<components["schemas"]["plan"]> & { [key: string]: any }) | null;
+      plan?: (Partial<components["schemas"]["plan"]> & { [key: string]: unknown }) | null;
       /** The quantity of the plan to which the customer is subscribed. For example, if your plan is $10/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the customer charged $50 (5 x $10) monthly. Only set if the subscription contains a single plan. */
       quantity?: number | null;
       /** The schedule attached to the subscription */
       schedule?:
-        | ((Partial<string> & Partial<components["schemas"]["subscription_schedule"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["subscription_schedule"]>) & { [key: string]: unknown })
         | null;
       /** Date when the subscription was first created. The date might differ from the `created` date due to backdating. */
       start_date: number;
@@ -8652,13 +8690,13 @@ export interface components {
       trial_end?: number | null;
       /** If the subscription has a trial, the beginning of that trial. */
       trial_start?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     subscription_billing_thresholds: {
       /** Monetary threshold that triggers the subscription to create an invoice */
       amount_gte?: number | null;
       /** Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If true, `billing_cycle_anchor` will be updated to the date/time the threshold was last reached; otherwise, the value will remain unchanged. This value may not be `true` if the subscription contains items with plans that have `aggregate_usage=last_ever`. */
       reset_billing_cycle_anchor?: boolean | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Subscription items allow you to create customer subscriptions with more than
      * one plan, making it easy to represent complex billing relationships.
@@ -8666,7 +8704,7 @@ export interface components {
     subscription_item: {
       /** Define thresholds at which an invoice will be sent, and the related subscription advanced to a new billing period */
       billing_thresholds?:
-        | (Partial<components["schemas"]["subscription_item_billing_thresholds"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscription_item_billing_thresholds"]> & { [key: string]: unknown })
         | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -8683,17 +8721,17 @@ export interface components {
       subscription: string;
       /** The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on the subscription do not apply to this `subscription_item`. */
       tax_rates?: components["schemas"]["tax_rate"][] | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     subscription_item_billing_thresholds: {
       /** Usage threshold that triggers the subscription to create an invoice */
       usage_gte?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     subscription_pending_invoice_item_interval: {
       /** Specifies invoicing frequency. Either `day`, `week`, `month` or `year`. */
       interval: "day" | "month" | "week" | "year";
       /** The number of intervals between invoices. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). */
       interval_count: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A subscription schedule allows you to create and manage the lifecycle of a subscription by predefining expected changes.
      *
@@ -8708,12 +8746,12 @@ export interface components {
       created: number;
       /** Object representing the start and end dates for the current phase of the subscription schedule, if it is `active`. */
       current_phase?:
-        | (Partial<components["schemas"]["subscription_schedule_current_phase"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscription_schedule_current_phase"]> & { [key: string]: unknown })
         | null;
       /** ID of the customer who owns the subscription schedule. */
       customer: (Partial<string> &
         Partial<components["schemas"]["customer"]> &
-        Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any };
+        Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown };
       default_settings: components["schemas"]["subscription_schedules_resource_default_settings"];
       /** Behavior of the subscription schedule and underlying subscription when it ends. */
       end_behavior: "cancel" | "none" | "release" | "renew";
@@ -8735,37 +8773,37 @@ export interface components {
       status: "active" | "canceled" | "completed" | "not_started" | "released";
       /** ID of the subscription managed by the subscription schedule. */
       subscription?:
-        | ((Partial<string> & Partial<components["schemas"]["subscription"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["subscription"]>) & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A phase item describes the plan and quantity of a phase. */
     subscription_schedule_configuration_item: {
       /** Define thresholds at which an invoice will be sent, and the related subscription advanced to a new billing period */
       billing_thresholds?:
-        | (Partial<components["schemas"]["subscription_item_billing_thresholds"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscription_item_billing_thresholds"]> & { [key: string]: unknown })
         | null;
       /** ID of the plan to which the customer should be subscribed. */
       plan: (Partial<string> &
         Partial<components["schemas"]["plan"]> &
-        Partial<components["schemas"]["deleted_plan"]>) & { [key: string]: any };
+        Partial<components["schemas"]["deleted_plan"]>) & { [key: string]: unknown };
       /** Quantity of the plan to which the customer should be subscribed. */
       quantity?: number;
       /** The tax rates which apply to this `phase_item`. When set, the `default_tax_rates` on the phase do not apply to this `phase_item`. */
       tax_rates?: components["schemas"]["tax_rate"][] | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     subscription_schedule_current_phase: {
       /** The end of this phase of the subscription schedule. */
       end_date: number;
       /** The start of this phase of the subscription schedule. */
       start_date: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /** A phase describes the plans, coupon, and trialing status of a subscription for a predefined time period. */
     subscription_schedule_phase_configuration: {
       /** A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account during this phase of the schedule. */
       application_fee_percent?: number | null;
       /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period */
       billing_thresholds?:
-        | (Partial<components["schemas"]["subscription_billing_thresholds"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscription_billing_thresholds"]> & { [key: string]: unknown })
         | null;
       /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. */
       collection_method?: ("charge_automatically" | "send_invoice") | null;
@@ -8773,11 +8811,11 @@ export interface components {
       coupon?:
         | ((Partial<string> &
             Partial<components["schemas"]["coupon"]> &
-            Partial<components["schemas"]["deleted_coupon"]>) & { [key: string]: any })
+            Partial<components["schemas"]["deleted_coupon"]>) & { [key: string]: unknown })
         | null;
       /** ID of the default payment method for the subscription schedule. It must belong to the customer associated with the subscription schedule. If not set, invoices will use the default payment method in the customer's invoice settings. */
       default_payment_method?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: unknown })
         | null;
       /** The default tax rates to apply to the subscription during this phase of the subscription schedule. */
       default_tax_rates?: components["schemas"]["tax_rate"][] | null;
@@ -8785,7 +8823,7 @@ export interface components {
       end_date: number;
       /** The subscription schedule's default invoice settings. */
       invoice_settings?:
-        | (Partial<components["schemas"]["invoice_setting_subscription_schedule_setting"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["invoice_setting_subscription_schedule_setting"]> & { [key: string]: unknown })
         | null;
       /** Plans to subscribe during this phase of the subscription schedule. */
       plans: components["schemas"]["subscription_schedule_configuration_item"][];
@@ -8797,23 +8835,23 @@ export interface components {
       tax_percent?: number | null;
       /** When the trial ends within the phase. */
       trial_end?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     subscription_schedules_resource_default_settings: {
       /** Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period */
       billing_thresholds?:
-        | (Partial<components["schemas"]["subscription_billing_thresholds"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["subscription_billing_thresholds"]> & { [key: string]: unknown })
         | null;
       /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. */
       collection_method?: ("charge_automatically" | "send_invoice") | null;
       /** ID of the default payment method for the subscription schedule. If not set, invoices will use the default payment method in the customer's invoice settings. */
       default_payment_method?:
-        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["payment_method"]>) & { [key: string]: unknown })
         | null;
       /** The subscription schedule's default invoice settings. */
       invoice_settings?:
-        | (Partial<components["schemas"]["invoice_setting_subscription_schedule_setting"]> & { [key: string]: any })
+        | (Partial<components["schemas"]["invoice_setting_subscription_schedule_setting"]> & { [key: string]: unknown })
         | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * The Pause Collection settings determine how we will pause collection for this subscription and for how long the subscription
      * should be paused.
@@ -8823,7 +8861,7 @@ export interface components {
       behavior: "keep_as_draft" | "mark_uncollectible" | "void";
       /** The time after which the subscription will resume collecting payments. */
       resumes_at?: number | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Pending Updates store the changes pending from a previous update that will be applied
      * to the Subscription upon successful payment.
@@ -8839,7 +8877,7 @@ export interface components {
       trial_end?: number | null;
       /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
       trial_from_plan?: boolean | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     tax_deducted_at_source: {
       /** Unique identifier for the object. */
       id: string;
@@ -8851,7 +8889,7 @@ export interface components {
       period_start: number;
       /** The TAN that was supplied to Stripe when TDS was assessed */
       tax_deduction_account_number: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * You can add one or multiple tax IDs to a [customer](https://stripe.com/docs/api/customers).
      * A customer's tax IDs are displayed on invoices and credit notes issued for the customer.
@@ -8864,7 +8902,7 @@ export interface components {
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
       /** ID of the customer. */
-      customer: (Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: any };
+      customer: (Partial<string> & Partial<components["schemas"]["customer"]>) & { [key: string]: unknown };
       /** Unique identifier for the object. */
       id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
@@ -8900,7 +8938,7 @@ export interface components {
       /** Value of the tax ID. */
       value: string;
       verification: components["schemas"]["tax_id_verification"];
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     tax_id_verification: {
       /** Verification status, one of `pending`, `verified`, `unverified`, or `unavailable`. */
       status: "pending" | "unavailable" | "unverified" | "verified";
@@ -8908,7 +8946,7 @@ export interface components {
       verified_address?: string | null;
       /** Verified name. */
       verified_name?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Tax rates can be applied to invoices and subscriptions to collect tax.
      *
@@ -8937,7 +8975,7 @@ export interface components {
       object: "tax_rate";
       /** This represents the tax rate percent out of 100. */
       percentage: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A Connection Token is used by the Stripe Terminal SDK to connect to a reader.
      *
@@ -8950,7 +8988,7 @@ export interface components {
       object: "terminal.connection_token";
       /** Your application should pass this token to the Stripe Terminal SDK. */
       secret: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A Location represents a grouping of readers.
      *
@@ -8968,7 +9006,7 @@ export interface components {
       metadata: { [key: string]: string };
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "terminal.location";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A Reader represents a physical device for accepting payment details.
      *
@@ -8997,7 +9035,7 @@ export interface components {
       serial_number: string;
       /** The networking status of the reader. */
       status?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Cardholder authentication via 3D Secure is initiated by creating a `3D Secure`
      * object. Once the object has been created, you can use it to authenticate the
@@ -9023,7 +9061,7 @@ export interface components {
       redirect_url?: string | null;
       /** Possible values are `redirect_pending`, `succeeded`, or `failed`. When the cardholder can be authenticated, the object starts with status `redirect_pending`. When liability will be shifted to the cardholder's bank (either because the cardholder was successfully authenticated, or because the bank has not implemented 3D Secure, the object wlil be in status `succeeded`. `failed` indicates that authentication was attempted unsuccessfully. */
       status: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     three_d_secure_details: {
       /** Whether or not authentication was performed. 3D Secure will succeed without authentication when the card is not enrolled. */
       authenticated?: boolean;
@@ -9031,11 +9069,11 @@ export interface components {
       succeeded?: boolean;
       /** The version of 3D Secure that was used for this payment. */
       version: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     three_d_secure_usage: {
       /** Whether 3D Secure is supported on this card. */
       supported: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Tokenization is the process Stripe uses to collect sensitive card or bank
      * account details, or personally identifiable information (PII), directly from
@@ -9077,7 +9115,7 @@ export interface components {
       type: string;
       /** Whether this token has already been used (tokens can be used only once). */
       used: boolean;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * To top up your Stripe balance, you create a top-up object. You can retrieve
      * individual top-ups, as well as list all top-ups. Top-ups are identified by a
@@ -9090,7 +9128,7 @@ export interface components {
       amount: number;
       /** ID of the balance transaction that describes the impact of this top-up on your account balance. May not be specified depending on status of top-up. */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -9119,7 +9157,7 @@ export interface components {
       status: "canceled" | "failed" | "pending" | "reversed" | "succeeded";
       /** A string that identifies this top-up as part of a group. */
       transfer_group?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * A `Transfer` object is created when you move funds between Stripe accounts as
      * part of Connect.
@@ -9139,7 +9177,7 @@ export interface components {
       amount_reversed: number;
       /** Balance transaction that describes the impact of this transfer on your account balance. */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** Time that this record of the transfer was first created. */
       created: number;
@@ -9148,9 +9186,9 @@ export interface components {
       /** An arbitrary string attached to the object. Often useful for displaying to users. */
       description?: string | null;
       /** ID of the Stripe account the transfer was sent to. */
-      destination?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any }) | null;
+      destination?: ((Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown }) | null;
       /** If the destination is a Stripe account, this will be the ID of the payment that the destination account received for the transfer. */
-      destination_payment?: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any };
+      destination_payment?: (Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown };
       /** Unique identifier for the object. */
       id: string;
       /** Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
@@ -9169,18 +9207,18 @@ export interface components {
         object: "list";
         /** The URL where this list can be accessed. */
         url: string;
-      } & { [key: string]: any };
+      } & { [key: string]: unknown };
       /** Whether the transfer has been fully reversed. If the transfer is only partially reversed, this attribute will still be false. */
       reversed: boolean;
       /** ID of the charge or payment that was used to fund the transfer. If null, the transfer was funded from the available balance. */
       source_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["charge"]>) & { [key: string]: unknown })
         | null;
       /** The source balance this transfer came from. One of `card`, `fpx`, or `bank_account`. */
       source_type?: string | null;
       /** A string that identifies this transaction as part of a group. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details. */
       transfer_group?: string | null;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     transfer_data: {
       /** Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
       amount?: number;
@@ -9189,8 +9227,8 @@ export interface components {
        * reporting, and where funds from the payment will be transferred to upon
        * payment success.
        */
-      destination: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: any };
-    } & { [key: string]: any };
+      destination: (Partial<string> & Partial<components["schemas"]["account"]>) & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     /**
      * [Stripe Connect](https://stripe.com/docs/connect) platforms can reverse transfers made to a
      * connected account, either entirely or partially, and can also specify whether
@@ -9211,7 +9249,7 @@ export interface components {
       amount: number;
       /** Balance transaction that describes the impact on your account balance. */
       balance_transaction?:
-        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["balance_transaction"]>) & { [key: string]: unknown })
         | null;
       /** Time at which the object was created. Measured in seconds since the Unix epoch. */
       created: number;
@@ -9219,7 +9257,7 @@ export interface components {
       currency: string;
       /** Linked payment refund for the transfer reversal. */
       destination_payment_refund?:
-        | ((Partial<string> & Partial<components["schemas"]["refund"]>) & { [key: string]: any })
+        | ((Partial<string> & Partial<components["schemas"]["refund"]>) & { [key: string]: unknown })
         | null;
       /** Unique identifier for the object. */
       id: string;
@@ -9228,10 +9266,12 @@ export interface components {
       /** String representing the object's type. Objects of the same type share the same value. */
       object: "transfer_reversal";
       /** ID of the refund responsible for the transfer reversal. */
-      source_refund?: ((Partial<string> & Partial<components["schemas"]["refund"]>) & { [key: string]: any }) | null;
+      source_refund?:
+        | ((Partial<string> & Partial<components["schemas"]["refund"]>) & { [key: string]: unknown })
+        | null;
       /** ID of the transfer that was reversed. */
-      transfer: (Partial<string> & Partial<components["schemas"]["transfer"]>) & { [key: string]: any };
-    } & { [key: string]: any };
+      transfer: (Partial<string> & Partial<components["schemas"]["transfer"]>) & { [key: string]: unknown };
+    } & { [key: string]: unknown };
     transfer_schedule: {
       /** The number of days charges for the account will be held before being paid out. */
       delay_days: number;
@@ -9241,13 +9281,13 @@ export interface components {
       monthly_anchor?: number;
       /** The day of the week funds will be paid out, of the style 'monday', 'tuesday', etc. Only shown if `interval` is weekly. */
       weekly_anchor?: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     transform_usage: {
       /** Divide usage by this number. */
       divide_by: number;
       /** After division, either round the result `up` or `down`. */
       round: "down" | "up";
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * Usage records allow you to report customer usage and metrics to Stripe for
      * metered billing of subscription plans.
@@ -9267,7 +9307,7 @@ export interface components {
       subscription_item: string;
       /** The timestamp when this usage occurred. */
       timestamp: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     usage_record_summary: {
       /** Unique identifier for the object. */
       id: string;
@@ -9282,7 +9322,7 @@ export interface components {
       subscription_item: string;
       /** The total usage within this usage period. */
       total_usage: number;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
     /**
      * You can configure [webhook endpoints](https://stripe.com/docs/webhooks/) via the API to be
      * notified about events that happen in your Stripe account or connected
@@ -9317,7 +9357,7 @@ export interface components {
       status: string;
       /** The URL of the webhook endpoint. */
       url: string;
-    } & { [key: string]: any };
+    } & { [key: string]: unknown };
   };
 }
 
@@ -9451,9 +9491,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -9463,7 +9503,7 @@ export interface operations {
             support_phone?: string;
             support_url?: string;
             url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The business type. */
           business_type?: "company" | "government_entity" | "individual" | "non_profit";
           /** Information about the company or business. This field is null unless `business_type` is set to `company`, `government_entity`, or `non_profit`. */
@@ -9475,7 +9515,7 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kana?: {
               city?: string;
               country?: string;
@@ -9484,7 +9524,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kanji?: {
               city?: string;
               country?: string;
@@ -9493,7 +9533,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             directors_provided?: boolean;
             executives_provided?: boolean;
             name?: string;
@@ -9525,9 +9565,9 @@ export interface operations {
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts). */
           default_currency?: string;
           /** Email address of the account representative. For Standard accounts, this is used to ask them to claim their Stripe account. For Custom accounts, this only makes the account easier to identify to platforms; Stripe does not email the account representative. */
@@ -9545,7 +9585,7 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kana?: {
               city?: string;
               country?: string;
@@ -9554,7 +9594,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kanji?: {
               city?: string;
               country?: string;
@@ -9563,15 +9603,15 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             dob?: (Partial<
               {
                 day: number;
                 month: number;
                 year: number;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -9582,22 +9622,22 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
             phone?: string;
             ssn_last_4?: string;
             verification?: {
               additional_document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -9615,36 +9655,36 @@ export interface operations {
               logo?: string;
               primary_color?: string;
               secondary_color?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             card_payments?: {
               decline_on?: {
                 avs_failure?: boolean;
                 cvc_failure?: boolean;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               statement_descriptor_prefix?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             payments?: {
               statement_descriptor?: string;
               statement_descriptor_kana?: string;
               statement_descriptor_kanji?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: (Partial<"minimum"> & Partial<number>) & { [key: string]: any };
+                delay_days?: (Partial<"minimum"> & Partial<number>) & { [key: string]: unknown };
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?: "friday" | "monday" | "saturday" | "sunday" | "thursday" | "tuesday" | "wednesday";
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               statement_descriptor?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
           tos_acceptance?: {
             date?: number;
             ip?: string;
             user_agent?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -9708,9 +9748,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -9806,7 +9846,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Cardholder name. */
           name?: string;
         };
@@ -9860,7 +9900,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -9960,7 +10000,7 @@ export interface operations {
           "application/json": {
             /** The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards. */
             data: ((Partial<components["schemas"]["bank_account"]> & Partial<components["schemas"]["card"]>) & {
-              [key: string]: any;
+              [key: string]: unknown;
             })[];
             /** True if this list has another page of items after this one that can be fetched. */
             has_more: boolean;
@@ -9968,7 +10008,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -10013,9 +10053,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -10111,7 +10151,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Cardholder name. */
           name?: string;
         };
@@ -10223,7 +10263,7 @@ export interface operations {
           executive?: boolean;
           owner?: boolean;
           representative?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         /** A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         starting_after?: string;
       };
@@ -10240,7 +10280,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -10284,7 +10324,7 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kana variation of the person's address (Japan only). */
           address_kana?: {
             city?: string;
@@ -10294,7 +10334,7 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kanji variation of the person's address (Japan only). */
           address_kanji?: {
             city?: string;
@@ -10304,16 +10344,16 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The person's date of birth. */
           dob?: (Partial<
             {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10337,7 +10377,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -10347,10 +10387,10 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             representative?: boolean;
             title?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The last 4 digits of the person's social security number. */
           ssn_last_4?: string;
           /** The person's verification status. */
@@ -10358,12 +10398,12 @@ export interface operations {
             additional_document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -10432,7 +10472,7 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kana variation of the person's address (Japan only). */
           address_kana?: {
             city?: string;
@@ -10442,7 +10482,7 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kanji variation of the person's address (Japan only). */
           address_kanji?: {
             city?: string;
@@ -10452,16 +10492,16 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The person's date of birth. */
           dob?: (Partial<
             {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10485,7 +10525,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -10495,10 +10535,10 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             representative?: boolean;
             title?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The last 4 digits of the person's social security number. */
           ssn_last_4?: string;
           /** The person's verification status. */
@@ -10506,12 +10546,12 @@ export interface operations {
             additional_document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -10559,7 +10599,7 @@ export interface operations {
           executive?: boolean;
           owner?: boolean;
           representative?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         /** A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         starting_after?: string;
       };
@@ -10576,7 +10616,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -10620,7 +10660,7 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kana variation of the person's address (Japan only). */
           address_kana?: {
             city?: string;
@@ -10630,7 +10670,7 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kanji variation of the person's address (Japan only). */
           address_kanji?: {
             city?: string;
@@ -10640,16 +10680,16 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The person's date of birth. */
           dob?: (Partial<
             {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10673,7 +10713,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -10683,10 +10723,10 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             representative?: boolean;
             title?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The last 4 digits of the person's social security number. */
           ssn_last_4?: string;
           /** The person's verification status. */
@@ -10694,12 +10734,12 @@ export interface operations {
             additional_document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -10768,7 +10808,7 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kana variation of the person's address (Japan only). */
           address_kana?: {
             city?: string;
@@ -10778,7 +10818,7 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kanji variation of the person's address (Japan only). */
           address_kanji?: {
             city?: string;
@@ -10788,16 +10828,16 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The person's date of birth. */
           dob?: (Partial<
             {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -10821,7 +10861,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -10831,10 +10871,10 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             representative?: boolean;
             title?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The last 4 digits of the person's social security number. */
           ssn_last_4?: string;
           /** The person's verification status. */
@@ -10842,12 +10882,12 @@ export interface operations {
             additional_document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -10924,9 +10964,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -10949,7 +10989,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -11002,9 +11042,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -11014,7 +11054,7 @@ export interface operations {
             support_phone?: string;
             support_url?: string;
             url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The business type. */
           business_type?: "company" | "government_entity" | "individual" | "non_profit";
           /** Information about the company or business. This field is null unless `business_type` is set to `company`, `government_entity`, or `non_profit`. */
@@ -11026,7 +11066,7 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kana?: {
               city?: string;
               country?: string;
@@ -11035,7 +11075,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kanji?: {
               city?: string;
               country?: string;
@@ -11044,7 +11084,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             directors_provided?: boolean;
             executives_provided?: boolean;
             name?: string;
@@ -11076,9 +11116,9 @@ export interface operations {
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** The country in which the account holder resides, or in which the business is legally established. This should be an ISO 3166-1 alpha-2 country code. For example, if you are in the United States and the business for which you're creating an account is legally represented in Canada, you would use `CA` as the country for the account being created. */
           country?: string;
           /** Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts). */
@@ -11098,7 +11138,7 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kana?: {
               city?: string;
               country?: string;
@@ -11107,7 +11147,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kanji?: {
               city?: string;
               country?: string;
@@ -11116,15 +11156,15 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             dob?: (Partial<
               {
                 day: number;
                 month: number;
                 year: number;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -11135,22 +11175,22 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
             phone?: string;
             ssn_last_4?: string;
             verification?: {
               additional_document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -11168,36 +11208,36 @@ export interface operations {
               logo?: string;
               primary_color?: string;
               secondary_color?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             card_payments?: {
               decline_on?: {
                 avs_failure?: boolean;
                 cvc_failure?: boolean;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               statement_descriptor_prefix?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             payments?: {
               statement_descriptor?: string;
               statement_descriptor_kana?: string;
               statement_descriptor_kanji?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: (Partial<"minimum"> & Partial<number>) & { [key: string]: any };
+                delay_days?: (Partial<"minimum"> & Partial<number>) & { [key: string]: unknown };
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?: "friday" | "monday" | "saturday" | "sunday" | "thursday" | "tuesday" | "wednesday";
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               statement_descriptor?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
           tos_acceptance?: {
             date?: number;
             ip?: string;
             user_agent?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The type of Stripe account to create. Currently must be `custom`, as only [Custom accounts](https://stripe.com/docs/connect/custom-accounts) may be created via the API. */
           type?: "custom" | "express" | "standard";
         };
@@ -11275,9 +11315,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Business information about the account. */
           business_profile?: {
             mcc?: string;
@@ -11287,7 +11327,7 @@ export interface operations {
             support_phone?: string;
             support_url?: string;
             url?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The business type. */
           business_type?: "company" | "government_entity" | "individual" | "non_profit";
           /** Information about the company or business. This field is null unless `business_type` is set to `company`, `government_entity`, or `non_profit`. */
@@ -11299,7 +11339,7 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kana?: {
               city?: string;
               country?: string;
@@ -11308,7 +11348,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kanji?: {
               city?: string;
               country?: string;
@@ -11317,7 +11357,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             directors_provided?: boolean;
             executives_provided?: boolean;
             name?: string;
@@ -11349,9 +11389,9 @@ export interface operations {
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts). */
           default_currency?: string;
           /** Email address of the account representative. For Standard accounts, this is used to ask them to claim their Stripe account. For Custom accounts, this only makes the account easier to identify to platforms; Stripe does not email the account representative. */
@@ -11369,7 +11409,7 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kana?: {
               city?: string;
               country?: string;
@@ -11378,7 +11418,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kanji?: {
               city?: string;
               country?: string;
@@ -11387,15 +11427,15 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             dob?: (Partial<
               {
                 day: number;
                 month: number;
                 year: number;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -11406,22 +11446,22 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
             phone?: string;
             ssn_last_4?: string;
             verification?: {
               additional_document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The set of capabilities you want to unlock for this account. Each capability will be inactive until you have provided its specific requirements and Stripe has verified them. An account may have some of its requested capabilities be active and some be inactive. */
           requested_capabilities?: (
             | "au_becs_debit_payments"
@@ -11439,36 +11479,36 @@ export interface operations {
               logo?: string;
               primary_color?: string;
               secondary_color?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             card_payments?: {
               decline_on?: {
                 avs_failure?: boolean;
                 cvc_failure?: boolean;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               statement_descriptor_prefix?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             payments?: {
               statement_descriptor?: string;
               statement_descriptor_kana?: string;
               statement_descriptor_kanji?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             payouts?: {
               debit_negative_balances?: boolean;
               schedule?: {
-                delay_days?: (Partial<"minimum"> & Partial<number>) & { [key: string]: any };
+                delay_days?: (Partial<"minimum"> & Partial<number>) & { [key: string]: unknown };
                 interval?: "daily" | "manual" | "monthly" | "weekly";
                 monthly_anchor?: number;
                 weekly_anchor?: "friday" | "monday" | "saturday" | "sunday" | "thursday" | "tuesday" | "wednesday";
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               statement_descriptor?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance). */
           tos_acceptance?: {
             date?: number;
             ip?: string;
             user_agent?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -11540,9 +11580,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -11640,7 +11680,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Cardholder name. */
           name?: string;
         };
@@ -11698,7 +11738,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -11803,7 +11843,7 @@ export interface operations {
           "application/json": {
             /** The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards. */
             data: ((Partial<components["schemas"]["bank_account"]> & Partial<components["schemas"]["card"]>) & {
-              [key: string]: any;
+              [key: string]: unknown;
             })[];
             /** True if this list has another page of items after this one that can be fetched. */
             has_more: boolean;
@@ -11811,7 +11851,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -11861,9 +11901,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency. */
           default_for_currency?: boolean;
           /** Specifies which fields in the response should be expanded. */
@@ -11961,7 +12001,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Cardholder name. */
           name?: string;
         };
@@ -12085,7 +12125,7 @@ export interface operations {
           executive?: boolean;
           owner?: boolean;
           representative?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         /** A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         starting_after?: string;
       };
@@ -12102,7 +12142,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -12150,7 +12190,7 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kana variation of the person's address (Japan only). */
           address_kana?: {
             city?: string;
@@ -12160,7 +12200,7 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kanji variation of the person's address (Japan only). */
           address_kanji?: {
             city?: string;
@@ -12170,16 +12210,16 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The person's date of birth. */
           dob?: (Partial<
             {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -12203,7 +12243,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -12213,10 +12253,10 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             representative?: boolean;
             title?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The last 4 digits of the person's social security number. */
           ssn_last_4?: string;
           /** The person's verification status. */
@@ -12224,12 +12264,12 @@ export interface operations {
             additional_document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -12299,7 +12339,7 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kana variation of the person's address (Japan only). */
           address_kana?: {
             city?: string;
@@ -12309,7 +12349,7 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kanji variation of the person's address (Japan only). */
           address_kanji?: {
             city?: string;
@@ -12319,16 +12359,16 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The person's date of birth. */
           dob?: (Partial<
             {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -12352,7 +12392,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -12362,10 +12402,10 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             representative?: boolean;
             title?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The last 4 digits of the person's social security number. */
           ssn_last_4?: string;
           /** The person's verification status. */
@@ -12373,12 +12413,12 @@ export interface operations {
             additional_document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -12430,7 +12470,7 @@ export interface operations {
           executive?: boolean;
           owner?: boolean;
           representative?: boolean;
-        } & { [key: string]: any };
+        } & { [key: string]: unknown };
         /** A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         starting_after?: string;
       };
@@ -12447,7 +12487,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -12495,7 +12535,7 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kana variation of the person's address (Japan only). */
           address_kana?: {
             city?: string;
@@ -12505,7 +12545,7 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kanji variation of the person's address (Japan only). */
           address_kanji?: {
             city?: string;
@@ -12515,16 +12555,16 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The person's date of birth. */
           dob?: (Partial<
             {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -12548,7 +12588,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -12558,10 +12598,10 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             representative?: boolean;
             title?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The last 4 digits of the person's social security number. */
           ssn_last_4?: string;
           /** The person's verification status. */
@@ -12569,12 +12609,12 @@ export interface operations {
             additional_document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -12644,7 +12684,7 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kana variation of the person's address (Japan only). */
           address_kana?: {
             city?: string;
@@ -12654,7 +12694,7 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The Kanji variation of the person's address (Japan only). */
           address_kanji?: {
             city?: string;
@@ -12664,16 +12704,16 @@ export interface operations {
             postal_code?: string;
             state?: string;
             town?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The person's date of birth. */
           dob?: (Partial<
             {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The person's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -12697,7 +12737,7 @@ export interface operations {
           /** The person's maiden name. */
           maiden_name?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person. */
           person_token?: string;
           /** The person's phone number. */
@@ -12707,10 +12747,10 @@ export interface operations {
             director?: boolean;
             executive?: boolean;
             owner?: boolean;
-            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             representative?: boolean;
             title?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The last 4 digits of the person's social security number. */
           ssn_last_4?: string;
           /** The person's verification status. */
@@ -12718,12 +12758,12 @@ export interface operations {
             additional_document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             document?: {
               back?: string;
               front?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -12819,7 +12859,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -12931,9 +12971,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -12956,7 +12996,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -13036,7 +13076,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -13133,7 +13173,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -13238,18 +13278,18 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         created?: (Partial<
           {
             gt?: number;
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
         currency?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13280,7 +13320,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -13345,18 +13385,18 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         created?: (Partial<
           {
             gt?: number;
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
         currency?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13387,7 +13427,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -13499,7 +13539,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -13578,7 +13618,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -13624,7 +13664,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -13650,9 +13690,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return charges for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -13681,7 +13721,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -13739,9 +13779,9 @@ export interface operations {
               name?: string;
               number: string;
               object?: "card";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           currency?: string;
           /** The ID of an existing customer that will be charged in this request. */
@@ -13752,13 +13792,13 @@ export interface operations {
             {
               account: string;
               amount?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The Stripe account ID for which these funds are intended. Automatically set if you use the `destination` parameter. For details, see [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers#on-behalf-of). */
           on_behalf_of?: string;
           /** The email address to which this charge's [receipt](https://stripe.com/docs/dashboard/receipts) will be sent. The receipt will not be sent until the charge is paid, and no receipts will be sent for test mode charges. If this charge is for a [Customer](https://stripe.com/docs/api/customers/object), the email address specified here will override the customer's email address. If `receipt_email` is specified for a charge in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails). */
@@ -13772,12 +13812,12 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             carrier?: string;
             name: string;
             phone?: string;
             tracking_number?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** A payment source to be charged. This can be the ID of a [card](https://stripe.com/docs/api#cards) (i.e., credit or debit card), a [bank account](https://stripe.com/docs/api#bank_accounts), a [source](https://stripe.com/docs/api#sources), a [token](https://stripe.com/docs/api#tokens), or a [connected account](https://stripe.com/docs/connect/account-debits#charging-a-connected-account). For certain sources---namely, [cards](https://stripe.com/docs/api#cards), [bank accounts](https://stripe.com/docs/api#bank_accounts), and attached [sources](https://stripe.com/docs/api#sources)---you must also pass the ID of the associated customer. */
           source?: string;
           /** For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this value as the complete description of a charge on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
@@ -13788,7 +13828,7 @@ export interface operations {
           transfer_data?: {
             amount?: number;
             destination: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** A string that identifies this transaction as part of a group. For details, see [Grouping transactions](https://stripe.com/docs/connect/charges-transfers#transfer-options). */
           transfer_group?: string;
         };
@@ -13859,9 +13899,9 @@ export interface operations {
           /** A set of key-value pairs you can attach to a charge giving information about its riskiness. If you believe a charge is fraudulent, include a `user_report` key with a value of `fraudulent`. If you believe a charge is safe, include a `user_report` key with a value of `safe`. Stripe will use the information you send to improve our fraud detection algorithms. */
           fraud_details?: {
             user_report: "" | "fraudulent" | "safe";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** This is the email address that the receipt for this charge will be sent to. If this field is updated, then a new email receipt will be sent to the updated address. */
           receipt_email?: string;
           /** Shipping information for the charge. Helps prevent fraud on charges for physical goods. */
@@ -13873,12 +13913,12 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             carrier?: string;
             name: string;
             phone?: string;
             tracking_number?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** A string that identifies this transaction as part of a group. `transfer_group` may only be provided if it has not been set. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details. */
           transfer_group?: string;
         };
@@ -13930,7 +13970,7 @@ export interface operations {
           /** An optional dictionary including the account to automatically transfer to as part of a destination charge. [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details. */
           transfer_data?: {
             amount?: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** A string that identifies this transaction as part of a group. `transfer_group` may only be provided if it has not been set. See the [Connect documentation](https://stripe.com/docs/connect/charges-transfers#transfer-options) for details. */
           transfer_group?: string;
         };
@@ -14020,11 +14060,11 @@ export interface operations {
             shipping_tracking_number?: string;
             uncategorized_file?: string;
             uncategorized_text?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default). */
           submit?: boolean;
         };
@@ -14100,7 +14140,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           payment_intent?: string;
           reason?: "duplicate" | "fraudulent" | "requested_by_customer";
           refund_application_fee?: boolean;
@@ -14139,7 +14179,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -14183,7 +14223,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           payment_intent?: string;
           reason?: "duplicate" | "fraudulent" | "requested_by_customer";
           refund_application_fee?: boolean;
@@ -14251,7 +14291,7 @@ export interface operations {
         "application/x-www-form-urlencoded": {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -14286,7 +14326,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -14364,7 +14404,7 @@ export interface operations {
             name?: string;
             quantity: number;
             tax_rates?: string[];
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           /** The IETF language tag of the locale Checkout is displayed in. If blank or `auto`, the browser's locale is used. */
           locale?:
             | "auto"
@@ -14405,19 +14445,19 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               carrier?: string;
               name: string;
               phone?: string;
               tracking_number?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             statement_descriptor?: string;
             statement_descriptor_suffix?: string;
             transfer_data?: {
               amount?: number;
               destination: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** A list of the types of payment methods (e.g., card) this Checkout session can accept. */
           payment_method_types: ("card" | "fpx" | "ideal")[];
           /** A subset of parameters to be passed to SetupIntent creation for Checkout Sessions in `setup` mode. */
@@ -14425,7 +14465,7 @@ export interface operations {
             description?: string;
             metadata?: { [key: string]: string };
             on_behalf_of?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** When set, provides configuration for Checkout to collect a shipping address from a customer. */
           shipping_address_collection?: {
             allowed_countries: (
@@ -14667,7 +14707,7 @@ export interface operations {
               | "ZW"
               | "ZZ"
             )[];
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /**
            * Describes the type of transaction being performed by Checkout in order to customize
            * relevant text on the page, such as the submit button. `submit_type` can only be
@@ -14683,12 +14723,12 @@ export interface operations {
               plan: string;
               quantity?: number;
               tax_rates?: string[];
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             metadata?: { [key: string]: string };
             trial_end?: number;
             trial_from_plan?: boolean;
             trial_period_days?: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /**
            * The URL to which Stripe should send customers when payment or setup
            * is complete.
@@ -14758,7 +14798,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -14816,9 +14856,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -14841,7 +14881,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -14895,7 +14935,7 @@ export interface operations {
           /** A positive integer specifying the number of times the coupon can be redeemed before it's no longer valid. For example, you might have a 50% off coupon that the first 20 readers of your blog can use. */
           max_redemptions?: number;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set. */
           name?: string;
           /** A positive float larger than 0, and smaller or equal to 100, that represents the discount the coupon will apply (required if `amount_off` is not passed). */
@@ -14964,7 +15004,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set. */
           name?: string;
         };
@@ -15028,7 +15068,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -15092,11 +15132,11 @@ export interface operations {
             description?: string;
             invoice_line_item?: string;
             quantity?: number;
-            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
             type: "custom_line_item" | "invoice_line_item";
             unit_amount?: number;
             unit_amount_decimal?: string;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           /** The credit note's memo appears on the credit note PDF. */
           memo?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -15131,11 +15171,11 @@ export interface operations {
           description?: string;
           invoice_line_item?: string;
           quantity?: number;
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           type: "custom_line_item" | "invoice_line_item";
           unit_amount?: number;
           unit_amount_decimal?: string;
-        } & { [key: string]: any })[];
+        } & { [key: string]: unknown })[];
         /** The credit note's memo appears on the credit note PDF. */
         memo?: string;
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -15192,11 +15232,11 @@ export interface operations {
           description?: string;
           invoice_line_item?: string;
           quantity?: number;
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           type: "custom_line_item" | "invoice_line_item";
           unit_amount?: number;
           unit_amount_decimal?: string;
-        } & { [key: string]: any })[];
+        } & { [key: string]: unknown })[];
         /** The credit note's memo appears on the credit note PDF. */
         memo?: string;
         /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -15226,7 +15266,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -15272,7 +15312,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -15393,9 +15433,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A filter on the list based on the customer's `email` field. The value must be a string. */
         email?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -15420,7 +15460,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -15464,9 +15504,9 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice. */
           balance?: number;
           coupon?: string;
@@ -15484,14 +15524,14 @@ export interface operations {
               ({
                 name: string;
                 value: string;
-              } & { [key: string]: any })[]
+              } & { [key: string]: unknown })[]
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             default_payment_method?: string;
             footer?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The customer's full name or business name. */
           name?: string;
           /** The sequence to be used on the customer's next invoice. Defaults to 1. */
@@ -15511,12 +15551,12 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               name: string;
               phone?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           source?: string;
           /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
           tax_exempt?: "" | "exempt" | "none" | "reverse";
@@ -15547,7 +15587,7 @@ export interface operations {
               | "us_ein"
               | "za_vat";
             value: string;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
         };
       };
     };
@@ -15568,7 +15608,7 @@ export interface operations {
       200: {
         content: {
           "application/json": (Partial<components["schemas"]["customer"]> &
-            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: any };
+            Partial<components["schemas"]["deleted_customer"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -15621,9 +15661,9 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice. */
           balance?: number;
           /** Either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary containing a user's bank account details. */
@@ -15636,9 +15676,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
           card?: (Partial<
             {
@@ -15655,9 +15695,9 @@ export interface operations {
               name?: string;
               number: string;
               object?: "card";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           coupon?: string;
           /** ID of Alipay account to make the customer's new default for invoice payments. */
           default_alipay_account?: string;
@@ -15687,14 +15727,14 @@ export interface operations {
               ({
                 name: string;
                 value: string;
-              } & { [key: string]: any })[]
+              } & { [key: string]: unknown })[]
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             default_payment_method?: string;
             footer?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The customer's full name or business name. */
           name?: string;
           /** The sequence to be used on the customer's next invoice. Defaults to 1. */
@@ -15713,17 +15753,17 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               name: string;
               phone?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           source?: string;
           /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
           tax_exempt?: "" | "exempt" | "none" | "reverse";
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: any };
+          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: unknown };
         };
       };
     };
@@ -15785,7 +15825,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -15834,7 +15874,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -15901,7 +15941,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -15936,7 +15976,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -15994,9 +16034,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
           card?: (Partial<
             {
@@ -16013,9 +16053,9 @@ export interface operations {
               name?: string;
               number: string;
               object?: "card";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -16072,7 +16112,7 @@ export interface operations {
         content: {
           "application/json": (Partial<components["schemas"]["card"]> &
             Partial<components["schemas"]["bank_account"]> &
-            Partial<components["schemas"]["source"]>) & { [key: string]: any };
+            Partial<components["schemas"]["source"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16108,7 +16148,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -16119,11 +16159,11 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             email?: string;
             name?: string;
             phone?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -16141,7 +16181,7 @@ export interface operations {
       200: {
         content: {
           "application/json": (Partial<components["schemas"]["payment_source"]> &
-            Partial<components["schemas"]["deleted_payment_source"]>) & { [key: string]: any };
+            Partial<components["schemas"]["deleted_payment_source"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16226,7 +16266,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16284,9 +16324,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
           card?: (Partial<
             {
@@ -16303,9 +16343,9 @@ export interface operations {
               name?: string;
               number: string;
               object?: "card";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -16362,7 +16402,7 @@ export interface operations {
         content: {
           "application/json": (Partial<components["schemas"]["card"]> &
             Partial<components["schemas"]["bank_account"]> &
-            Partial<components["schemas"]["source"]>) & { [key: string]: any };
+            Partial<components["schemas"]["source"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16398,7 +16438,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -16409,11 +16449,11 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             email?: string;
             name?: string;
             phone?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -16431,7 +16471,7 @@ export interface operations {
       200: {
         content: {
           "application/json": (Partial<components["schemas"]["payment_source"]> &
-            Partial<components["schemas"]["deleted_payment_source"]>) & { [key: string]: any };
+            Partial<components["schemas"]["deleted_payment_source"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16536,14 +16576,14 @@ export interface operations {
               Partial<components["schemas"]["bank_account"]> &
               Partial<components["schemas"]["bitcoin_receiver"]> &
               Partial<components["schemas"]["card"]> &
-              Partial<components["schemas"]["source"]>) & { [key: string]: any })[];
+              Partial<components["schemas"]["source"]>) & { [key: string]: unknown })[];
             /** True if this list has another page of items after this one that can be fetched. */
             has_more: boolean;
             /** String representing the object's type. Objects of the same type share the same value. Always has the value `list`. */
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16601,9 +16641,9 @@ export interface operations {
               currency?: string;
               object?: "bank_account";
               routing_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** A token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js). */
           card?: (Partial<
             {
@@ -16620,9 +16660,9 @@ export interface operations {
               name?: string;
               number: string;
               object?: "card";
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -16679,7 +16719,7 @@ export interface operations {
         content: {
           "application/json": (Partial<components["schemas"]["card"]> &
             Partial<components["schemas"]["bank_account"]> &
-            Partial<components["schemas"]["source"]>) & { [key: string]: any };
+            Partial<components["schemas"]["source"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16715,7 +16755,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Cardholder name. */
           name?: string;
           owner?: {
@@ -16726,11 +16766,11 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             email?: string;
             name?: string;
             phone?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -16748,7 +16788,7 @@ export interface operations {
       200: {
         content: {
           "application/json": (Partial<components["schemas"]["payment_source"]> &
-            Partial<components["schemas"]["deleted_payment_source"]>) & { [key: string]: any };
+            Partial<components["schemas"]["deleted_payment_source"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16830,7 +16870,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -16881,9 +16921,9 @@ export interface operations {
             {
               amount_gte?: number;
               reset_billing_cycle_anchor?: boolean;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
           cancel_at?: number;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
@@ -16899,7 +16939,7 @@ export interface operations {
           /** ID of the default payment source for the subscription. It must belong to the customer associated with the subscription and be in a chargeable state. If not set, defaults to the customer's default source. */
           default_source?: string;
           /** The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription. */
-          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** A list of up to 20 subscription items, each with an attached plan. */
@@ -16907,16 +16947,16 @@ export interface operations {
             billing_thresholds?: (Partial<
               {
                 usage_gte: number;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             metadata?: { [key: string]: string };
             plan?: string;
             quantity?: number;
-            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-          } & { [key: string]: any })[];
+            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+          } & { [key: string]: unknown })[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -16932,9 +16972,9 @@ export interface operations {
             {
               interval: "day" | "month" | "week" | "year";
               interval_count?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -16944,9 +16984,9 @@ export interface operations {
            */
           proration_behavior?: "always_invoice" | "create_prorations" | "none";
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: any };
+          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: any };
+          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: unknown };
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
           /** Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. */
@@ -17021,11 +17061,11 @@ export interface operations {
             {
               amount_gte?: number;
               reset_billing_cycle_anchor?: boolean;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
-          cancel_at?: (Partial<number> & Partial<"">) & { [key: string]: any };
+          cancel_at?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
           cancel_at_period_end?: boolean;
           /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
@@ -17039,7 +17079,7 @@ export interface operations {
           /** ID of the default payment source for the subscription. It must belong to the customer associated with the subscription and be in a chargeable state. If not set, defaults to the customer's default source. */
           default_source?: string;
           /** The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription. Pass an empty string to remove previously-defined tax rates. */
-          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** List of subscription items, each with an attached plan. */
@@ -17047,19 +17087,19 @@ export interface operations {
             billing_thresholds?: (Partial<
               {
                 usage_gte: number;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             clear_usage?: boolean;
             deleted?: boolean;
             id?: string;
-            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
             plan?: string;
             quantity?: number;
-            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-          } & { [key: string]: any })[];
+            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+          } & { [key: string]: unknown })[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /** If specified, payment collection for this subscription will be paused. */
@@ -17067,9 +17107,9 @@ export interface operations {
             {
               behavior: "keep_as_draft" | "mark_uncollectible" | "void";
               resumes_at?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -17083,9 +17123,9 @@ export interface operations {
             {
               interval: "day" | "month" | "week" | "year";
               interval_count?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -17099,9 +17139,9 @@ export interface operations {
           /** If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. */
           proration_date?: number;
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: any };
+          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: any };
+          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: unknown };
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
         };
@@ -17238,7 +17278,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -17383,9 +17423,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -17410,7 +17450,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -17514,11 +17554,11 @@ export interface operations {
             shipping_tracking_number?: string;
             uncategorized_file?: string;
             uncategorized_text?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default). */
           submit?: boolean;
         };
@@ -17628,9 +17668,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Filter events by whether all webhooks were successfully delivered. If false, events which are still pending or have failed all delivery attempts to a webhook endpoint will be returned. */
         delivery_success?: boolean;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -17659,7 +17699,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -17732,7 +17772,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -17789,9 +17829,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -17818,7 +17858,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -17860,7 +17900,7 @@ export interface operations {
           /** The ID of the file. The file's `purpose` must be one of the following: `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `finance_report_run`, `pci_document`, `sigma_scheduled_query`, or `tax_document_user_upload`. */
           file: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -17923,9 +17963,9 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** A future timestamp after which the link will no longer be usable, or `now` to expire the link immediately. */
-          expires_at?: (Partial<"now"> & Partial<number> & Partial<"">) & { [key: string]: any };
+          expires_at?: (Partial<"now"> & Partial<number> & Partial<"">) & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -17940,9 +17980,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -17977,7 +18017,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -18024,8 +18064,8 @@ export interface operations {
           file_link_data?: {
             create: boolean;
             expires_at?: number;
-            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
-          } & { [key: string]: any };
+            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** The purpose of the uploaded file. Possible values are `additional_verification`, `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`, or `tax_document_user_upload`. */
           purpose:
             | "additional_verification"
@@ -18081,9 +18121,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** The identifier of the customer whose invoice items to return. If none is provided, all invoice items will be returned. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -18112,7 +18152,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -18162,12 +18202,12 @@ export interface operations {
           /** The ID of an existing invoice to add this invoice item to. When left blank, the invoice item will be added to the next upcoming scheduled invoice. This is useful when adding invoice items in response to an invoice.created webhook. You can only add invoice items to draft invoices. */
           invoice?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The period associated with this invoice item. */
           period?: {
             end: number;
             start: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Non-negative integer. The quantity of units for the invoice item. */
           quantity?: number;
           /** The ID of a subscription to add this invoice item to. When left blank, the invoice item will be be added to the next upcoming scheduled invoice. When set, scheduled invoices for subscriptions other than the specified subscription will ignore the invoice item. Use this when you want to express that an invoice item has been accrued within the context of a particular subscription. */
@@ -18246,16 +18286,16 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The period associated with this invoice item. */
           period?: {
             end: number;
             start: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Non-negative integer. The quantity of units for the invoice item. */
           quantity?: number;
           /** The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the invoice do not apply to this invoice item. Pass an empty string to remove previously-defined tax rates. */
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           /** The integer unit amount in **%s** of the charge to be applied to the upcoming invoice. This unit_amount will be multiplied by the quantity to get the full amount. If you want to apply a credit to the customer's account, pass a negative unit_amount. */
           unit_amount?: number;
           /** Same as `unit_amount`, but accepts a decimal value with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set. */
@@ -18303,9 +18343,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return invoices for the customer specified by this customer ID. */
         customer?: string;
         due_date?: (Partial<
@@ -18314,9 +18354,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -18343,7 +18383,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -18389,9 +18429,9 @@ export interface operations {
             ({
               name: string;
               value: string;
-            } & { [key: string]: any })[]
+            } & { [key: string]: unknown })[]
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The ID of the customer who will be billed. */
           customer: string;
           /** The number of days from when the invoice is created until it is due. Valid only for invoices where `collection_method=send_invoice`. */
@@ -18411,7 +18451,7 @@ export interface operations {
           /** Footer to be displayed on the invoice. */
           footer?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`. */
           statement_descriptor?: string;
           /** The ID of the subscription to invoice, if any. If not set, the created invoice will include all pending invoice items for the customer. If set, the created invoice will only include pending invoice items for that subscription and pending invoice items not associated with any subscription. The subscription's billing cycle and regular subscription events won't be affected. */
@@ -18445,46 +18485,48 @@ export interface operations {
           description?: string;
           discountable?: boolean;
           invoiceitem?: string;
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           period?: {
             end: number;
             start: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           quantity?: number;
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           unit_amount?: number;
           unit_amount_decimal?: string;
-        } & { [key: string]: any })[];
+        } & { [key: string]: unknown })[];
         /** The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields. */
         schedule?: string;
         /** The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If not provided, but a `subscription_items` is provided, you will preview creating a subscription with those items. If neither `subscription` nor `subscription_items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions. */
         subscription?: string;
         /** For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`. */
-        subscription_billing_cycle_anchor?: (Partial<"now" | "unchanged"> & Partial<number>) & { [key: string]: any };
+        subscription_billing_cycle_anchor?: (Partial<"now" | "unchanged"> & Partial<number>) & {
+          [key: string]: unknown;
+        };
         /** Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.` */
-        subscription_cancel_at?: (Partial<number> & Partial<"">) & { [key: string]: any };
+        subscription_cancel_at?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
         /** Boolean indicating whether this subscription should cancel at the end of the current period. */
         subscription_cancel_at_period_end?: boolean;
         /** This simulates the subscription being canceled or expired immediately. */
         subscription_cancel_now?: boolean;
         /** If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set. */
-        subscription_default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+        subscription_default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
         /** List of subscription items, each with an attached plan. */
         subscription_items?: ({
           billing_thresholds?: (Partial<
             {
               usage_gte: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           plan?: string;
           quantity?: number;
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-        } & { [key: string]: any })[];
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+        } & { [key: string]: unknown })[];
         /** If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. */
         subscription_prorate?: boolean;
         /**
@@ -18502,7 +18544,7 @@ export interface operations {
         /** If provided, the invoice returned will preview updating or creating a subscription with that tax percent. If set, one of `subscription_items` or `subscription` is required. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
         subscription_tax_percent?: number;
         /** If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_items` or `subscription` is required. */
-        subscription_trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: any };
+        subscription_trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: unknown };
         /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. */
         subscription_trial_from_plan?: boolean;
       };
@@ -18546,16 +18588,16 @@ export interface operations {
           description?: string;
           discountable?: boolean;
           invoiceitem?: string;
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           period?: {
             end: number;
             start: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           quantity?: number;
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           unit_amount?: number;
           unit_amount_decimal?: string;
-        } & { [key: string]: any })[];
+        } & { [key: string]: unknown })[];
         /** A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         limit?: number;
         /** The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot be used with subscription or subscription fields. */
@@ -18565,31 +18607,33 @@ export interface operations {
         /** The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If not provided, but a `subscription_items` is provided, you will preview creating a subscription with those items. If neither `subscription` nor `subscription_items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions. */
         subscription?: string;
         /** For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`. */
-        subscription_billing_cycle_anchor?: (Partial<"now" | "unchanged"> & Partial<number>) & { [key: string]: any };
+        subscription_billing_cycle_anchor?: (Partial<"now" | "unchanged"> & Partial<number>) & {
+          [key: string]: unknown;
+        };
         /** Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.` */
-        subscription_cancel_at?: (Partial<number> & Partial<"">) & { [key: string]: any };
+        subscription_cancel_at?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
         /** Boolean indicating whether this subscription should cancel at the end of the current period. */
         subscription_cancel_at_period_end?: boolean;
         /** This simulates the subscription being canceled or expired immediately. */
         subscription_cancel_now?: boolean;
         /** If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set. */
-        subscription_default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+        subscription_default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
         /** List of subscription items, each with an attached plan. */
         subscription_items?: ({
           billing_thresholds?: (Partial<
             {
               usage_gte: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           clear_usage?: boolean;
           deleted?: boolean;
           id?: string;
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           plan?: string;
           quantity?: number;
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-        } & { [key: string]: any })[];
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+        } & { [key: string]: unknown })[];
         /** If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. */
         subscription_prorate?: boolean;
         /**
@@ -18607,7 +18651,7 @@ export interface operations {
         /** If provided, the invoice returned will preview updating or creating a subscription with that tax percent. If set, one of `subscription_items` or `subscription` is required. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
         subscription_tax_percent?: number;
         /** If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_items` or `subscription` is required. */
-        subscription_trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: any };
+        subscription_trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: unknown };
         /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. */
         subscription_trial_from_plan?: boolean;
       };
@@ -18625,7 +18669,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -18714,9 +18758,9 @@ export interface operations {
             ({
               name: string;
               value: string;
-            } & { [key: string]: any })[]
+            } & { [key: string]: unknown })[]
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The number of days from which the invoice is created until it is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices. */
           days_until_due?: number;
           /** ID of the default payment method for the invoice. It must belong to the customer associated with the invoice. If not set, defaults to the subscription's default payment method, if any, or to the default payment method in the customer's invoice settings. */
@@ -18724,7 +18768,7 @@ export interface operations {
           /** ID of the default payment source for the invoice. It must belong to the customer associated with the invoice and be in a chargeable state. If not set, defaults to the subscription's default source, if any, or to the customer's default source. */
           default_source?: string;
           /** The tax rates that will apply to any line item that does not have `tax_rates` set. Pass an empty string to remove previously-defined tax rates. */
-          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           /** An arbitrary string attached to the object. Often useful for displaying to users. Referenced as 'memo' in the Dashboard. */
           description?: string;
           /** The date on which payment for this invoice is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices. */
@@ -18734,11 +18778,11 @@ export interface operations {
           /** Footer to be displayed on the invoice. */
           footer?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`. */
           statement_descriptor?: string;
           /** The percent tax rate applied to the invoice, represented as a non-negative decimal number (with at most four decimal places) between 0 and 100. To unset a previously-set value, pass an empty string. This field can be updated only on `draft` invoices. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: any };
+          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -18832,7 +18876,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -19014,7 +19058,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -19080,9 +19124,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -19107,7 +19151,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -19181,7 +19225,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -19215,7 +19259,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -19247,7 +19291,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -19263,9 +19307,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return cardholders that have the given email address. */
         email?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -19296,7 +19340,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -19340,12 +19384,12 @@ export interface operations {
               line2?: string;
               postal_code: string;
               state?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Additional information about a `company` cardholder. */
           company?: {
             tax_id?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The cardholder's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -19356,16 +19400,16 @@ export interface operations {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             first_name: string;
             last_name: string;
             verification?: {
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: { [key: string]: string };
           /** The cardholder's name. This will be printed on cards issued to them. */
@@ -20247,9 +20291,9 @@ export interface operations {
                 | "wrecking_and_salvage_yards"
               )[];
               interval: "all_time" | "daily" | "monthly" | "per_authorization" | "weekly" | "yearly";
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             spending_limits_currency?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Specifies whether to permit authorizations on this cardholder's cards. Defaults to `active`. */
           status?: "active" | "inactive";
           /** One of `individual` or `company`. */
@@ -20322,12 +20366,12 @@ export interface operations {
               line2?: string;
               postal_code: string;
               state?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Additional information about a `company` cardholder. */
           company?: {
             tax_id?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The cardholder's email address. */
           email?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -20338,16 +20382,16 @@ export interface operations {
               day: number;
               month: number;
               year: number;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             first_name: string;
             last_name: string;
             verification?: {
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: { [key: string]: string };
           /** The cardholder's phone number. */
@@ -21227,9 +21271,9 @@ export interface operations {
                 | "wrecking_and_salvage_yards"
               )[];
               interval: "all_time" | "daily" | "monthly" | "per_authorization" | "weekly" | "yearly";
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             spending_limits_currency?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Specifies whether to permit authorizations on this cardholder's cards. */
           status?: "active" | "inactive";
         };
@@ -21249,9 +21293,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Only return cards that have the given expiration month. */
@@ -21284,7 +21328,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -21340,11 +21384,11 @@ export interface operations {
               line2?: string;
               postal_code: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             name: string;
             service?: "express" | "priority" | "standard";
             type?: "bulk" | "individual";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details. */
           spending_controls?: {
             allowed_categories?: (
@@ -22220,8 +22264,8 @@ export interface operations {
                 | "wrecking_and_salvage_yards"
               )[];
               interval: "all_time" | "daily" | "monthly" | "per_authorization" | "weekly" | "yearly";
-            } & { [key: string]: any })[];
-          } & { [key: string]: any };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown };
           /** Whether authorizations can be approved on this card. Defaults to `inactive`. */
           status?: "active" | "inactive";
           /** The type of card to issue. Possible values are `physical` or `virtual`. */
@@ -22290,7 +22334,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details. */
           spending_controls?: {
             allowed_categories?: (
@@ -23166,8 +23210,8 @@ export interface operations {
                 | "wrecking_and_salvage_yards"
               )[];
               interval: "all_time" | "daily" | "monthly" | "per_authorization" | "weekly" | "yearly";
-            } & { [key: string]: any })[];
-          } & { [key: string]: any };
+            } & { [key: string]: unknown })[];
+          } & { [key: string]: unknown };
           /** Dictates whether authorizations can be approved on this card. If this card is being canceled because it was lost or stolen, this information should be provided as `cancellation_reason`. */
           status?: "active" | "canceled" | "inactive";
         };
@@ -23200,7 +23244,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -23317,9 +23361,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -23342,7 +23386,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -23436,9 +23480,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -23461,7 +23505,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -23535,7 +23579,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -23582,9 +23626,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -23609,7 +23653,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -23667,9 +23711,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return orders for the given customer. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -23692,37 +23736,37 @@ export interface operations {
               gte?: number;
               lt?: number;
               lte?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<number>) & { [key: string]: any };
+            Partial<number>) & { [key: string]: unknown };
           fulfilled?: (Partial<
             {
               gt?: number;
               gte?: number;
               lt?: number;
               lte?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<number>) & { [key: string]: any };
+            Partial<number>) & { [key: string]: unknown };
           paid?: (Partial<
             {
               gt?: number;
               gte?: number;
               lt?: number;
               lte?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<number>) & { [key: string]: any };
+            Partial<number>) & { [key: string]: unknown };
           returned?: (Partial<
             {
               gt?: number;
               gte?: number;
               lt?: number;
               lte?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<number>) & { [key: string]: any };
-        } & { [key: string]: any };
+            Partial<number>) & { [key: string]: unknown };
+        } & { [key: string]: unknown };
         /** Only return orders with the given upstream order IDs. */
         upstream_ids?: string[];
       };
@@ -23739,7 +23783,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -23792,7 +23836,7 @@ export interface operations {
             parent?: string;
             quantity?: number;
             type?: "discount" | "shipping" | "sku" | "tax";
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: { [key: string]: string };
           /** Shipping address for the order. Required if any of the SKUs are for products that have `shippable` set to true. */
@@ -23804,10 +23848,10 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             name: string;
             phone?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -23872,14 +23916,14 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The shipping method to select for fulfilling this order. If specified, must be one of the `id`s of a shipping method in the `shipping_methods` array. If specified, will overwrite the existing selected shipping method, updating `items` as necessary. */
           selected_shipping_method?: string;
           /** Tracking information once the order has been fulfilled. */
           shipping?: {
             carrier: string;
             tracking_number: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Current order status. One of `created`, `paid`, `canceled`, `fulfilled`, or `returned`. More detail in the [Orders Guide](https://stripe.com/docs/orders/guide#understanding-order-statuses). */
           status?: "canceled" | "created" | "fulfilled" | "paid" | "returned";
         };
@@ -23960,9 +24004,9 @@ export interface operations {
               parent?: string;
               quantity?: number;
               type?: "discount" | "shipping" | "sku" | "tax";
-            } & { [key: string]: any })[]
+            } & { [key: string]: unknown })[]
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -23978,9 +24022,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return PaymentIntents for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -24005,7 +24049,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -24090,14 +24134,14 @@ export interface operations {
               online?: {
                 ip_address: string;
                 user_agent: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               type: "offline" | "online";
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: { [key: string]: string };
           /** Set to `true` to indicate that the customer is not in your checkout flow during this payment attempt, and therefore is unable to authenticate. This parameter is intended for scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards). This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm). */
-          off_session?: (Partial<boolean> & Partial<"one_off" | "recurring">) & { [key: string]: any };
+          off_session?: (Partial<boolean> & Partial<"one_off" | "recurring">) & { [key: string]: unknown };
           /** The Stripe account ID for which these funds are intended. For details, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts). */
           on_behalf_of?: string;
           /**
@@ -24117,15 +24161,15 @@ export interface operations {
                       count: number;
                       interval: "month";
                       type: "fixed_count";
-                    } & { [key: string]: any }
+                    } & { [key: string]: unknown }
                   > &
-                    Partial<"">) & { [key: string]: any };
-                } & { [key: string]: any };
+                    Partial<"">) & { [key: string]: unknown };
+                } & { [key: string]: unknown };
                 request_three_d_secure?: "any" | "automatic";
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
-          } & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. If this is not provided, defaults to ["card"]. */
           payment_method_types?: string[];
           /** Email address that the receipt for the resulting payment will be sent to. */
@@ -24149,12 +24193,12 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             carrier?: string;
             name: string;
             phone?: string;
             tracking_number?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
           statement_descriptor?: string;
           /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
@@ -24166,7 +24210,7 @@ export interface operations {
           transfer_data?: {
             amount?: number;
             destination: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** A string that identifies the resulting payment as part of a group. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
           transfer_group?: string;
           /** Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle additional authentication steps. */
@@ -24249,7 +24293,7 @@ export interface operations {
           /** Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
           amount?: number;
           /** The amount of the application fee (if any) for the resulting payment. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
-          application_fee_amount?: (Partial<number> & Partial<"">) & { [key: string]: any };
+          application_fee_amount?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
           /** Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
           currency?: string;
           /**
@@ -24265,7 +24309,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
@@ -24279,19 +24323,19 @@ export interface operations {
                       count: number;
                       interval: "month";
                       type: "fixed_count";
-                    } & { [key: string]: any }
+                    } & { [key: string]: unknown }
                   > &
-                    Partial<"">) & { [key: string]: any };
-                } & { [key: string]: any };
+                    Partial<"">) & { [key: string]: unknown };
+                } & { [key: string]: unknown };
                 request_three_d_secure?: "any" | "automatic";
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
-          } & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
           payment_method_types?: string[];
           /** Email address that the receipt for the resulting payment will be sent to. */
-          receipt_email?: (Partial<string> & Partial<"">) & { [key: string]: any };
+          receipt_email?: (Partial<string> & Partial<"">) & { [key: string]: unknown };
           /**
            * Indicates that you intend to make future payments with this PaymentIntent's payment method.
            *
@@ -24312,14 +24356,14 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               carrier?: string;
               name: string;
               phone?: string;
               tracking_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** For non-card charges, you can use this value as the complete description that appears on your customers’ statements. Must contain at least one letter, maximum 22 characters. */
           statement_descriptor?: string;
           /** Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor. */
@@ -24327,7 +24371,7 @@ export interface operations {
           /** The parameters used to automatically create a Transfer when the payment succeeds. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts). */
           transfer_data?: {
             amount?: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** A string that identifies the resulting payment as part of a group. `transfer_group` may only be provided if it has not been set. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details. */
           transfer_group?: string;
         };
@@ -24420,7 +24464,7 @@ export interface operations {
            */
           transfer_data?: {
             amount?: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -24492,10 +24536,10 @@ export interface operations {
                 online?: {
                   ip_address: string;
                   user_agent: string;
-                } & { [key: string]: any };
+                } & { [key: string]: unknown };
                 type: "offline" | "online";
-              } & { [key: string]: any };
-            } & { [key: string]: any }
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown }
           > &
             Partial<
               {
@@ -24503,13 +24547,13 @@ export interface operations {
                   online: {
                     ip_address?: string;
                     user_agent?: string;
-                  } & { [key: string]: any };
+                  } & { [key: string]: unknown };
                   type: "online";
-                } & { [key: string]: any };
-              } & { [key: string]: any }
-            >) & { [key: string]: any };
+                } & { [key: string]: unknown };
+              } & { [key: string]: unknown }
+            >) & { [key: string]: unknown };
           /** Set to `true` to indicate that the customer is not in your checkout flow during this payment attempt, and therefore is unable to authenticate. This parameter is intended for scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards). */
-          off_session?: (Partial<boolean> & Partial<"one_off" | "recurring">) & { [key: string]: any };
+          off_session?: (Partial<boolean> & Partial<"one_off" | "recurring">) & { [key: string]: unknown };
           /** ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this PaymentIntent. */
@@ -24523,19 +24567,19 @@ export interface operations {
                       count: number;
                       interval: "month";
                       type: "fixed_count";
-                    } & { [key: string]: any }
+                    } & { [key: string]: unknown }
                   > &
-                    Partial<"">) & { [key: string]: any };
-                } & { [key: string]: any };
+                    Partial<"">) & { [key: string]: unknown };
+                } & { [key: string]: unknown };
                 request_three_d_secure?: "any" | "automatic";
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
-          } & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
           payment_method_types?: string[];
           /** Email address that the receipt for the resulting payment will be sent to. */
-          receipt_email?: (Partial<string> & Partial<"">) & { [key: string]: any };
+          receipt_email?: (Partial<string> & Partial<"">) & { [key: string]: unknown };
           /**
            * The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site.
            * If you'd prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
@@ -24562,14 +24606,14 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               carrier?: string;
               name: string;
               phone?: string;
               tracking_number?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle additional authentication steps. */
           use_stripe_sdk?: boolean;
         };
@@ -24606,7 +24650,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -24645,7 +24689,7 @@ export interface operations {
           au_becs_debit?: {
             account_number: string;
             bsb_number: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods. */
           billing_details?: {
             address?: {
@@ -24655,11 +24699,11 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             email?: string;
             name?: string;
             phone?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** If this is a `card` PaymentMethod, this hash contains the user's card details. For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`. When creating with a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance). We strongly recommend using Stripe.js instead of interacting with this API directly. */
           card?: (Partial<
             {
@@ -24667,13 +24711,13 @@ export interface operations {
               exp_month: number;
               exp_year: number;
               number: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
             Partial<
               {
                 token: string;
-              } & { [key: string]: any }
-            >) & { [key: string]: any };
+              } & { [key: string]: unknown }
+            >) & { [key: string]: unknown };
           /** The `Customer` to whom the original PaymentMethod is attached. */
           customer?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -24701,7 +24745,7 @@ export interface operations {
               | "rhb"
               | "standard_chartered"
               | "uob";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method. */
           ideal?: {
             bank?:
@@ -24717,7 +24761,7 @@ export interface operations {
               | "sns_bank"
               | "triodos_bank"
               | "van_lanschot";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: { [key: string]: string };
           /** The PaymentMethod to share. */
@@ -24725,7 +24769,7 @@ export interface operations {
           /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
           sepa_debit?: {
             iban: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type. Required unless `payment_method` is specified (see the [Cloning PaymentMethods](https://stripe.com/docs/payments/payment-methods/connect#cloning-payment-methods) guide) */
           type?: "au_becs_debit" | "card" | "fpx" | "ideal" | "sepa_debit";
         };
@@ -24796,20 +24840,20 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             email?: string;
             name?: string;
             phone?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** If this is a `card` PaymentMethod, this hash contains the user's card details. */
           card?: {
             exp_month?: number;
             exp_year?: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account. */
           sepa_debit?: { [key: string]: unknown };
         };
@@ -24900,18 +24944,18 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         created?: (Partial<
           {
             gt?: number;
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** The ID of an external account - only return payouts sent to this external account. */
         destination?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -24938,7 +24982,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -25059,7 +25103,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -25107,9 +25151,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -25134,7 +25178,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -25190,7 +25234,7 @@ export interface operations {
           /** The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). */
           interval_count?: number;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A brief description of the plan, hidden from customers. */
           nickname?: string;
           product?: (Partial<
@@ -25201,24 +25245,24 @@ export interface operations {
               name: string;
               statement_descriptor?: string;
               unit_label?: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`. */
           tiers?: ({
             flat_amount?: number;
             flat_amount_decimal?: string;
             unit_amount?: number;
             unit_amount_decimal?: string;
-            up_to: (Partial<"inf"> & Partial<number>) & { [key: string]: any };
-          } & { [key: string]: any })[];
+            up_to: (Partial<"inf"> & Partial<number>) & { [key: string]: unknown };
+          } & { [key: string]: unknown })[];
           /** Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows. */
           tiers_mode?: "graduated" | "volume";
           /** Apply a transformation to the reported usage or set quantity before computing the billed price. Cannot be combined with `tiers`. */
           transform_usage?: {
             divide_by: number;
             round: "down" | "up";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Default number of trial days when subscribing a customer to this plan using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan). */
           trial_period_days?: number;
           /** Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`. */
@@ -25287,7 +25331,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A brief description of the plan, hidden from customers. */
           nickname?: string;
           /** The product the plan belongs to. Note that after updating, statement descriptors and line items of the plan in active subscriptions will be affected. */
@@ -25338,9 +25382,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -25371,7 +25415,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -25432,7 +25476,7 @@ export interface operations {
             length: number;
             weight: number;
             width: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Whether this product is shipped (i.e., physical goods). Defaults to `true`. May only be set if type=`good`. */
           shippable?: boolean;
           /**
@@ -25510,7 +25554,7 @@ export interface operations {
           /** Whether the product is available for purchase. */
           active?: boolean;
           /** A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g., `["color", "size"]`). If a value for `attributes` is specified, the list specified will replace the existing attributes list on this product. Any attributes not present after the update will be deleted from the SKUs for this product. */
-          attributes?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          attributes?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           /** A short one-line description of the product, meant to be displayable to the customer. May only be set if `type=good`. */
           caption?: string;
           /** An array of Connect application names or identifiers that should not be able to order the SKUs for this product. May only be set if `type=good`. */
@@ -25520,9 +25564,9 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** A list of up to 8 URLs of images for this product, meant to be displayable to the customer. */
-          images?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          images?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions. */
           name?: string;
           /** The dimensions of this product for shipping purposes. A SKU associated with this product can override this value by having its own `package_dimensions`. May only be set if `type=good`. */
@@ -25532,9 +25576,9 @@ export interface operations {
               length: number;
               weight: number;
               width: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** Whether this product is shipped (i.e., physical goods). Defaults to `true`. May only be set if `type=good`. */
           shippable?: boolean;
           /**
@@ -25607,7 +25651,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -25668,9 +25712,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -25697,7 +25741,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -25814,9 +25858,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -25839,7 +25883,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -25999,9 +26043,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -26027,7 +26071,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -26076,7 +26120,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The recipient's full, legal name. For type `individual`, should be in the format `First Last`, `First Middle Last`, or `First M Last` (no prefixes or suffixes). For `corporation`, the full, incorporated name. */
           name: string;
           /** The recipient's tax ID, as a string. For type `individual`, the full SSN; for type `corporation`, the full EIN. */
@@ -26103,7 +26147,7 @@ export interface operations {
       200: {
         content: {
           "application/json": (Partial<components["schemas"]["recipient"]> &
-            Partial<components["schemas"]["deleted_recipient"]>) & { [key: string]: any };
+            Partial<components["schemas"]["deleted_recipient"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -26162,7 +26206,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The recipient's full, legal name. For type `individual`, should be in the format `First Last`, `First Middle Last`, or `First M Last` (no prefixes or suffixes). For `corporation`, the full, incorporated name. */
           name?: string;
           /** The recipient's tax ID, as a string. For type `individual`, the full SSN; for type `corporation`, the full EIN. */
@@ -26210,9 +26254,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -26237,7 +26281,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -26277,7 +26321,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           payment_intent?: string;
           reason?: "duplicate" | "fraudulent" | "requested_by_customer";
           refund_application_fee?: boolean;
@@ -26348,7 +26392,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -26363,9 +26407,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -26388,7 +26432,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -27060,7 +27104,7 @@ export interface operations {
               | "W-SU"
               | "WET"
               | "Zulu";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The ID of the [report type](https://stripe.com/docs/reporting/statements/api#report-types) to run, such as `"balance.summary.1"`. */
           report_type: string;
         };
@@ -27118,7 +27162,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -27175,9 +27219,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -27200,7 +27244,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -27288,9 +27332,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return SetupIntents for the customer specified by this customer ID. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -27317,7 +27361,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -27377,10 +27421,10 @@ export interface operations {
               online?: {
                 ip_address: string;
                 user_agent: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               type: "offline" | "online";
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: { [key: string]: string };
           /** The Stripe account ID for which this SetupIntent is created. */
@@ -27391,8 +27435,8 @@ export interface operations {
           payment_method_options?: {
             card?: {
               request_three_d_secure?: "any" | "automatic";
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** The list of payment method types (e.g. card) that this SetupIntent is allowed to use. If this is not provided, defaults to ["card"]. */
           payment_method_types?: string[];
           /** The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site. If you'd prefer to redirect to a mobile application, you can alternatively supply an application URI scheme. This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm). */
@@ -27401,7 +27445,7 @@ export interface operations {
           single_use?: {
             amount: number;
             currency: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Indicates how the payment method is intended to be used in the future. If not provided, this value defaults to `off_session`. */
           usage?: "off_session" | "on_session";
         };
@@ -27482,15 +27526,15 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this SetupIntent. */
           payment_method_options?: {
             card?: {
               request_three_d_secure?: "any" | "automatic";
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** The list of payment method types (e.g. card) that this SetupIntent is allowed to set up. If this is not provided, defaults to ["card"]. */
           payment_method_types?: string[];
         };
@@ -27584,10 +27628,10 @@ export interface operations {
                 online?: {
                   ip_address: string;
                   user_agent: string;
-                } & { [key: string]: any };
+                } & { [key: string]: unknown };
                 type: "offline" | "online";
-              } & { [key: string]: any };
-            } & { [key: string]: any }
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown }
           > &
             Partial<
               {
@@ -27595,19 +27639,19 @@ export interface operations {
                   online: {
                     ip_address?: string;
                     user_agent?: string;
-                  } & { [key: string]: any };
+                  } & { [key: string]: unknown };
                   type: "online";
-                } & { [key: string]: any };
-              } & { [key: string]: any }
-            >) & { [key: string]: any };
+                } & { [key: string]: unknown };
+              } & { [key: string]: unknown }
+            >) & { [key: string]: unknown };
           /** ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent. */
           payment_method?: string;
           /** Payment-method-specific configuration for this SetupIntent. */
           payment_method_options?: {
             card?: {
               request_three_d_secure?: "any" | "automatic";
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /**
            * The URL to redirect your customer back to after they authenticate on the payment method's app or site.
            * If you'd prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
@@ -27644,7 +27688,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -27727,7 +27771,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -27779,7 +27823,7 @@ export interface operations {
             quantity?: number;
             type?: "bucket" | "finite" | "infinite";
             value?: "" | "in_stock" | "limited" | "out_of_stock";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
           metadata?: { [key: string]: string };
           /** The dimensions of this SKU for shipping purposes. */
@@ -27788,7 +27832,7 @@ export interface operations {
             length: number;
             weight: number;
             width: number;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The cost of the item as a nonnegative integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency). */
           price: number;
           /** The ID of the product this SKU is associated with. Must be a product with type `good`. */
@@ -27813,7 +27857,7 @@ export interface operations {
       200: {
         content: {
           "application/json": (Partial<components["schemas"]["sku"]> &
-            Partial<components["schemas"]["deleted_sku"]>) & { [key: string]: any };
+            Partial<components["schemas"]["deleted_sku"]>) & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -27872,9 +27916,9 @@ export interface operations {
             quantity?: number;
             type?: "bucket" | "finite" | "infinite";
             value?: "" | "in_stock" | "limited" | "out_of_stock";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The dimensions of this SKU for shipping purposes. */
           package_dimensions?: (Partial<
             {
@@ -27882,9 +27926,9 @@ export interface operations {
               length: number;
               weight: number;
               width: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency). */
           price?: number;
           /** The ID of the product that this SKU should belong to. The product must exist, have the same set of attribute names as the SKU's current product, and be of type `good`. */
@@ -27956,21 +28000,21 @@ export interface operations {
               ip?: string;
               offline?: {
                 contact_email: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               online?: {
                 date?: number;
                 ip?: string;
                 user_agent?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               status: "accepted" | "pending" | "refused" | "revoked";
               type?: "offline" | "online";
               user_agent?: string;
-            } & { [key: string]: any };
-            amount?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            } & { [key: string]: unknown };
+            amount?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             currency?: string;
             interval?: "one_time" | "scheduled" | "variable";
             notification_method?: "deprecated_none" | "email" | "manual" | "none" | "stripe_email";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           metadata?: { [key: string]: string };
           /** The source to share. */
           original_source?: string;
@@ -27983,19 +28027,19 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             email?: string;
             name?: string;
             phone?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Optional parameters for the receiver flow. Can be set only if the source is a receiver (`flow` is `receiver`). */
           receiver?: {
             refund_attributes_method?: "email" | "manual" | "none";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Parameters required for the redirect flow. Required if the source is authenticated by a redirect (`flow` is `redirect`). */
           redirect?: {
             return_url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Information about the items and shipping associated with the source. Required for transactional credit (for example Klarna) sources before you can charge it. */
           source_order?: {
             items?: ({
@@ -28005,7 +28049,7 @@ export interface operations {
               parent?: string;
               quantity?: number;
               type?: "discount" | "shipping" | "sku" | "tax";
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             shipping?: {
               address: {
                 city?: string;
@@ -28014,13 +28058,13 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               carrier?: string;
               name?: string;
               phone?: string;
               tracking_number?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** An arbitrary string to be displayed on your customer's statement. As an example, if your website is `RunClub` and the item you're charging for is a race ticket, you may want to specify a `statement_descriptor` of `RunClub 5K race ticket.` While many payment types will display this information, some may not display it at all. */
           statement_descriptor?: string;
           /** An optional token used to create the source. When passed, token properties will override source parameters. */
@@ -28104,23 +28148,23 @@ export interface operations {
               ip?: string;
               offline?: {
                 contact_email: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               online?: {
                 date?: number;
                 ip?: string;
                 user_agent?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               status: "accepted" | "pending" | "refused" | "revoked";
               type?: "offline" | "online";
               user_agent?: string;
-            } & { [key: string]: any };
-            amount?: (Partial<number> & Partial<"">) & { [key: string]: any };
+            } & { [key: string]: unknown };
+            amount?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
             currency?: string;
             interval?: "one_time" | "scheduled" | "variable";
             notification_method?: "deprecated_none" | "email" | "manual" | "none" | "stripe_email";
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Information about the owner of the payment instrument that may be used or required by particular source types. */
           owner?: {
             address?: {
@@ -28130,11 +28174,11 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             email?: string;
             name?: string;
             phone?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** Information about the items and shipping associated with the source. Required for transactional credit (for example Klarna) sources before you can charge it. */
           source_order?: {
             items?: ({
@@ -28144,7 +28188,7 @@ export interface operations {
               parent?: string;
               quantity?: number;
               type?: "discount" | "shipping" | "sku" | "tax";
-            } & { [key: string]: any })[];
+            } & { [key: string]: unknown })[];
             shipping?: {
               address: {
                 city?: string;
@@ -28153,13 +28197,13 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               carrier?: string;
               name?: string;
               phone?: string;
               tracking_number?: string;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -28225,7 +28269,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -28333,7 +28377,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -28372,9 +28416,9 @@ export interface operations {
           billing_thresholds?: (Partial<
             {
               usage_gte: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -28406,7 +28450,7 @@ export interface operations {
           /** The identifier of the subscription to modify. */
           subscription: string;
           /** A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates. */
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -28470,13 +28514,13 @@ export interface operations {
           billing_thresholds?: (Partial<
             {
               usage_gte: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -28504,7 +28548,7 @@ export interface operations {
           /** The quantity you'd like to apply to the subscription item you're creating. */
           quantity?: number;
           /** A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates. */
-          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -28584,7 +28628,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -28655,9 +28699,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return subscription schedules that completed during the given date interval. */
         completed_at?: (Partial<
           {
@@ -28665,9 +28709,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return subscription schedules that were created during the given date interval. */
         created?: (Partial<
           {
@@ -28675,9 +28719,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return subscription schedules for the given customer. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -28693,9 +28737,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return subscription schedules that have not started yet. */
         scheduled?: boolean;
         /** A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
@@ -28714,7 +28758,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -28757,15 +28801,15 @@ export interface operations {
               {
                 amount_gte?: number;
                 reset_billing_cycle_anchor?: boolean;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             collection_method?: "charge_automatically" | "send_invoice";
             default_payment_method?: string;
             invoice_settings?: {
               days_until_due?: number;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Configures how the subscription schedule behaves when it ends. Possible values are `release` or `cancel` with the default being `release`. `release` will end the subscription schedule and keep the underlying subscription running.`cancel` will end the subscription schedule and cancel the underlying subscription. */
           end_behavior?: "cancel" | "none" | "release" | "renew";
           /** Specifies which fields in the response should be expanded. */
@@ -28773,7 +28817,7 @@ export interface operations {
           /** Migrate an existing subscription to be managed by a subscription schedule. If this parameter is set, a subscription schedule will be created using the subscription's plan(s), set to auto-renew using the subscription's interval. When using this parameter, other parameters (such as phase values) cannot be set. To create a subscription schedule with other modifications, we recommend making two separate API calls. */
           from_subscription?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. */
           phases?: ({
             application_fee_percent?: number;
@@ -28781,36 +28825,36 @@ export interface operations {
               {
                 amount_gte?: number;
                 reset_billing_cycle_anchor?: boolean;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             collection_method?: "charge_automatically" | "send_invoice";
             coupon?: string;
             default_payment_method?: string;
-            default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+            default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
             end_date?: number;
             invoice_settings?: {
               days_until_due?: number;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             iterations?: number;
             plans: ({
               billing_thresholds?: (Partial<
                 {
                   usage_gte: number;
-                } & { [key: string]: any }
+                } & { [key: string]: unknown }
               > &
-                Partial<"">) & { [key: string]: any };
+                Partial<"">) & { [key: string]: unknown };
               plan?: string;
               quantity?: number;
-              tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-            } & { [key: string]: any })[];
+              tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+            } & { [key: string]: unknown })[];
             proration_behavior?: "always_invoice" | "create_prorations" | "none";
             tax_percent?: number;
             trial?: boolean;
             trial_end?: number;
-          } & { [key: string]: any })[];
+          } & { [key: string]: unknown })[];
           /** When the subscription schedule starts. We recommend using `now` so that it starts the subscription immediately. You can also use a Unix timestamp to backdate the subscription so that it starts on a past date, or set a future date for the subscription to start on. */
-          start_date?: (Partial<number> & Partial<"now">) & { [key: string]: any };
+          start_date?: (Partial<number> & Partial<"now">) & { [key: string]: unknown };
         };
       };
     };
@@ -28876,21 +28920,21 @@ export interface operations {
               {
                 amount_gte?: number;
                 reset_billing_cycle_anchor?: boolean;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             collection_method?: "charge_automatically" | "send_invoice";
             default_payment_method?: string;
             invoice_settings?: {
               days_until_due?: number;
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** Configures how the subscription schedule behaves when it ends. Possible values are `release` or `cancel` with the default being `release`. `release` will end the subscription schedule and keep the underlying subscription running.`cancel` will end the subscription schedule and cancel the underlying subscription. */
           end_behavior?: "cancel" | "none" | "release" | "renew";
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. Note that past phases can be omitted. */
           phases?: ({
             application_fee_percent?: number;
@@ -28898,35 +28942,35 @@ export interface operations {
               {
                 amount_gte?: number;
                 reset_billing_cycle_anchor?: boolean;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             collection_method?: "charge_automatically" | "send_invoice";
             coupon?: string;
             default_payment_method?: string;
-            default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-            end_date?: (Partial<number> & Partial<"now">) & { [key: string]: any };
+            default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+            end_date?: (Partial<number> & Partial<"now">) & { [key: string]: unknown };
             invoice_settings?: {
               days_until_due?: number;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             iterations?: number;
             plans: ({
               billing_thresholds?: (Partial<
                 {
                   usage_gte: number;
-                } & { [key: string]: any }
+                } & { [key: string]: unknown }
               > &
-                Partial<"">) & { [key: string]: any };
+                Partial<"">) & { [key: string]: unknown };
               plan?: string;
               quantity?: number;
-              tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-            } & { [key: string]: any })[];
+              tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+            } & { [key: string]: unknown })[];
             proration_behavior?: "always_invoice" | "create_prorations" | "none";
-            start_date?: (Partial<number> & Partial<"now">) & { [key: string]: any };
+            start_date?: (Partial<number> & Partial<"now">) & { [key: string]: unknown };
             tax_percent?: number;
             trial?: boolean;
-            trial_end?: (Partial<number> & Partial<"now">) & { [key: string]: any };
-          } & { [key: string]: any })[];
+            trial_end?: (Partial<number> & Partial<"now">) & { [key: string]: unknown };
+          } & { [key: string]: unknown })[];
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /** If the update changes the current phase, indicates if the changes should be prorated. Valid values are `create_prorations` or `none`, and the default value is `create_prorations`. */
@@ -29013,27 +29057,27 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         current_period_end?: (Partial<
           {
             gt?: number;
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         current_period_start?: (Partial<
           {
             gt?: number;
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** The ID of the customer whose subscriptions will be retrieved. */
         customer?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -29071,7 +29115,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -29117,9 +29161,9 @@ export interface operations {
             {
               amount_gte?: number;
               reset_billing_cycle_anchor?: boolean;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
           cancel_at?: number;
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
@@ -29137,7 +29181,7 @@ export interface operations {
           /** ID of the default payment source for the subscription. It must belong to the customer associated with the subscription and be in a chargeable state. If not set, defaults to the customer's default source. */
           default_source?: string;
           /** The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription. */
-          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** A list of up to 20 subscription items, each with an attached plan. */
@@ -29145,16 +29189,16 @@ export interface operations {
             billing_thresholds?: (Partial<
               {
                 usage_gte: number;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             metadata?: { [key: string]: string };
             plan?: string;
             quantity?: number;
-            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-          } & { [key: string]: any })[];
+            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+          } & { [key: string]: unknown })[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /**
@@ -29170,9 +29214,9 @@ export interface operations {
             {
               interval: "day" | "month" | "week" | "year";
               interval_count?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -29182,9 +29226,9 @@ export interface operations {
            */
           proration_behavior?: "always_invoice" | "create_prorations" | "none";
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: any };
+          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: any };
+          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: unknown };
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
           /** Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. */
@@ -29257,11 +29301,11 @@ export interface operations {
             {
               amount_gte?: number;
               reset_billing_cycle_anchor?: boolean;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period. */
-          cancel_at?: (Partial<number> & Partial<"">) & { [key: string]: any };
+          cancel_at?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
           /** Boolean indicating whether this subscription should cancel at the end of the current period. */
           cancel_at_period_end?: boolean;
           /** Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this subscription at the end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`. */
@@ -29275,7 +29319,7 @@ export interface operations {
           /** ID of the default payment source for the subscription. It must belong to the customer associated with the subscription and be in a chargeable state. If not set, defaults to the customer's default source. */
           default_source?: string;
           /** The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription. Pass an empty string to remove previously-defined tax rates. */
-          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
+          default_tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** List of subscription items, each with an attached plan. */
@@ -29283,19 +29327,19 @@ export interface operations {
             billing_thresholds?: (Partial<
               {
                 usage_gte: number;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             clear_usage?: boolean;
             deleted?: boolean;
             id?: string;
-            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
             plan?: string;
             quantity?: number;
-            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: any };
-          } & { [key: string]: any })[];
+            tax_rates?: (Partial<string[]> & Partial<"">) & { [key: string]: unknown };
+          } & { [key: string]: unknown })[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
           off_session?: boolean;
           /** If specified, payment collection for this subscription will be paused. */
@@ -29303,9 +29347,9 @@ export interface operations {
             {
               behavior: "keep_as_draft" | "mark_uncollectible" | "void";
               resumes_at?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /**
            * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
            *
@@ -29319,9 +29363,9 @@ export interface operations {
             {
               interval: "day" | "month" | "week" | "year";
               interval_count?: number;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<"">) & { [key: string]: any };
+            Partial<"">) & { [key: string]: unknown };
           /** This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`. */
           prorate?: boolean;
           /**
@@ -29335,9 +29379,9 @@ export interface operations {
           /** If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations. */
           proration_date?: number;
           /** A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`. */
-          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: any };
+          tax_percent?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
           /** Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. */
-          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: any };
+          trial_end?: (Partial<"now"> & Partial<number>) & { [key: string]: unknown };
           /** Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. */
           trial_from_plan?: boolean;
         };
@@ -29424,9 +29468,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -29451,7 +29495,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -29572,7 +29616,7 @@ export interface operations {
           /** The jurisdiction for the tax rate. */
           jurisdiction?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -29630,7 +29674,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -29673,13 +29717,13 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** A name for the location. */
           display_name: string;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -29747,13 +29791,13 @@ export interface operations {
             line2?: string;
             postal_code?: string;
             state?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** A name for the location. */
           display_name?: string;
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -29818,7 +29862,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -29860,7 +29904,7 @@ export interface operations {
           /** The location to assign the reader to. If no location is specified, the reader will be assigned to the account's default location. */
           location?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** A code generated by the reader used for registering to an account. */
           registration_code: string;
         };
@@ -29927,7 +29971,7 @@ export interface operations {
           /** The new label of the reader. */
           label?: string;
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -29992,7 +30036,7 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               address_kana?: {
                 city?: string;
                 country?: string;
@@ -30001,7 +30045,7 @@ export interface operations {
                 postal_code?: string;
                 state?: string;
                 town?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               address_kanji?: {
                 city?: string;
                 country?: string;
@@ -30010,7 +30054,7 @@ export interface operations {
                 postal_code?: string;
                 state?: string;
                 town?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               directors_provided?: boolean;
               executives_provided?: boolean;
               name?: string;
@@ -30042,9 +30086,9 @@ export interface operations {
                 document?: {
                   back?: string;
                   front?: string;
-                } & { [key: string]: any };
-              } & { [key: string]: any };
-            } & { [key: string]: any };
+                } & { [key: string]: unknown };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
             individual?: {
               address?: {
                 city?: string;
@@ -30053,7 +30097,7 @@ export interface operations {
                 line2?: string;
                 postal_code?: string;
                 state?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               address_kana?: {
                 city?: string;
                 country?: string;
@@ -30062,7 +30106,7 @@ export interface operations {
                 postal_code?: string;
                 state?: string;
                 town?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               address_kanji?: {
                 city?: string;
                 country?: string;
@@ -30071,15 +30115,15 @@ export interface operations {
                 postal_code?: string;
                 state?: string;
                 town?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               dob?: (Partial<
                 {
                   day: number;
                   month: number;
                   year: number;
-                } & { [key: string]: any }
+                } & { [key: string]: unknown }
               > &
-                Partial<"">) & { [key: string]: any };
+                Partial<"">) & { [key: string]: unknown };
               email?: string;
               first_name?: string;
               first_name_kana?: string;
@@ -30090,22 +30134,22 @@ export interface operations {
               last_name_kana?: string;
               last_name_kanji?: string;
               maiden_name?: string;
-              metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+              metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
               phone?: string;
               ssn_last_4?: string;
               verification?: {
                 additional_document?: {
                   back?: string;
                   front?: string;
-                } & { [key: string]: any };
+                } & { [key: string]: unknown };
                 document?: {
                   back?: string;
                   front?: string;
-                } & { [key: string]: any };
-              } & { [key: string]: any };
-            } & { [key: string]: any };
+                } & { [key: string]: unknown };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
             tos_shown_and_accepted?: boolean;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           /** The bank account this token will represent. */
           bank_account?: {
             account_holder_name?: string;
@@ -30114,7 +30158,7 @@ export interface operations {
             country: string;
             currency?: string;
             routing_number?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
           card?: (Partial<
             {
               address_city?: string;
@@ -30129,9 +30173,9 @@ export interface operations {
               exp_year: string;
               name?: string;
               number: string;
-            } & { [key: string]: any }
+            } & { [key: string]: unknown }
           > &
-            Partial<string>) & { [key: string]: any };
+            Partial<string>) & { [key: string]: unknown };
           /** The customer (owned by the application's account) for which to create a token. This can be used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods). */
           customer?: string;
           /** Specifies which fields in the response should be expanded. */
@@ -30145,7 +30189,7 @@ export interface operations {
               line2?: string;
               postal_code?: string;
               state?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kana?: {
               city?: string;
               country?: string;
@@ -30154,7 +30198,7 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             address_kanji?: {
               city?: string;
               country?: string;
@@ -30163,15 +30207,15 @@ export interface operations {
               postal_code?: string;
               state?: string;
               town?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             dob?: (Partial<
               {
                 day: number;
                 month: number;
                 year: number;
-              } & { [key: string]: any }
+              } & { [key: string]: unknown }
             > &
-              Partial<"">) & { [key: string]: any };
+              Partial<"">) & { [key: string]: unknown };
             email?: string;
             first_name?: string;
             first_name_kana?: string;
@@ -30182,32 +30226,32 @@ export interface operations {
             last_name_kana?: string;
             last_name_kanji?: string;
             maiden_name?: string;
-            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+            metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
             phone?: string;
             relationship?: {
               director?: boolean;
               executive?: boolean;
               owner?: boolean;
-              percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: any };
+              percent_ownership?: (Partial<number> & Partial<"">) & { [key: string]: unknown };
               representative?: boolean;
               title?: string;
-            } & { [key: string]: any };
+            } & { [key: string]: unknown };
             ssn_last_4?: string;
             verification?: {
               additional_document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
+              } & { [key: string]: unknown };
               document?: {
                 back?: string;
                 front?: string;
-              } & { [key: string]: any };
-            } & { [key: string]: any };
-          } & { [key: string]: any };
+              } & { [key: string]: unknown };
+            } & { [key: string]: unknown };
+          } & { [key: string]: unknown };
           /** The PII this token will represent. */
           pii?: {
             id_number?: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
     };
@@ -30254,9 +30298,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         created?: (Partial<
           {
@@ -30264,9 +30308,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         ending_before?: string;
         /** Specifies which fields in the response should be expanded. */
@@ -30291,7 +30335,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -30335,7 +30379,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The ID of a source to transfer funds from. For most users, this should be left unspecified which will use the bank account that was set up in the dashboard for the specified currency. In test mode, this can be a test bank token (see [Testing Top-ups](https://stripe.com/docs/connect/testing#testing-top-ups)). */
           source?: string;
           /** Extra information about a top-up for the source's bank statement. Limited to 15 ASCII characters. */
@@ -30406,7 +30450,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -30451,9 +30495,9 @@ export interface operations {
             gte?: number;
             lt?: number;
             lte?: number;
-          } & { [key: string]: any }
+          } & { [key: string]: unknown }
         > &
-          Partial<number>) & { [key: string]: any };
+          Partial<number>) & { [key: string]: unknown };
         /** Only return transfers for the destination specified by this account ID. */
         destination?: string;
         /** A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -30481,7 +30525,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -30568,7 +30612,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -30621,7 +30665,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** Boolean indicating whether the application fee should be refunded when reversing this transfer. If a full transfer reversal is given, the full application fee will be refunded. Otherwise, the application fee will be refunded with an amount proportional to the amount of the transfer reversed. */
           refund_application_fee?: boolean;
         };
@@ -30692,7 +30736,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -30761,7 +30805,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
         };
       };
     };
@@ -30792,7 +30836,7 @@ export interface operations {
             object: "list";
             /** The URL where this list can be accessed. */
             url: string;
-          } & { [key: string]: any };
+          } & { [key: string]: unknown };
         };
       };
       /** Error response. */
@@ -31083,7 +31127,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The URL of the webhook endpoint. */
           url: string;
         };
@@ -31304,7 +31348,7 @@ export interface operations {
           /** Specifies which fields in the response should be expanded. */
           expand?: string[];
           /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
-          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: any };
+          metadata?: (Partial<{ [key: string]: string }> & Partial<"">) & { [key: string]: unknown };
           /** The URL of the webhook endpoint. */
           url?: string;
         };


### PR DESCRIPTION
Fixes #693, #554

## Background

According to #693, I believe this is correct:

>According to the [OpenAPI spec](https://swagger.io/docs/specification/data-models/data-types/#any), when a schema is defined without a type it is the equivalent of:
>
>```
>      anyOf:
>        - type: string
>        - type: number
>        - type: integer
>        - type: boolean
>        - type: array
>          items: {}
>        - type: object
>```
>
>but openapi-typescript uses [`object` type as the default](https://github.com/drwpow/openapi-typescript/blob/main/src/types.ts#L102) and [generates](https://github.com/drwpow/openapi-typescript/blob/main/src/transform/schema.ts#L116-L121) `{ [key: string]: unknown }`. Instead it should generate just `unknown`.

This PR addresses that, fixing some bugs in the process. And also switches from `any` to `unknown` in other areas (#554).

I had originally thought that changing to `unknown` would be disruptive for people, but after looking again at the output I don’t believe it will be too bad for most. It should actually surface errors that people weren’t aware of before, which is the whole goal! So this will be released as a **minor version** rather than a breaking major version.