### PR TITLE
Remove CJS build, update deps, use undici

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.dccache
 .cache
 .DS_Store
 .nyc_output/

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import glob from "tiny-glob";
 import parser from "yargs-parser";
-import openapiTS from "../dist/esm/index.js";
+import openapiTS from "../dist/index.js";
 
 const GREEN = "\u001b[32m";
 const BOLD = "\u001b[1m";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "js-yaml": "^4.1.0",
         "mime": "^3.0.0",
-        "node-fetch": "^3.1.0",
         "prettier": "^2.5.1",
         "tiny-glob": "^0.2.9",
+        "undici": "^4.12.2",
         "yargs-parser": "^21.0.0"
       },
       "bin": {
@@ -22,21 +22,19 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",
         "@types/mime": "^2.0.3",
-        "@types/node": "^17.0.8",
-        "@types/node-fetch": "^3.0.3",
-        "@types/prettier": "^2.4.2",
-        "@typescript-eslint/eslint-plugin": "^5.9.1",
-        "@typescript-eslint/parser": "^5.9.1",
+        "@types/node": "^17.0.10",
+        "@types/prettier": "^2.4.3",
+        "@typescript-eslint/eslint-plugin": "^5.10.0",
+        "@typescript-eslint/parser": "^5.10.0",
         "chai": "^4.3.4",
         "codecov": "^3.8.3",
         "eol": "^0.9.1",
-        "esbuild": "^0.14.11",
-        "eslint": "^8.6.0",
+        "eslint": "^8.7.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
-        "mocha": "^9.1.3",
+        "mocha": "^9.1.4",
         "nyc": "^15.1.0",
-        "typescript": "^4.5.4"
+        "typescript": "^4.5.5"
       },
       "engines": {
         "node": ">= 12.0.0",
@@ -594,36 +592,26 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==",
       "dev": true
     },
-    "node_modules/@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "deprecated": "This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "*"
-      }
-    },
     "node_modules/@types/prettier": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
