### PR TITLE
Update types.ts to allow "produces" and "consumes" in Operation Object per OpenAPI v2 spec.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,8 @@ export interface OperationObject {
   description?: string;
   tags?: string[]; // unused
   summary?: string; // unused
+  consumes?: string; // unused
+  produces?: string; // unused
   operationId?: string;
   parameters?: (ReferenceObject | ParameterObject)[];
   requestBody?: ReferenceObject | RequestBody;


### PR DESCRIPTION
Allow "produces" and "consumes" mime types that are defined in the v2 spec: https://swagger.io/specification/v2/#operation-object