-      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.3.tgz",
+      "integrity": "sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
-      "integrity": "sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.9.1",
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/type-utils": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/type-utils": "5.10.0",
+        "@typescript-eslint/utils": "5.10.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -657,39 +645,15 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
-      "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/typescript-estree": "5.9.1",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.1.tgz",
-      "integrity": "sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
+      "integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/typescript-estree": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/typescript-estree": "5.10.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -709,13 +673,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
+      "integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1"
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/visitor-keys": "5.10.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -726,12 +690,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz",
-      "integrity": "sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
+      "integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.9.1",
+        "@typescript-eslint/utils": "5.10.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -752,9 +716,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
+      "integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -765,13 +729,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
+      "integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1",
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/visitor-keys": "5.10.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -791,13 +755,37 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
+      "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/typescript-estree": "5.10.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
+      "integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.10.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -809,9 +797,9 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1269,14 +1257,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -1378,18 +1358,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/eol": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
@@ -1401,270 +1369,6 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
-    },
-    "node_modules/esbuild": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.11.tgz",
-      "integrity": "sha512-xZvPtVj6yecnDeFb3KjjCM6i7B5TCAQZT77kkW/CpXTMnd6VLnRPKrUB1XHI1pSq6a4Zcy3BGueQ8VljqjDGCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "optionalDependencies": {
-        "esbuild-android-arm64": "0.14.11",
-        "esbuild-darwin-64": "0.14.11",
-        "esbuild-darwin-arm64": "0.14.11",
-        "esbuild-freebsd-64": "0.14.11",
-        "esbuild-freebsd-arm64": "0.14.11",
-        "esbuild-linux-32": "0.14.11",
-        "esbuild-linux-64": "0.14.11",
-        "esbuild-linux-arm": "0.14.11",
-        "esbuild-linux-arm64": "0.14.11",
-        "esbuild-linux-mips64le": "0.14.11",
-        "esbuild-linux-ppc64le": "0.14.11",
-        "esbuild-linux-s390x": "0.14.11",
-        "esbuild-netbsd-64": "0.14.11",
-        "esbuild-openbsd-64": "0.14.11",
-        "esbuild-sunos-64": "0.14.11",
-        "esbuild-windows-32": "0.14.11",
-        "esbuild-windows-64": "0.14.11",
-        "esbuild-windows-arm64": "0.14.11"
-      }
-    },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.11.tgz",
-      "integrity": "sha512-6iHjgvMnC/SzDH8TefL+/3lgCjYWwAd1LixYfmz/TBPbDQlxcuSkX0yiQgcJB9k+ibZ54yjVXziIwGdlc+6WNw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.11.tgz",
-      "integrity": "sha512-olq84ikh6TiBcrs3FnM4eR5VPPlcJcdW8BnUz/lNoEWYifYQ+Po5DuYV1oz1CTFMw4k6bQIZl8T3yxL+ZT2uvQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.11.tgz",
-      "integrity": "sha512-Jj0ieWLREPBYr/TZJrb2GFH8PVzDqiQWavo1pOFFShrcmHWDBDrlDxPzEZ67NF/Un3t6sNNmeI1TUS/fe1xARg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.11.tgz",
-      "integrity": "sha512-C5sT3/XIztxxz/zwDjPRHyzj/NJFOnakAanXuyfLDwhwupKPd76/PPHHyJx6Po6NI6PomgVp/zi6GRB8PfrOTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.11.tgz",
-      "integrity": "sha512-y3Llu4wbs0bk4cwjsdAtVOesXb6JkdfZDLKMt+v1U3tOEPBdSu6w8796VTksJgPfqvpX22JmPLClls0h5p+L9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.11.tgz",
-      "integrity": "sha512-Cg3nVsxArjyLke9EuwictFF3Sva+UlDTwHIuIyx8qpxRYAOUTmxr2LzYrhHyTcGOleLGXUXYsnUVwKqnKAgkcg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.11.tgz",
-      "integrity": "sha512-oeR6dIrrojr8DKVrxtH3xl4eencmjsgI6kPkDCRIIFwv4p+K7ySviM85K66BN01oLjzthpUMvBVfWSJkBLeRbg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.11.tgz",
-      "integrity": "sha512-vcwskfD9g0tojux/ZaTJptJQU3a7YgTYsptK1y6LQ/rJmw7U5QJvboNawqM98Ca3ToYEucfCRGbl66OTNtp6KQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.11.tgz",
-      "integrity": "sha512-+e6ZCgTFQYZlmg2OqLkg1jHLYtkNDksxWDBWNtI4XG4WxuOCUErLqfEt9qWjvzK3XBcCzHImrajkUjO+rRkbMg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.11.tgz",
-      "integrity": "sha512-Rrs99L+p54vepmXIb87xTG6ukrQv+CzrM8eoeR+r/OFL2Rg8RlyEtCeshXJ2+Q66MXZOgPJaokXJZb9snq28bw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.11.tgz",
-      "integrity": "sha512-JyzziGAI0D30Vyzt0HDihp4s1IUtJ3ssV2zx9O/c+U/dhUHVP2TmlYjzCfCr2Q6mwXTeloDcLS4qkyvJtYptdQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.11.tgz",
-      "integrity": "sha512-DoThrkzunZ1nfRGoDN6REwmo8ZZWHd2ztniPVIR5RMw/Il9wiWEYBahb8jnMzQaSOxBsGp0PbyJeVLTUatnlcw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.11.tgz",
-      "integrity": "sha512-12luoRQz+6eihKYh1zjrw0CBa2aw3twIiHV/FAfjh2NEBDgJQOY4WCEUEN+Rgon7xmLh4XUxCQjnwrvf8zhACw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ]
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.11.tgz",
-      "integrity": "sha512-l18TZDjmvwW6cDeR4fmizNoxndyDHamGOOAenwI4SOJbzlJmwfr0jUgjbaXCUuYVOA964siw+Ix+A+bhALWg8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.11.tgz",
-      "integrity": "sha512-bmYzDtwASBB8c+0/HVOAiE9diR7+8zLm/i3kEojUH2z0aIs6x/S4KiTuT5/0VKJ4zk69kXel1cNWlHBMkmavQg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ]
-    },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.11.tgz",
-      "integrity": "sha512-J1Ys5hMid8QgdY00OBvIolXgCQn1ARhYtxPnG6ESWNTty3ashtc4+As5nTrsErnv8ZGUcWZe4WzTP/DmEVX1UQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.11.tgz",
-      "integrity": "sha512-h9FmMskMuGeN/9G9+LlHPAoiQk9jlKDUn9yA0MpiGzwLa82E7r1b1u+h2a+InprbSnSLxDq/7p5YGtYVO85Mlg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.11.tgz",
-      "integrity": "sha512-dZp7Krv13KpwKklt9/1vBFBMqxEQIO6ri7Azf8C+ob4zOegpJmha2XY9VVWP/OyQ0OWk6cEeIzMJwInRZrzBUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -1688,9 +1392,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
+      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.5",
@@ -1700,11 +1404,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.1.0",
+        "eslint-visitor-keys": "^3.2.0",
         "espree": "^9.3.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
@@ -1713,7 +1416,7 @@
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -1724,9 +1427,7 @@
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.2.1",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
@@ -1829,9 +1530,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1871,6 +1572,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/eslint/node_modules/type-fest": {
@@ -1994,9 +1704,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2043,27 +1753,6 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
-      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2159,17 +1848,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fromentries": {
@@ -2914,9 +2592,9 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
+      "integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -3070,23 +2748,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.0.tgz",
-      "integrity": "sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.2",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -3440,15 +3101,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/punycode": {
@@ -3934,9 +3586,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3944,6 +3596,14 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.12.2.tgz",
+      "integrity": "sha512-RZj6SbkQFs5O/pJCboGEo6l5DTCe3Zg4r/8Z/0/2qnIv08+s6zL4akohOPMYWKc3mzwv15WTvsfMWaafZcvYoQ==",
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/uri-js": {
@@ -3978,14 +3638,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -4614,35 +4266,26 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==",
       "dev": true
     },
-    "@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "*"
-      }
-    },
     "@types/prettier": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
-      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.3.tgz",
+      "integrity": "sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
-      "integrity": "sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "5.9.1",
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/type-utils": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/type-utils": "5.10.0",
+        "@typescript-eslint/utils": "5.10.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -4659,67 +4302,53 @@
         }
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
-      "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/typescript-estree": "5.9.1",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      }
-    },
     "@typescript-eslint/parser": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.1.tgz",
-      "integrity": "sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.0.tgz",
+      "integrity": "sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/typescript-estree": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/typescript-estree": "5.10.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.0.tgz",
+      "integrity": "sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1"
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/visitor-keys": "5.10.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz",
-      "integrity": "sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.0.tgz",
+      "integrity": "sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "5.9.1",
+        "@typescript-eslint/utils": "5.10.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.0.tgz",
+      "integrity": "sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.0.tgz",
+      "integrity": "sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1",
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/visitor-keys": "5.10.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -4727,20 +4356,34 @@
         "tsutils": "^3.21.0"
       }
     },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+    "@typescript-eslint/utils": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.0.tgz",
+      "integrity": "sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.1",
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.10.0",
+        "@typescript-eslint/types": "5.10.0",
+        "@typescript-eslint/typescript-estree": "5.10.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.0.tgz",
+      "integrity": "sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.10.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+          "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
           "dev": true
         }
       }
@@ -5091,11 +4734,6 @@
         "which": "^2.0.1"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -5171,15 +4809,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^4.1.1"
-      }
-    },
     "eol": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
@@ -5191,158 +4820,6 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
-    },
-    "esbuild": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.11.tgz",
-      "integrity": "sha512-xZvPtVj6yecnDeFb3KjjCM6i7B5TCAQZT77kkW/CpXTMnd6VLnRPKrUB1XHI1pSq6a4Zcy3BGueQ8VljqjDGCg==",
-      "dev": true,
-      "requires": {
-        "esbuild-android-arm64": "0.14.11",
-        "esbuild-darwin-64": "0.14.11",
-        "esbuild-darwin-arm64": "0.14.11",
-        "esbuild-freebsd-64": "0.14.11",
-        "esbuild-freebsd-arm64": "0.14.11",
-        "esbuild-linux-32": "0.14.11",
-        "esbuild-linux-64": "0.14.11",
-        "esbuild-linux-arm": "0.14.11",
-        "esbuild-linux-arm64": "0.14.11",
-        "esbuild-linux-mips64le": "0.14.11",
-        "esbuild-linux-ppc64le": "0.14.11",
-        "esbuild-linux-s390x": "0.14.11",
-        "esbuild-netbsd-64": "0.14.11",
-        "esbuild-openbsd-64": "0.14.11",
-        "esbuild-sunos-64": "0.14.11",
-        "esbuild-windows-32": "0.14.11",
-        "esbuild-windows-64": "0.14.11",
-        "esbuild-windows-arm64": "0.14.11"
-      }
-    },
-    "esbuild-android-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.11.tgz",
-      "integrity": "sha512-6iHjgvMnC/SzDH8TefL+/3lgCjYWwAd1LixYfmz/TBPbDQlxcuSkX0yiQgcJB9k+ibZ54yjVXziIwGdlc+6WNw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.11.tgz",
-      "integrity": "sha512-olq84ikh6TiBcrs3FnM4eR5VPPlcJcdW8BnUz/lNoEWYifYQ+Po5DuYV1oz1CTFMw4k6bQIZl8T3yxL+ZT2uvQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.11.tgz",
-      "integrity": "sha512-Jj0ieWLREPBYr/TZJrb2GFH8PVzDqiQWavo1pOFFShrcmHWDBDrlDxPzEZ67NF/Un3t6sNNmeI1TUS/fe1xARg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.11.tgz",
-      "integrity": "sha512-C5sT3/XIztxxz/zwDjPRHyzj/NJFOnakAanXuyfLDwhwupKPd76/PPHHyJx6Po6NI6PomgVp/zi6GRB8PfrOTA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.11.tgz",
-      "integrity": "sha512-y3Llu4wbs0bk4cwjsdAtVOesXb6JkdfZDLKMt+v1U3tOEPBdSu6w8796VTksJgPfqvpX22JmPLClls0h5p+L9w==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-32": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.11.tgz",
-      "integrity": "sha512-Cg3nVsxArjyLke9EuwictFF3Sva+UlDTwHIuIyx8qpxRYAOUTmxr2LzYrhHyTcGOleLGXUXYsnUVwKqnKAgkcg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.11.tgz",
-      "integrity": "sha512-oeR6dIrrojr8DKVrxtH3xl4eencmjsgI6kPkDCRIIFwv4p+K7ySviM85K66BN01oLjzthpUMvBVfWSJkBLeRbg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.11.tgz",
-      "integrity": "sha512-vcwskfD9g0tojux/ZaTJptJQU3a7YgTYsptK1y6LQ/rJmw7U5QJvboNawqM98Ca3ToYEucfCRGbl66OTNtp6KQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.11.tgz",
-      "integrity": "sha512-+e6ZCgTFQYZlmg2OqLkg1jHLYtkNDksxWDBWNtI4XG4WxuOCUErLqfEt9qWjvzK3XBcCzHImrajkUjO+rRkbMg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.11.tgz",
-      "integrity": "sha512-Rrs99L+p54vepmXIb87xTG6ukrQv+CzrM8eoeR+r/OFL2Rg8RlyEtCeshXJ2+Q66MXZOgPJaokXJZb9snq28bw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.11.tgz",
-      "integrity": "sha512-JyzziGAI0D30Vyzt0HDihp4s1IUtJ3ssV2zx9O/c+U/dhUHVP2TmlYjzCfCr2Q6mwXTeloDcLS4qkyvJtYptdQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-s390x": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.11.tgz",
-      "integrity": "sha512-DoThrkzunZ1nfRGoDN6REwmo8ZZWHd2ztniPVIR5RMw/Il9wiWEYBahb8jnMzQaSOxBsGp0PbyJeVLTUatnlcw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.11.tgz",
-      "integrity": "sha512-12luoRQz+6eihKYh1zjrw0CBa2aw3twIiHV/FAfjh2NEBDgJQOY4WCEUEN+Rgon7xmLh4XUxCQjnwrvf8zhACw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.11.tgz",
-      "integrity": "sha512-l18TZDjmvwW6cDeR4fmizNoxndyDHamGOOAenwI4SOJbzlJmwfr0jUgjbaXCUuYVOA964siw+Ix+A+bhALWg8Q==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.11.tgz",
-      "integrity": "sha512-bmYzDtwASBB8c+0/HVOAiE9diR7+8zLm/i3kEojUH2z0aIs6x/S4KiTuT5/0VKJ4zk69kXel1cNWlHBMkmavQg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.11.tgz",
-      "integrity": "sha512-J1Ys5hMid8QgdY00OBvIolXgCQn1ARhYtxPnG6ESWNTty3ashtc4+As5nTrsErnv8ZGUcWZe4WzTP/DmEVX1UQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.11.tgz",
-      "integrity": "sha512-h9FmMskMuGeN/9G9+LlHPAoiQk9jlKDUn9yA0MpiGzwLa82E7r1b1u+h2a+InprbSnSLxDq/7p5YGtYVO85Mlg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.14.11",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.11.tgz",
-      "integrity": "sha512-dZp7Krv13KpwKklt9/1vBFBMqxEQIO6ri7Azf8C+ob4zOegpJmha2XY9VVWP/OyQ0OWk6cEeIzMJwInRZrzBUQ==",
-      "dev": true,
-      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -5357,9 +4834,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
+      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.5",
@@ -5369,11 +4846,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.1.0",
+        "eslint-visitor-keys": "^3.2.0",
         "espree": "^9.3.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
@@ -5382,7 +4858,7 @@
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -5393,9 +4869,7 @@
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.2.1",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
@@ -5413,9 +4887,9 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+          "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
           "dev": true
         },
         "estraverse": {
@@ -5441,6 +4915,12 @@
           "requires": {
             "type-fest": "^0.20.2"
           }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
         },
         "type-fest": {
           "version": "0.20.2",
@@ -5575,9 +5055,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5623,14 +5103,6 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
-      }
-    },
-    "fetch-blob": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
-      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
-      "requires": {
-        "web-streams-polyfill": "^3.0.3"
       }
     },
     "file-entry-cache": {
@@ -5702,14 +5174,6 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "fromentries": {
@@ -6260,9 +5724,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
+      "integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -6368,16 +5832,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.0.tgz",
-      "integrity": "sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.2",
-        "formdata-polyfill": "^4.0.10"
-      }
     },
     "node-preload": {
       "version": "0.2.1",
@@ -6650,12 +6104,6 @@
       "requires": {
         "fromentries": "^1.2.0"
       }
-    },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
     },
     "punycode": {
       "version": "2.1.1",
@@ -7000,10 +6448,15 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
+    },
+    "undici": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.12.2.tgz",
+      "integrity": "sha512-RZj6SbkQFs5O/pJCboGEo6l5DTCe3Zg4r/8Z/0/2qnIv08+s6zL4akohOPMYWKc3mzwv15WTvsfMWaafZcvYoQ=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -7034,11 +6487,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,22 +11,13 @@
   "bin": {
     "openapi-typescript": "bin/cli.js"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "type": "module",
-  "exports": {
-    ".": {
-      "browser": "./dist/esm/index.js",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
-    },
-    "./*": "./*"
-  },
   "files": [
     "bin",
     "dist",
-    "src",
-    "types"
+    "src"
   ],
   "repository": {
     "type": "git",
@@ -48,10 +39,7 @@
   },
   "homepage": "https://github.com/drwpow/openapi-typescript#readme",
   "scripts": {
-    "build": "rm -rf dist && npm run build:esm && npm run build:cjs && npm run build:cjs-types",
-    "build:cjs": "esbuild src/index.ts --bundle --format=cjs --outfile=dist/cjs/index.cjs --platform=node --target=es2019 --external:js-yaml --external:mime --external:node-fetch --external:prettier --external:tiny-glob",
-    "build:cjs-types": "echo \"import openapiTS from '../esm/index';\nexport default openapiTS;\nexport * from '../esm/index';\" > dist/cjs/index.d.ts",
-    "build:esm": "tsc",
+    "build": "rm -rf dist && tsc",
     "format": "npm run prettier -w .",
     "lint": "eslint .",
     "prepare": "npm run build",
@@ -63,28 +51,26 @@
   "dependencies": {
     "js-yaml": "^4.1.0",
     "mime": "^3.0.0",
-    "node-fetch": "^3.1.0",
     "prettier": "^2.5.1",
     "tiny-glob": "^0.2.9",
+    "undici": "^4.12.2",
     "yargs-parser": "^21.0.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
     "@types/mime": "^2.0.3",
-    "@types/node": "^17.0.8",
-    "@types/node-fetch": "^3.0.3",
-    "@types/prettier": "^2.4.2",
-    "@typescript-eslint/eslint-plugin": "^5.9.1",
-    "@typescript-eslint/parser": "^5.9.1",
+    "@types/node": "^17.0.10",
+    "@types/prettier": "^2.4.3",
+    "@typescript-eslint/eslint-plugin": "^5.10.0",
+    "@typescript-eslint/parser": "^5.10.0",
     "chai": "^4.3.4",
     "codecov": "^3.8.3",
     "eol": "^0.9.1",
-    "esbuild": "^0.14.11",
-    "eslint": "^8.6.0",
+    "eslint": "^8.7.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "mocha": "^9.1.3",
+    "mocha": "^9.1.4",
     "nyc": "^15.1.0",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.5"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext, OpenAPI2, OpenAPI3, SchemaObject, SwaggerToTSOptions } from "./types";
+import type { GlobalContext, OpenAPI2, OpenAPI3, SchemaObject, SwaggerToTSOptions } from "./types.js";
 import path from "path";
 import prettier from "prettier";
 import parserTypescript from "prettier/parser-typescript.js";

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,5 +1,6 @@
-import type { GlobalContext, Headers } from "./types";
-import fetch from "node-fetch";
+import type { GlobalContext, Headers } from "./types.js";
+import type { Dispatcher } from "undici";
+import { request } from "undici";
 import fs from "fs";
 import path from "path";
 import { URL } from "url";
@@ -136,9 +137,10 @@ export default async function load(
         }
       }
 
-      const res = await fetch(schemaID, { method: options.httpMethod || "GET", headers });
-      contentType = res.headers.get("Content-Type") || "";
-      contents = await res.text();
+      const res = await request(schemaID, { method: (options.httpMethod as Dispatcher.HttpMethod) || "GET", headers });
+      if (Array.isArray(res.headers["Content-Type"])) contentType = res.headers["Content-Type"][0];
+      else if (res.headers["Content-Type"]) contentType = res.headers["Content-Type"];
+      contents = await res.body.text();
     }
 
     const isYAML = contentType === "application/openapi+yaml" || contentType === "text/yaml";

--- a/src/transform/headers.ts
+++ b/src/transform/headers.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext, HeaderObject } from "../types";
+import type { GlobalContext, HeaderObject } from "../types.js";
 import { comment, tsReadonly } from "../utils.js";
 import { transformSchemaObj } from "./schema.js";
 

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext, OperationObject, PathItemObject } from "../types";
+import type { GlobalContext, OperationObject, PathItemObject } from "../types.js";
 import { comment, tsReadonly } from "../utils.js";
 import { transformHeaderObjMap } from "./headers.js";
 import { transformOperationObj } from "./operation.js";

--- a/src/transform/operation.ts
+++ b/src/transform/operation.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext, OperationObject, ParameterObject, PathItemObject } from "../types";
+import type { GlobalContext, OperationObject, ParameterObject, PathItemObject } from "../types.js";
 import { comment, isRef, tsReadonly } from "../utils.js";
 import { transformParametersArray } from "./parameters.js";
 import { transformRequestBodyObj } from "./request.js";

--- a/src/transform/parameters.ts
+++ b/src/transform/parameters.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext, ParameterObject, ReferenceObject } from "../types";
+import type { GlobalContext, ParameterObject, ReferenceObject } from "../types.js";
 import { comment, tsReadonly } from "../utils.js";
 import { transformSchemaObj } from "./schema.js";
 

--- a/src/transform/paths.ts
+++ b/src/transform/paths.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext, OperationObject, ParameterObject, PathItemObject } from "../types";
+import type { GlobalContext, OperationObject, ParameterObject, PathItemObject } from "../types.js";
 import { comment, tsReadonly } from "../utils.js";
 import { transformOperationObj } from "./operation.js";
 import { transformParametersArray } from "./parameters.js";

--- a/src/transform/request.ts
+++ b/src/transform/request.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext, RequestBody } from "../types";
+import type { GlobalContext, RequestBody } from "../types.js";
 import { comment, tsReadonly } from "../utils.js";
 import { transformSchemaObj } from "./schema.js";
 

--- a/src/transform/responses.ts
+++ b/src/transform/responses.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext } from "../types";
+import type { GlobalContext } from "../types.js";
 import { comment, tsReadonly } from "../utils.js";
 import { transformHeaderObjMap } from "./headers.js";
 import { transformSchemaObj } from "./schema.js";

--- a/src/transform/schema.ts
+++ b/src/transform/schema.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext } from "../types";
+import type { GlobalContext } from "../types.js";
 import {
   prepareComment,
   nodeType,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { OpenAPI2, OpenAPI3, ReferenceObject } from "./types";
+import type { OpenAPI2, OpenAPI3, ReferenceObject } from "./types.js";
 
 type CommentObject = {
   const?: boolean; // jsdoc without value

--- a/test/core/operation.test.js
+++ b/test/core/operation.test.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { transformOperationObj } from "../../dist/esm/transform/operation.js";
+import { transformOperationObj } from "../../dist/transform/operation.js";
 
 const defaults = {
   additionalProperties: false,

--- a/test/core/parameters.test.js
+++ b/test/core/parameters.test.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { transformParametersArray } from "../../dist/esm/transform/parameters.js";
+import { transformParametersArray } from "../../dist/transform/parameters.js";
 
 const defaults = {
   additionalProperties: false,

--- a/test/core/paths.test.js
+++ b/test/core/paths.test.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import prettier from "prettier";
-import { transformPathsObj as transform } from "../../dist/esm/transform/paths.js";
+import { transformPathsObj as transform } from "../../dist/transform/paths.js";
 
 function format(source) {
   return prettier.format(`export interface paths {\n${source}\n}`, { parser: "typescript" });

--- a/test/core/request.test.js
+++ b/test/core/request.test.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import prettier from "prettier";
-import { transformRequestBodies } from "../../dist/esm/transform/request.js";
+import { transformRequestBodies } from "../../dist/transform/request.js";
 
 const defaults = {
   additionalProperties: false,

--- a/test/core/schema.test.js
+++ b/test/core/schema.test.js
@@ -2,7 +2,7 @@
  * Tests raw generation, pre-Prettier
  */
 import { expect } from "chai";
-import { transformSchemaObj as transform } from "../../dist/esm/transform/schema.js";
+import { transformSchemaObj as transform } from "../../dist/transform/schema.js";
 
 const defaults = {
   additionalProperties: false,

--- a/test/opts/empty-definitions.test.js
+++ b/test/opts/empty-definitions.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import eol from "eol";
 import fs from "fs";
-import openapiTS from "../../dist/esm/index.js";
+import openapiTS from "../../dist/index.js";
 
 describe("allow empty definitions", () => {
   const schema = {

--- a/test/opts/formatter.test.js
+++ b/test/opts/formatter.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import fs from "fs";
 import eol from "eol";
-import openapiTS from "../../dist/esm/index.js";
+import openapiTS from "../../dist/index.js";
 
 describe("formatter", () => {
   it("basic", async () => {

--- a/test/opts/raw-schema.test.js
+++ b/test/opts/raw-schema.test.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import openapiTS from "../../dist/esm/index.js";
+import openapiTS from "../../dist/index.js";
 
 describe("rawSchema", () => {
   it("v2", async () => {

--- a/test/opts/remote-schema.test.js
+++ b/test/opts/remote-schema.test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import fs from "fs";
 import eol from "eol";
-import openapiTS from "../../dist/esm/index.js";
+import openapiTS from "../../dist/index.js";
 
 describe("remote $refs", () => {
   it("resolves remote $refs", async () => {

--- a/test/v2/index.test.js
+++ b/test/v2/index.test.js
@@ -4,7 +4,7 @@ import eol from "eol";
 import fs from "fs";
 import yaml from "js-yaml";
 import { fileURLToPath } from "url";
-import openapiTS from "../../dist/esm/index.js";
+import openapiTS from "../../dist/index.js";
 
 const cmd = `node ../../bin/cli.js`;
 const cwd = new URL(".", import.meta.url);

--- a/test/v3/index.test.js
+++ b/test/v3/index.test.js
@@ -3,7 +3,7 @@ import { execSync } from "child_process";
 import eol from "eol";
 import fs from "fs";
 import yaml from "js-yaml";
-import openapiTS from "../../dist/esm/index.js";
+import openapiTS from "../../dist/index.js";
 import { fileURLToPath } from "url";
 
 const cmd = `node ../../bin/cli.js`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "lib": ["ES2018"],
     "moduleResolution": "Node",
     "noImplicitReturns": true,
-    "outDir": "./dist/esm",
+    "outDir": "./dist",
     "removeComments": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
- Patches a [security issue](https://security.snyk.io/vuln/SNYK-JS-NODEFETCH-2342118) with `node-fetch`, but rather than update, switches to `undici`.
- Removes CJS build (mostly because of type errors)
- Fixes a type export error for an upcoming TS version (#847)