### PR TITLE
Fix serialize object

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,8 @@ export function prepareComment(v: CommentObject): string | void {
     if (v[field] === "" && !allowEmptyString) {
       continue;
     }
-    commentsArray.push(`@${field} ${v[field]} `);
+    const serialized = typeof v[field] === "object" ? JSON.stringify(v[field], null, 2) : v[field];
+    commentsArray.push(`@${field} ${serialized} `);
   }
 
   // * JSDOC 'Constant' without value

--- a/test/bin/expected/specs/manifold.ts
+++ b/test/bin/expected/specs/manifold.ts
@@ -639,7 +639,7 @@ export interface definitions {
       sso_url?: string;
       /** @enum {string} */
       version?: "v1";
-      /** @default [object Object] */
+      /** @default {} */
       features?: {
         access_code?: boolean;
         sso?: boolean;
@@ -762,7 +762,13 @@ export interface definitions {
       /**
        * @description Price describes how the feature cost should be calculated.
        *
-       * @example [object Object]
+       * @example {
+       *   "feature_multiplies_base_cost": "(* plan#base_cost feature-a#multiply_factor)",
+       *   "feature_multiplies_feature_cost": "(* feature-b#cost feature-a#multiply_factor)",
+       *   "feature_multiplies_numeric_value": "(* feature-c#number feature-a#multiply_factor)",
+       *   "feature_multiplies_total_cost": "(* plan#total_cost feature-a#multiply_factor)",
+       *   "feature_nested_formulas": "(+ (- (* feature-a#cost feature-b#multiply_factor) 500) plan#partial_cost)"
+       * }
        */
       formula?: definitions["PriceFormula"];
       /** @description Description explains how a feature is calculated to the user. */
@@ -834,7 +840,7 @@ export interface definitions {
   ProductTags: definitions["Label"][];
   /** @enum {string} */
   ProductState: "available" | "hidden" | "grandfathered" | "new" | "upcoming";
-  /** @default [object Object] */
+  /** @default {} */
   ProductListing: {
     /**
      * @description When true, everyone can see the product when requested. When false it will
@@ -859,7 +865,7 @@ export interface definitions {
      * we find ourselves in a position where we think they should, we should
      * consider refactoring our listing definition.
      *
-     * @default [object Object]
+     * @default {}
      */
     marketing?: {
       /**
@@ -898,7 +904,7 @@ export interface definitions {
    * @enum {string}
    */
   ProductProvisioning: "provider-only" | "pre-order" | "public";
-  /** @default [object Object] */
+  /** @default {} */
   ProductIntegrationFeatures: {
     /**
      * @description Indicates whether or not this product supports resource transitions to

--- a/test/v2/expected/http.ts
+++ b/test/v2/expected/http.ts
@@ -639,7 +639,7 @@ export interface definitions {
       sso_url?: string;
       /** @enum {string} */
       version?: "v1";
-      /** @default [object Object] */
+      /** @default {} */
       features?: {
         access_code?: boolean;
         sso?: boolean;
@@ -762,7 +762,13 @@ export interface definitions {
       /**
        * @description Price describes how the feature cost should be calculated.
        *
-       * @example [object Object]
+       * @example {
+       *   "feature_multiplies_base_cost": "(* plan#base_cost feature-a#multiply_factor)",
+       *   "feature_multiplies_feature_cost": "(* feature-b#cost feature-a#multiply_factor)",
+       *   "feature_multiplies_numeric_value": "(* feature-c#number feature-a#multiply_factor)",
+       *   "feature_multiplies_total_cost": "(* plan#total_cost feature-a#multiply_factor)",
+       *   "feature_nested_formulas": "(+ (- (* feature-a#cost feature-b#multiply_factor) 500) plan#partial_cost)"
+       * }
        */
       formula?: definitions["PriceFormula"];
       /** @description Description explains how a feature is calculated to the user. */
@@ -834,7 +840,7 @@ export interface definitions {
   ProductTags: definitions["Label"][];
   /** @enum {string} */
   ProductState: "available" | "hidden" | "grandfathered" | "new" | "upcoming";
-  /** @default [object Object] */
+  /** @default {} */
   ProductListing: {
     /**
      * @description When true, everyone can see the product when requested. When false it will
@@ -859,7 +865,7 @@ export interface definitions {
      * we find ourselves in a position where we think they should, we should
      * consider refactoring our listing definition.
      *
-     * @default [object Object]
+     * @default {}
      */
     marketing?: {
       /**
@@ -898,7 +904,7 @@ export interface definitions {
    * @enum {string}
    */
   ProductProvisioning: "provider-only" | "pre-order" | "public";
-  /** @default [object Object] */
+  /** @default {} */
   ProductIntegrationFeatures: {
     /**
      * @description Indicates whether or not this product supports resource transitions to

--- a/test/v2/expected/manifold.immutable.ts
+++ b/test/v2/expected/manifold.immutable.ts
@@ -639,7 +639,7 @@ export interface definitions {
       readonly sso_url?: string
       /** @enum {string} */
       readonly version?: 'v1'
-      /** @default [object Object] */
+      /** @default {} */
       readonly features?: {
         readonly access_code?: boolean
         readonly sso?: boolean
@@ -762,7 +762,13 @@ export interface definitions {
       /**
        * @description Price describes how the feature cost should be calculated.
        *
-       * @example [object Object]
+       * @example {
+       *   "feature_multiplies_base_cost": "(* plan#base_cost feature-a#multiply_factor)",
+       *   "feature_multiplies_feature_cost": "(* feature-b#cost feature-a#multiply_factor)",
+       *   "feature_multiplies_numeric_value": "(* feature-c#number feature-a#multiply_factor)",
+       *   "feature_multiplies_total_cost": "(* plan#total_cost feature-a#multiply_factor)",
+       *   "feature_nested_formulas": "(+ (- (* feature-a#cost feature-b#multiply_factor) 500) plan#partial_cost)"
+       * }
        */
       readonly formula?: definitions['PriceFormula']
       /** @description Description explains how a feature is calculated to the user. */
@@ -834,7 +840,7 @@ export interface definitions {
   readonly ProductTags: readonly definitions['Label'][]
   /** @enum {string} */
   readonly ProductState: 'available' | 'hidden' | 'grandfathered' | 'new' | 'upcoming'
-  /** @default [object Object] */
+  /** @default {} */
   readonly ProductListing: {
     /**
      * @description When true, everyone can see the product when requested. When false it will
@@ -859,7 +865,7 @@ export interface definitions {
      * we find ourselves in a position where we think they should, we should
      * consider refactoring our listing definition.
      *
-     * @default [object Object]
+     * @default {}
      */
     readonly marketing?: {
       /**
@@ -898,7 +904,7 @@ export interface definitions {
    * @enum {string}
    */
   readonly ProductProvisioning: 'provider-only' | 'pre-order' | 'public'
-  /** @default [object Object] */
+  /** @default {} */
   readonly ProductIntegrationFeatures: {
     /**
      * @description Indicates whether or not this product supports resource transitions to

--- a/test/v2/expected/manifold.ts
+++ b/test/v2/expected/manifold.ts
@@ -639,7 +639,7 @@ export interface definitions {
       sso_url?: string
       /** @enum {string} */
       version?: 'v1'
-      /** @default [object Object] */
+      /** @default {} */
       features?: {
         access_code?: boolean
         sso?: boolean
@@ -762,7 +762,13 @@ export interface definitions {
       /**
        * @description Price describes how the feature cost should be calculated.
        *
-       * @example [object Object]
+       * @example {
+       *   "feature_multiplies_base_cost": "(* plan#base_cost feature-a#multiply_factor)",
+       *   "feature_multiplies_feature_cost": "(* feature-b#cost feature-a#multiply_factor)",
+       *   "feature_multiplies_numeric_value": "(* feature-c#number feature-a#multiply_factor)",
+       *   "feature_multiplies_total_cost": "(* plan#total_cost feature-a#multiply_factor)",
+       *   "feature_nested_formulas": "(+ (- (* feature-a#cost feature-b#multiply_factor) 500) plan#partial_cost)"
+       * }
        */
       formula?: definitions['PriceFormula']
       /** @description Description explains how a feature is calculated to the user. */
@@ -834,7 +840,7 @@ export interface definitions {
   ProductTags: definitions['Label'][]
   /** @enum {string} */
   ProductState: 'available' | 'hidden' | 'grandfathered' | 'new' | 'upcoming'
-  /** @default [object Object] */
+  /** @default {} */
   ProductListing: {
     /**
      * @description When true, everyone can see the product when requested. When false it will
@@ -859,7 +865,7 @@ export interface definitions {
      * we find ourselves in a position where we think they should, we should
      * consider refactoring our listing definition.
      *
-     * @default [object Object]
+     * @default {}
      */
     marketing?: {
       /**
@@ -898,7 +904,7 @@ export interface definitions {
    * @enum {string}
    */
   ProductProvisioning: 'provider-only' | 'pre-order' | 'public'
-  /** @default [object Object] */
+  /** @default {} */
   ProductIntegrationFeatures: {
     /**
      * @description Indicates whether or not this product supports resource transitions to

--- a/test/v3/expected/github.additional.ts
+++ b/test/v3/expected/github.additional.ts
@@ -6087,7 +6087,10 @@ export interface components {
       updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       permissions: {
         issues?: string
@@ -6098,7 +6101,10 @@ export interface components {
       } & { [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       events: string[]
       /**
@@ -6449,7 +6455,12 @@ export interface components {
     /**
      * App Permissions
      * @description The permissions granted to the user-to-server access token.
-     * @example [object Object]
+     * @example {
+     *   "contents": "read",
+     *   "issues": "read",
+     *   "deployments": "write",
+     *   "single_file": "read"
+     * }
      */
     'app-permissions': {
       /**
@@ -6650,7 +6661,12 @@ export interface components {
       single_file_name: string | null
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
       /** @example github-actions */
       app_slug: string
@@ -7105,7 +7121,12 @@ export interface components {
       single_file?: string
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
     } & { [key: string]: unknown }
     /**
@@ -7136,7 +7157,11 @@ export interface components {
        * @example 2011-09-06T20:39:23Z
        */
       updated_at: string
-      /** @example public_repo */
+      /**
+       * @example [
+       *   "public_repo"
+       * ]
+       */
       scopes: string[]
       user?: components['schemas']['nullable-simple-user']
     } & { [key: string]: unknown }
@@ -7153,7 +7178,12 @@ export interface components {
           single_file_name: string | null
           /** @example true */
           has_multiple_single_files?: boolean
-          /** @example config.yml,.github/issue_TEMPLATE.md */
+          /**
+           * @example [
+           *   "config.yml",
+           *   ".github/issue_TEMPLATE.md"
+           * ]
+           */
           single_file_paths?: string[]
           /**
            * Format: uri
@@ -7410,7 +7440,12 @@ export interface components {
        * @example 2016-07-11T22:14:10Z
        */
       expires_at: string
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
+       */
       permissions?: { [key: string]: unknown }
       /** @description The repositories this token has access to */
       repositories?: components['schemas']['repository'][]
@@ -8330,7 +8365,10 @@ export interface components {
           updated_at: string
           /**
            * @description The set of permissions for the GitHub app
-           * @example [object Object]
+           * @example {
+           *   "issues": "read",
+           *   "deployments": "write"
+           * }
            */
           permissions: {
             issues?: string
@@ -8341,7 +8379,10 @@ export interface components {
           } & { [key: string]: string }
           /**
            * @description The list of events for the GitHub app
-           * @example label,deployment
+           * @example [
+           *   "label",
+           *   "deployment"
+           * ]
            */
           events: string[]
           /**
@@ -8425,7 +8466,10 @@ export interface components {
       user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       labels: ((
         | string
@@ -8576,7 +8620,11 @@ export interface components {
       current_user_actor_url?: string
       /** @example https://github.com/octocat-org */
       current_user_organization_url?: string
-      /** @example https://github.com/organizations/github/octocat.private.atom?token=abc123 */
+      /**
+       * @example [
+       *   "https://github.com/organizations/github/octocat.private.atom?token=abc123"
+       * ]
+       */
       current_user_organization_urls?: string[]
       /** @example https://github.com/security-advisories */
       security_advisories_url?: string
@@ -8946,11 +8994,27 @@ export interface components {
       description: string
       /** @example Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. */
       implementation: string
-      /** @example commercial-use,modifications,distribution,sublicense,private-use */
+      /**
+       * @example [
+       *   "commercial-use",
+       *   "modifications",
+       *   "distribution",
+       *   "sublicense",
+       *   "private-use"
+       * ]
+       */
       permissions: string[]
-      /** @example include-copyright */
+      /**
+       * @example [
+       *   "include-copyright"
+       * ]
+       */
       conditions: string[]
-      /** @example no-liability */
+      /**
+       * @example [
+       *   "no-liability"
+       * ]
+       */
       limitations: string[]
       /**
        * @example
@@ -9015,7 +9079,12 @@ export interface components {
       unit_name: string | null
       /** @example published */
       state: string
-      /** @example Up to 25 private repositories,11 concurrent builds */
+      /**
+       * @example [
+       *   "Up to 25 private repositories",
+       *   "11 concurrent builds"
+       * ]
+       */
       bullets: string[]
     } & { [key: string]: unknown }
     /**
@@ -9062,25 +9131,71 @@ export interface components {
         SHA256_ECDSA?: string
         SHA256_ED25519?: string
       } & { [key: string]: unknown }
-      /** @example ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl */
+      /**
+       * @example [
+       *   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+       * ]
+       */
       ssh_keys?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       hooks?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       web?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       api?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       git?: string[]
-      /** @example 13.65.0.0/16,157.55.204.33/32,2a01:111:f403:f90c::/62 */
+      /**
+       * @example [
+       *   "13.65.0.0/16",
+       *   "157.55.204.33/32",
+       *   "2a01:111:f403:f90c::/62"
+       * ]
+       */
       packages?: string[]
-      /** @example 192.30.252.153/32,192.30.252.154/32 */
+      /**
+       * @example [
+       *   "192.30.252.153/32",
+       *   "192.30.252.154/32"
+       * ]
+       */
       pages?: string[]
-      /** @example 54.158.161.132,54.226.70.38 */
+      /**
+       * @example [
+       *   "54.158.161.132",
+       *   "54.226.70.38"
+       * ]
+       */
       importer?: string[]
-      /** @example 13.64.0.0/16,13.65.0.0/16 */
+      /**
+       * @example [
+       *   "13.64.0.0/16",
+       *   "13.65.0.0/16"
+       * ]
+       */
       actions?: string[]
-      /** @example 192.168.7.15/32,192.168.7.16/32 */
+      /**
+       * @example [
+       *   "192.168.7.15/32",
+       *   "192.168.7.16/32"
+       * ]
+       */
       dependabot?: string[]
     } & { [key: string]: unknown }
     /**
@@ -9149,7 +9264,18 @@ export interface components {
     'external-groups': {
       /**
        * @description An array of external groups available to be mapped to a team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": 1,
+       *     "group_name": "group-azuread-test",
+       *     "updated_at": "2021-01-03 22:27:15:000 -700"
+       *   },
+       *   {
+       *     "group_id": 2,
+       *     "group_name": "group-azuread-test2",
+       *     "updated_at": "2021-06-03 22:27:15:000 -700"
+       *   }
+       * ]
        */
       groups?: ({
         /**
@@ -9547,7 +9673,10 @@ export interface components {
       credential_authorized_at: string
       /**
        * @description List of oauth scopes the token has been granted.
-       * @example user,repo
+       * @example [
+       *   "user",
+       *   "repo"
+       * ]
        */
       scopes?: string[]
       /**
@@ -9642,7 +9771,16 @@ export interface components {
       updated_at?: string
       /**
        * @description An array of teams linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "team_id": 1,
+       *     "team_name": "team-test"
+       *   },
+       *   {
+       *     "team_id": 2,
+       *     "team_name": "team-test2"
+       *   }
+       * ]
        */
       teams: ({
         /**
@@ -9658,7 +9796,20 @@ export interface components {
       } & { [key: string]: unknown })[]
       /**
        * @description An array of external members linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "member_id": 1,
+       *     "member_login": "mona-lisa_eocsaxrs",
+       *     "member_name": "Mona Lisa",
+       *     "member_email": "mona_lisa@github.com"
+       *   },
+       *   {
+       *     "member_id": 2,
+       *     "member_login": "octo-lisa_eocsaxrs",
+       *     "member_name": "Octo Lisa",
+       *     "member_email": "octo_lisa@github.com"
+       *   }
+       * ]
        */
       members: ({
         /**
@@ -9726,7 +9877,12 @@ export interface components {
       deliveries_url?: string
       /** @example web */
       name: string
-      /** @example push,pull_request */
+      /**
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
+       */
       events: string[]
       /** @example true */
       active: boolean
@@ -10332,7 +10488,18 @@ export interface components {
     'group-mapping': {
       /**
        * @description Array of groups to be mapped to this team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": "111a1a11-aaa1-1aaa-11a1-a1a1a1a1a1aa",
+       *     "group_name": "saml-azuread-test",
+       *     "group_description": "A group of Developers working on AzureAD SAML SSO"
+       *   },
+       *   {
+       *     "group_id": "2bb2bb2b-bb22-22bb-2bb2-bb2bbb2bb2b2",
+       *     "group_name": "saml-azuread-test2",
+       *     "group_description": "Another group of Developers working on AzureAD SAML SSO"
+       *   }
+       * ]
        */
       groups?: ({
         /**
@@ -11257,7 +11424,14 @@ export interface components {
       open_issues_count: number
       /** @example true */
       is_template?: boolean
-      /** @example octocat,atom,electron,API */
+      /**
+       * @example [
+       *   "octocat",
+       *   "atom",
+       *   "electron",
+       *   "API"
+       * ]
+       */
       topics?: string[]
       /** @example true */
       has_issues: boolean
@@ -11473,7 +11647,11 @@ export interface components {
       check_run_url: string
       /**
        * @description Labels for the workflow job. Specified by the "runs_on" attribute in the action's workflow file.
-       * @example self-hosted,foo,bar
+       * @example [
+       *   "self-hosted",
+       *   "foo",
+       *   "bar"
+       * ]
        */
       labels: string[]
       /**
@@ -12351,7 +12529,11 @@ export interface components {
       url: string
       /** @example true */
       strict: boolean
-      /** @example continuous-integration/travis-ci */
+      /**
+       * @example [
+       *   "continuous-integration/travis-ci"
+       * ]
+       */
       contexts: string[]
       checks: ({
         /** @example continuous-integration/travis-ci */
@@ -14183,7 +14365,44 @@ export interface components {
       truncated: boolean
       /**
        * @description Objects specifying a tree structure
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "path": "file.rb",
+       *     "mode": "100644",
+       *     "type": "blob",
+       *     "size": 30,
+       *     "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "properties": {
+       *       "path": {
+       *         "type": "string"
+       *       },
+       *       "mode": {
+       *         "type": "string"
+       *       },
+       *       "type": {
+       *         "type": "string"
+       *       },
+       *       "size": {
+       *         "type": "integer"
+       *       },
+       *       "sha": {
+       *         "type": "string"
+       *       },
+       *       "url": {
+       *         "type": "string"
+       *       }
+       *     },
+       *     "required": [
+       *       "path",
+       *       "mode",
+       *       "type",
+       *       "sha",
+       *       "url",
+       *       "size"
+       *     ]
+       *   }
+       * ]
        */
       tree: ({
         /** @example test/file.rb */
@@ -14229,7 +14448,10 @@ export interface components {
       active: boolean
       /**
        * @description Determines what events the hook is triggered for. Default: ['push'].
-       * @example push,pull_request
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
        */
       events: string[]
       config: {
@@ -14408,7 +14630,10 @@ export interface components {
           user: components['schemas']['nullable-simple-user']
           /**
            * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-           * @example bug,registration
+           * @example [
+           *   "bug",
+           *   "registration"
+           * ]
            */
           labels: ((
             | string
@@ -15476,7 +15701,10 @@ export interface components {
       description: string
       /**
        * @description Array of the domain set and its alternate name (if it is configured)
-       * @example example.com,www.example.com
+       * @example [
+       *   "example.com",
+       *   "www.example.com"
+       * ]
        */
       domains: string[]
       /** Format: date */
@@ -16556,7 +16784,17 @@ export interface components {
      * @description Commit Activity
      */
     'commit-activity': {
-      /** @example 0,3,26,20,39,1,0 */
+      /**
+       * @example [
+       *   0,
+       *   3,
+       *   26,
+       *   20,
+       *   39,
+       *   1,
+       *   0
+       * ]
+       */
       days: number[]
       /** @example 89 */
       total: number
@@ -16571,7 +16809,16 @@ export interface components {
       author: components['schemas']['nullable-simple-user']
       /** @example 135 */
       total: number
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "w": "1367712000",
+       *     "a": 6898,
+       *     "d": 77,
+       *     "c": 10
+       *   }
+       * ]
+       */
       weeks: ({
         w?: number
         a?: number
@@ -16822,7 +17069,12 @@ export interface components {
        * @example Jon Doe
        */
       displayName?: string | null
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "givenName": "Jane",
+       *   "familyName": "User"
+       * }
+       */
       name: {
         givenName: string | null
         familyName: string | null
@@ -16830,7 +17082,16 @@ export interface components {
       } & { [key: string]: unknown }
       /**
        * @description user emails
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "value": "someone@example.com",
+       *     "primary": true
+       *   },
+       *   {
+       *     "value": "another@example.com",
+       *     "primary": false
+       *   }
+       * ]
        */
       emails: ({
         value: string
@@ -16864,7 +17125,14 @@ export interface components {
       organization_id?: number
       /**
        * @description Set of operations to be performed
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "op": "replace",
+       *     "value": {
+       *       "active": false
+       *     }
+       *   }
+       * ]
        */
       operations?: ({
         /** @enum {string} */
@@ -16924,7 +17192,12 @@ export interface components {
       language?: string | null
       /** Format: date-time */
       last_modified_at?: string
-      /** @example 73..77,77..78 */
+      /**
+       * @example [
+       *   "73..77",
+       *   "77..78"
+       * ]
+       */
       line_numbers?: string[]
       text_matches?: components['schemas']['search-result-text-matches']
     } & { [key: string]: unknown }
@@ -17503,12 +17776,36 @@ export interface components {
       key_id: string
       /** @example xsBNBFayYZ... */
       public_key: string
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "email": "mastahyeti@users.noreply.github.com",
+       *     "verified": true
+       *   }
+       * ]
+       */
       emails: ({
         email?: string
         verified?: boolean
       } & { [key: string]: unknown })[]
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "id": 4,
+       *     "primary_key_id": 3,
+       *     "key_id": "4A595D4C72EE49C7",
+       *     "public_key": "zsBNBFayYZ...",
+       *     "emails": [],
+       *     "subkeys": [],
+       *     "can_sign": false,
+       *     "can_encrypt_comms": true,
+       *     "can_encrypt_storage": true,
+       *     "can_certify": false,
+       *     "created_at": "2016-03-24T11:31:04-06:00",
+       *     "expires_at": null
+       *   }
+       * ]
+       */
       subkeys: ({
         id?: number
         primary_key_id?: number
@@ -18365,7 +18662,9 @@ export interface operations {
           repositories?: string[]
           /**
            * @description List of repository IDs that the token should have access to
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           repository_ids?: number[]
           permissions?: components['schemas']['app-permissions']
@@ -18621,7 +18920,9 @@ export interface operations {
           repositories?: string[]
           /**
            * @description The list of repository IDs to scope the user-to-server access token to. `repository_ids` may not be specified if `repositories` is specified.
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           repository_ids?: number[]
           permissions?: components['schemas']['app-permissions']
@@ -18714,7 +19015,10 @@ export interface operations {
         'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18783,7 +19087,10 @@ export interface operations {
           client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18844,7 +19151,10 @@ export interface operations {
           client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18922,7 +19232,10 @@ export interface operations {
         'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /** @description A list of scopes to add to this authorization. */
@@ -20087,7 +20400,11 @@ export interface operations {
           description?: string
           /**
            * @description Names and content for the files that make up the gist
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "puts \"Hello, World!\""
+           *   }
+           * }
            */
           files: {
             [key: string]: {
@@ -20217,7 +20534,12 @@ export interface operations {
               description?: string
               /**
                * @description Names of files to be updated
-               * @example [object Object]
+               * @example {
+               *   "hello.rb": {
+               *     "content": "blah",
+               *     "filename": "goodbye.rb"
+               *   }
+               * }
                */
               files?: { [key: string]: Partial<{ [key: string]: unknown }> }
             } & { [key: string]: unknown })
@@ -23122,7 +23444,9 @@ export interface operations {
           } & { [key: string]: unknown }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -23195,7 +23519,9 @@ export interface operations {
           } & { [key: string]: unknown }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -27555,7 +27881,10 @@ export interface operations {
         'application/json': {
           /**
            * @description The list of environment ids to approve or reject
-           * @example 161171787,161171795
+           * @example [
+           *   161171787,
+           *   161171795
+           * ]
            */
           environment_ids: number[]
           /**
@@ -32680,7 +33009,9 @@ export interface operations {
           } & { [key: string]: unknown }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -32760,7 +33091,9 @@ export interface operations {
           } & { [key: string]: unknown }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /** @description Determines a list of events to be added to the list of events that the Hook triggers for. */
@@ -38011,7 +38344,12 @@ export interface operations {
            * @example Jon Doe
            */
           displayName?: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           name: {
             givenName: string
             familyName: string
@@ -38019,7 +38357,16 @@ export interface operations {
           } & { [key: string]: unknown }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           emails: ({
             value: string
@@ -38097,7 +38444,12 @@ export interface operations {
            * @example someone@example.com
            */
           userName: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           name: {
             givenName: string
             familyName: string
@@ -38105,7 +38457,16 @@ export interface operations {
           } & { [key: string]: unknown }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           emails: ({
             type?: string
@@ -38182,7 +38543,14 @@ export interface operations {
           schemas?: string[]
           /**
            * @description Set of operations to be performed
-           * @example [object Object]
+           * @example [
+           *   {
+           *     "op": "replace",
+           *     "value": {
+           *       "active": false
+           *     }
+           *   }
+           * ]
            */
           Operations: ({
             /** @enum {string} */
@@ -40378,7 +40746,7 @@ export interface operations {
           | ({
               /**
                * @description Adds one or more email addresses to your GitHub account. Must contain at least one email address. **Note:** Alternatively, you can pass a single email address or an `array` of emails addresses directly, but we recommend that you pass an object using the `emails` key.
-               * @example
+               * @example []
                */
               emails: string[]
             } & { [key: string]: unknown })
@@ -41077,7 +41445,9 @@ export interface operations {
           exclude_owner_projects?: boolean
           /**
            * @description Exclude attributes from the API response to improve performance
-           * @example repositories
+           * @example [
+           *   "repositories"
+           * ]
            */
           exclude?: 'repositories'[]
           repositories: string[]

--- a/test/v3/expected/github.exported-type.ts
+++ b/test/v3/expected/github.exported-type.ts
@@ -6085,7 +6085,10 @@ export type components = {
       updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       permissions: {
         issues?: string
@@ -6096,7 +6099,10 @@ export type components = {
       } & { [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       events: string[]
       /**
@@ -6447,7 +6453,12 @@ export type components = {
     /**
      * App Permissions
      * @description The permissions granted to the user-to-server access token.
-     * @example [object Object]
+     * @example {
+     *   "contents": "read",
+     *   "issues": "read",
+     *   "deployments": "write",
+     *   "single_file": "read"
+     * }
      */
     'app-permissions': {
       /**
@@ -6648,7 +6659,12 @@ export type components = {
       single_file_name: string | null
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
       /** @example github-actions */
       app_slug: string
@@ -7099,7 +7115,12 @@ export type components = {
       single_file?: string
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
     }
     /**
@@ -7130,7 +7151,11 @@ export type components = {
        * @example 2011-09-06T20:39:23Z
        */
       updated_at: string
-      /** @example public_repo */
+      /**
+       * @example [
+       *   "public_repo"
+       * ]
+       */
       scopes: string[]
       user?: components['schemas']['nullable-simple-user']
     }
@@ -7146,7 +7171,12 @@ export type components = {
       single_file_name: string | null
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
       /**
        * Format: uri
@@ -7402,7 +7432,12 @@ export type components = {
        * @example 2016-07-11T22:14:10Z
        */
       expires_at: string
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
+       */
       permissions?: { [key: string]: unknown }
       /** @description The repositories this token has access to */
       repositories?: components['schemas']['repository'][]
@@ -8313,7 +8348,10 @@ export type components = {
       updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       permissions: {
         issues?: string
@@ -8324,7 +8362,10 @@ export type components = {
       } & { [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       events: string[]
       /**
@@ -8407,7 +8448,10 @@ export type components = {
       user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       labels: (
         | string
@@ -8558,7 +8602,11 @@ export type components = {
       current_user_actor_url?: string
       /** @example https://github.com/octocat-org */
       current_user_organization_url?: string
-      /** @example https://github.com/organizations/github/octocat.private.atom?token=abc123 */
+      /**
+       * @example [
+       *   "https://github.com/organizations/github/octocat.private.atom?token=abc123"
+       * ]
+       */
       current_user_organization_urls?: string[]
       /** @example https://github.com/security-advisories */
       security_advisories_url?: string
@@ -8924,11 +8972,27 @@ export type components = {
       description: string
       /** @example Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. */
       implementation: string
-      /** @example commercial-use,modifications,distribution,sublicense,private-use */
+      /**
+       * @example [
+       *   "commercial-use",
+       *   "modifications",
+       *   "distribution",
+       *   "sublicense",
+       *   "private-use"
+       * ]
+       */
       permissions: string[]
-      /** @example include-copyright */
+      /**
+       * @example [
+       *   "include-copyright"
+       * ]
+       */
       conditions: string[]
-      /** @example no-liability */
+      /**
+       * @example [
+       *   "no-liability"
+       * ]
+       */
       limitations: string[]
       /**
        * @example
@@ -8993,7 +9057,12 @@ export type components = {
       unit_name: string | null
       /** @example published */
       state: string
-      /** @example Up to 25 private repositories,11 concurrent builds */
+      /**
+       * @example [
+       *   "Up to 25 private repositories",
+       *   "11 concurrent builds"
+       * ]
+       */
       bullets: string[]
     }
     /**
@@ -9038,25 +9107,71 @@ export type components = {
         SHA256_ECDSA?: string
         SHA256_ED25519?: string
       }
-      /** @example ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl */
+      /**
+       * @example [
+       *   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+       * ]
+       */
       ssh_keys?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       hooks?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       web?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       api?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       git?: string[]
-      /** @example 13.65.0.0/16,157.55.204.33/32,2a01:111:f403:f90c::/62 */
+      /**
+       * @example [
+       *   "13.65.0.0/16",
+       *   "157.55.204.33/32",
+       *   "2a01:111:f403:f90c::/62"
+       * ]
+       */
       packages?: string[]
-      /** @example 192.30.252.153/32,192.30.252.154/32 */
+      /**
+       * @example [
+       *   "192.30.252.153/32",
+       *   "192.30.252.154/32"
+       * ]
+       */
       pages?: string[]
-      /** @example 54.158.161.132,54.226.70.38 */
+      /**
+       * @example [
+       *   "54.158.161.132",
+       *   "54.226.70.38"
+       * ]
+       */
       importer?: string[]
-      /** @example 13.64.0.0/16,13.65.0.0/16 */
+      /**
+       * @example [
+       *   "13.64.0.0/16",
+       *   "13.65.0.0/16"
+       * ]
+       */
       actions?: string[]
-      /** @example 192.168.7.15/32,192.168.7.16/32 */
+      /**
+       * @example [
+       *   "192.168.7.15/32",
+       *   "192.168.7.16/32"
+       * ]
+       */
       dependabot?: string[]
     }
     /**
@@ -9125,7 +9240,18 @@ export type components = {
     'external-groups': {
       /**
        * @description An array of external groups available to be mapped to a team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": 1,
+       *     "group_name": "group-azuread-test",
+       *     "updated_at": "2021-01-03 22:27:15:000 -700"
+       *   },
+       *   {
+       *     "group_id": 2,
+       *     "group_name": "group-azuread-test2",
+       *     "updated_at": "2021-06-03 22:27:15:000 -700"
+       *   }
+       * ]
        */
       groups?: {
         /**
@@ -9523,7 +9649,10 @@ export type components = {
       credential_authorized_at: string
       /**
        * @description List of oauth scopes the token has been granted.
-       * @example user,repo
+       * @example [
+       *   "user",
+       *   "repo"
+       * ]
        */
       scopes?: string[]
       /**
@@ -9618,7 +9747,16 @@ export type components = {
       updated_at?: string
       /**
        * @description An array of teams linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "team_id": 1,
+       *     "team_name": "team-test"
+       *   },
+       *   {
+       *     "team_id": 2,
+       *     "team_name": "team-test2"
+       *   }
+       * ]
        */
       teams: {
         /**
@@ -9634,7 +9772,20 @@ export type components = {
       }[]
       /**
        * @description An array of external members linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "member_id": 1,
+       *     "member_login": "mona-lisa_eocsaxrs",
+       *     "member_name": "Mona Lisa",
+       *     "member_email": "mona_lisa@github.com"
+       *   },
+       *   {
+       *     "member_id": 2,
+       *     "member_login": "octo-lisa_eocsaxrs",
+       *     "member_name": "Octo Lisa",
+       *     "member_email": "octo_lisa@github.com"
+       *   }
+       * ]
        */
       members: {
         /**
@@ -9702,7 +9853,12 @@ export type components = {
       deliveries_url?: string
       /** @example web */
       name: string
-      /** @example push,pull_request */
+      /**
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
+       */
       events: string[]
       /** @example true */
       active: boolean
@@ -10302,7 +10458,18 @@ export type components = {
     'group-mapping': {
       /**
        * @description Array of groups to be mapped to this team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": "111a1a11-aaa1-1aaa-11a1-a1a1a1a1a1aa",
+       *     "group_name": "saml-azuread-test",
+       *     "group_description": "A group of Developers working on AzureAD SAML SSO"
+       *   },
+       *   {
+       *     "group_id": "2bb2bb2b-bb22-22bb-2bb2-bb2bbb2bb2b2",
+       *     "group_name": "saml-azuread-test2",
+       *     "group_description": "Another group of Developers working on AzureAD SAML SSO"
+       *   }
+       * ]
        */
       groups?: {
         /**
@@ -11227,7 +11394,14 @@ export type components = {
       open_issues_count: number
       /** @example true */
       is_template?: boolean
-      /** @example octocat,atom,electron,API */
+      /**
+       * @example [
+       *   "octocat",
+       *   "atom",
+       *   "electron",
+       *   "API"
+       * ]
+       */
       topics?: string[]
       /** @example true */
       has_issues: boolean
@@ -11441,7 +11615,11 @@ export type components = {
       check_run_url: string
       /**
        * @description Labels for the workflow job. Specified by the "runs_on" attribute in the action's workflow file.
-       * @example self-hosted,foo,bar
+       * @example [
+       *   "self-hosted",
+       *   "foo",
+       *   "bar"
+       * ]
        */
       labels: string[]
       /**
@@ -12309,7 +12487,11 @@ export type components = {
       url: string
       /** @example true */
       strict: boolean
-      /** @example continuous-integration/travis-ci */
+      /**
+       * @example [
+       *   "continuous-integration/travis-ci"
+       * ]
+       */
       contexts: string[]
       checks: {
         /** @example continuous-integration/travis-ci */
@@ -14115,7 +14297,44 @@ export type components = {
       truncated: boolean
       /**
        * @description Objects specifying a tree structure
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "path": "file.rb",
+       *     "mode": "100644",
+       *     "type": "blob",
+       *     "size": 30,
+       *     "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "properties": {
+       *       "path": {
+       *         "type": "string"
+       *       },
+       *       "mode": {
+       *         "type": "string"
+       *       },
+       *       "type": {
+       *         "type": "string"
+       *       },
+       *       "size": {
+       *         "type": "integer"
+       *       },
+       *       "sha": {
+       *         "type": "string"
+       *       },
+       *       "url": {
+       *         "type": "string"
+       *       }
+       *     },
+       *     "required": [
+       *       "path",
+       *       "mode",
+       *       "type",
+       *       "sha",
+       *       "url",
+       *       "size"
+       *     ]
+       *   }
+       * ]
        */
       tree: {
         /** @example test/file.rb */
@@ -14161,7 +14380,10 @@ export type components = {
       active: boolean
       /**
        * @description Determines what events the hook is triggered for. Default: ['push'].
-       * @example push,pull_request
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
        */
       events: string[]
       config: {
@@ -14339,7 +14561,10 @@ export type components = {
       user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       labels: (
         | string
@@ -15406,7 +15631,10 @@ export type components = {
       description: string
       /**
        * @description Array of the domain set and its alternate name (if it is configured)
-       * @example example.com,www.example.com
+       * @example [
+       *   "example.com",
+       *   "www.example.com"
+       * ]
        */
       domains: string[]
       /** Format: date */
@@ -16480,7 +16708,17 @@ export type components = {
      * @description Commit Activity
      */
     'commit-activity': {
-      /** @example 0,3,26,20,39,1,0 */
+      /**
+       * @example [
+       *   0,
+       *   3,
+       *   26,
+       *   20,
+       *   39,
+       *   1,
+       *   0
+       * ]
+       */
       days: number[]
       /** @example 89 */
       total: number
@@ -16495,7 +16733,16 @@ export type components = {
       author: components['schemas']['nullable-simple-user']
       /** @example 135 */
       total: number
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "w": "1367712000",
+       *     "a": 6898,
+       *     "d": 77,
+       *     "c": 10
+       *   }
+       * ]
+       */
       weeks: {
         w?: number
         a?: number
@@ -16746,7 +16993,12 @@ export type components = {
        * @example Jon Doe
        */
       displayName?: string | null
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "givenName": "Jane",
+       *   "familyName": "User"
+       * }
+       */
       name: {
         givenName: string | null
         familyName: string | null
@@ -16754,7 +17006,16 @@ export type components = {
       }
       /**
        * @description user emails
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "value": "someone@example.com",
+       *     "primary": true
+       *   },
+       *   {
+       *     "value": "another@example.com",
+       *     "primary": false
+       *   }
+       * ]
        */
       emails: {
         value: string
@@ -16788,7 +17049,14 @@ export type components = {
       organization_id?: number
       /**
        * @description Set of operations to be performed
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "op": "replace",
+       *     "value": {
+       *       "active": false
+       *     }
+       *   }
+       * ]
        */
       operations?: {
         /** @enum {string} */
@@ -16848,7 +17116,12 @@ export type components = {
       language?: string | null
       /** Format: date-time */
       last_modified_at?: string
-      /** @example 73..77,77..78 */
+      /**
+       * @example [
+       *   "73..77",
+       *   "77..78"
+       * ]
+       */
       line_numbers?: string[]
       text_matches?: components['schemas']['search-result-text-matches']
     }
@@ -17427,12 +17700,36 @@ export type components = {
       key_id: string
       /** @example xsBNBFayYZ... */
       public_key: string
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "email": "mastahyeti@users.noreply.github.com",
+       *     "verified": true
+       *   }
+       * ]
+       */
       emails: {
         email?: string
         verified?: boolean
       }[]
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "id": 4,
+       *     "primary_key_id": 3,
+       *     "key_id": "4A595D4C72EE49C7",
+       *     "public_key": "zsBNBFayYZ...",
+       *     "emails": [],
+       *     "subkeys": [],
+       *     "can_sign": false,
+       *     "can_encrypt_comms": true,
+       *     "can_encrypt_storage": true,
+       *     "can_certify": false,
+       *     "created_at": "2016-03-24T11:31:04-06:00",
+       *     "expires_at": null
+       *   }
+       * ]
+       */
       subkeys: {
         id?: number
         primary_key_id?: number
@@ -18289,7 +18586,9 @@ export type operations = {
           repositories?: string[]
           /**
            * @description List of repository IDs that the token should have access to
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           repository_ids?: number[]
           permissions?: components['schemas']['app-permissions']
@@ -18545,7 +18844,9 @@ export type operations = {
           repositories?: string[]
           /**
            * @description The list of repository IDs to scope the user-to-server access token to. `repository_ids` may not be specified if `repositories` is specified.
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           repository_ids?: number[]
           permissions?: components['schemas']['app-permissions']
@@ -18638,7 +18939,10 @@ export type operations = {
         'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18707,7 +19011,10 @@ export type operations = {
           client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18768,7 +19075,10 @@ export type operations = {
           client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18846,7 +19156,10 @@ export type operations = {
         'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /** @description A list of scopes to add to this authorization. */
@@ -20011,7 +20324,11 @@ export type operations = {
           description?: string
           /**
            * @description Names and content for the files that make up the gist
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "puts \"Hello, World!\""
+           *   }
+           * }
            */
           files: {
             [key: string]: {
@@ -20140,7 +20457,12 @@ export type operations = {
           description?: string
           /**
            * @description Names of files to be updated
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "blah",
+           *     "filename": "goodbye.rb"
+           *   }
+           * }
            */
           files?: { [key: string]: Partial<{ [key: string]: unknown }> }
         } | null
@@ -23042,7 +23364,9 @@ export type operations = {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -23115,7 +23439,9 @@ export type operations = {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -27464,7 +27790,10 @@ export type operations = {
         'application/json': {
           /**
            * @description The list of environment ids to approve or reject
-           * @example 161171787,161171795
+           * @example [
+           *   161171787,
+           *   161171795
+           * ]
            */
           environment_ids: number[]
           /**
@@ -32564,7 +32893,9 @@ export type operations = {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -32644,7 +32975,9 @@ export type operations = {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /** @description Determines a list of events to be added to the list of events that the Hook triggers for. */
@@ -37877,7 +38210,12 @@ export type operations = {
            * @example Jon Doe
            */
           displayName?: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           name: {
             givenName: string
             familyName: string
@@ -37885,7 +38223,16 @@ export type operations = {
           }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           emails: {
             value: string
@@ -37963,7 +38310,12 @@ export type operations = {
            * @example someone@example.com
            */
           userName: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           name: {
             givenName: string
             familyName: string
@@ -37971,7 +38323,16 @@ export type operations = {
           }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           emails: {
             type?: string
@@ -38048,7 +38409,14 @@ export type operations = {
           schemas?: string[]
           /**
            * @description Set of operations to be performed
-           * @example [object Object]
+           * @example [
+           *   {
+           *     "op": "replace",
+           *     "value": {
+           *       "active": false
+           *     }
+           *   }
+           * ]
            */
           Operations: {
             /** @enum {string} */
@@ -40242,7 +40610,7 @@ export type operations = {
           | {
               /**
                * @description Adds one or more email addresses to your GitHub account. Must contain at least one email address. **Note:** Alternatively, you can pass a single email address or an `array` of emails addresses directly, but we recommend that you pass an object using the `emails` key.
-               * @example
+               * @example []
                */
               emails: string[]
             }
@@ -40937,7 +41305,9 @@ export type operations = {
           exclude_owner_projects?: boolean
           /**
            * @description Exclude attributes from the API response to improve performance
-           * @example repositories
+           * @example [
+           *   "repositories"
+           * ]
            */
           exclude?: 'repositories'[]
           repositories: string[]

--- a/test/v3/expected/github.immutable.ts
+++ b/test/v3/expected/github.immutable.ts
@@ -6085,7 +6085,10 @@ export interface components {
       readonly updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       readonly permissions: {
         readonly issues?: string
@@ -6096,7 +6099,10 @@ export interface components {
       } & { readonly [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       readonly events: readonly string[]
       /**
@@ -6447,7 +6453,12 @@ export interface components {
     /**
      * App Permissions
      * @description The permissions granted to the user-to-server access token.
-     * @example [object Object]
+     * @example {
+     *   "contents": "read",
+     *   "issues": "read",
+     *   "deployments": "write",
+     *   "single_file": "read"
+     * }
      */
     readonly 'app-permissions': {
       /**
@@ -6648,7 +6659,12 @@ export interface components {
       readonly single_file_name: string | null
       /** @example true */
       readonly has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       readonly single_file_paths?: readonly string[]
       /** @example github-actions */
       readonly app_slug: string
@@ -7099,7 +7115,12 @@ export interface components {
       readonly single_file?: string
       /** @example true */
       readonly has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       readonly single_file_paths?: readonly string[]
     }
     /**
@@ -7130,7 +7151,11 @@ export interface components {
        * @example 2011-09-06T20:39:23Z
        */
       readonly updated_at: string
-      /** @example public_repo */
+      /**
+       * @example [
+       *   "public_repo"
+       * ]
+       */
       readonly scopes: readonly string[]
       readonly user?: components['schemas']['nullable-simple-user']
     }
@@ -7146,7 +7171,12 @@ export interface components {
       readonly single_file_name: string | null
       /** @example true */
       readonly has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       readonly single_file_paths?: readonly string[]
       /**
        * Format: uri
@@ -7402,7 +7432,12 @@ export interface components {
        * @example 2016-07-11T22:14:10Z
        */
       readonly expires_at: string
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
+       */
       readonly permissions?: { readonly [key: string]: unknown }
       /** @description The repositories this token has access to */
       readonly repositories?: readonly components['schemas']['repository'][]
@@ -8313,7 +8348,10 @@ export interface components {
       readonly updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       readonly permissions: {
         readonly issues?: string
@@ -8324,7 +8362,10 @@ export interface components {
       } & { readonly [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       readonly events: readonly string[]
       /**
@@ -8407,7 +8448,10 @@ export interface components {
       readonly user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       readonly labels: readonly (
         | string
@@ -8558,7 +8602,11 @@ export interface components {
       readonly current_user_actor_url?: string
       /** @example https://github.com/octocat-org */
       readonly current_user_organization_url?: string
-      /** @example https://github.com/organizations/github/octocat.private.atom?token=abc123 */
+      /**
+       * @example [
+       *   "https://github.com/organizations/github/octocat.private.atom?token=abc123"
+       * ]
+       */
       readonly current_user_organization_urls?: readonly string[]
       /** @example https://github.com/security-advisories */
       readonly security_advisories_url?: string
@@ -8924,11 +8972,27 @@ export interface components {
       readonly description: string
       /** @example Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. */
       readonly implementation: string
-      /** @example commercial-use,modifications,distribution,sublicense,private-use */
+      /**
+       * @example [
+       *   "commercial-use",
+       *   "modifications",
+       *   "distribution",
+       *   "sublicense",
+       *   "private-use"
+       * ]
+       */
       readonly permissions: readonly string[]
-      /** @example include-copyright */
+      /**
+       * @example [
+       *   "include-copyright"
+       * ]
+       */
       readonly conditions: readonly string[]
-      /** @example no-liability */
+      /**
+       * @example [
+       *   "no-liability"
+       * ]
+       */
       readonly limitations: readonly string[]
       /**
        * @example
@@ -8993,7 +9057,12 @@ export interface components {
       readonly unit_name: string | null
       /** @example published */
       readonly state: string
-      /** @example Up to 25 private repositories,11 concurrent builds */
+      /**
+       * @example [
+       *   "Up to 25 private repositories",
+       *   "11 concurrent builds"
+       * ]
+       */
       readonly bullets: readonly string[]
     }
     /**
@@ -9038,25 +9107,71 @@ export interface components {
         readonly SHA256_ECDSA?: string
         readonly SHA256_ED25519?: string
       }
-      /** @example ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl */
+      /**
+       * @example [
+       *   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+       * ]
+       */
       readonly ssh_keys?: readonly string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       readonly hooks?: readonly string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       readonly web?: readonly string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       readonly api?: readonly string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       readonly git?: readonly string[]
-      /** @example 13.65.0.0/16,157.55.204.33/32,2a01:111:f403:f90c::/62 */
+      /**
+       * @example [
+       *   "13.65.0.0/16",
+       *   "157.55.204.33/32",
+       *   "2a01:111:f403:f90c::/62"
+       * ]
+       */
       readonly packages?: readonly string[]
-      /** @example 192.30.252.153/32,192.30.252.154/32 */
+      /**
+       * @example [
+       *   "192.30.252.153/32",
+       *   "192.30.252.154/32"
+       * ]
+       */
       readonly pages?: readonly string[]
-      /** @example 54.158.161.132,54.226.70.38 */
+      /**
+       * @example [
+       *   "54.158.161.132",
+       *   "54.226.70.38"
+       * ]
+       */
       readonly importer?: readonly string[]
-      /** @example 13.64.0.0/16,13.65.0.0/16 */
+      /**
+       * @example [
+       *   "13.64.0.0/16",
+       *   "13.65.0.0/16"
+       * ]
+       */
       readonly actions?: readonly string[]
-      /** @example 192.168.7.15/32,192.168.7.16/32 */
+      /**
+       * @example [
+       *   "192.168.7.15/32",
+       *   "192.168.7.16/32"
+       * ]
+       */
       readonly dependabot?: readonly string[]
     }
     /**
@@ -9125,7 +9240,18 @@ export interface components {
     readonly 'external-groups': {
       /**
        * @description An array of external groups available to be mapped to a team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": 1,
+       *     "group_name": "group-azuread-test",
+       *     "updated_at": "2021-01-03 22:27:15:000 -700"
+       *   },
+       *   {
+       *     "group_id": 2,
+       *     "group_name": "group-azuread-test2",
+       *     "updated_at": "2021-06-03 22:27:15:000 -700"
+       *   }
+       * ]
        */
       readonly groups?: readonly {
         /**
@@ -9523,7 +9649,10 @@ export interface components {
       readonly credential_authorized_at: string
       /**
        * @description List of oauth scopes the token has been granted.
-       * @example user,repo
+       * @example [
+       *   "user",
+       *   "repo"
+       * ]
        */
       readonly scopes?: readonly string[]
       /**
@@ -9618,7 +9747,16 @@ export interface components {
       readonly updated_at?: string
       /**
        * @description An array of teams linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "team_id": 1,
+       *     "team_name": "team-test"
+       *   },
+       *   {
+       *     "team_id": 2,
+       *     "team_name": "team-test2"
+       *   }
+       * ]
        */
       readonly teams: readonly {
         /**
@@ -9634,7 +9772,20 @@ export interface components {
       }[]
       /**
        * @description An array of external members linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "member_id": 1,
+       *     "member_login": "mona-lisa_eocsaxrs",
+       *     "member_name": "Mona Lisa",
+       *     "member_email": "mona_lisa@github.com"
+       *   },
+       *   {
+       *     "member_id": 2,
+       *     "member_login": "octo-lisa_eocsaxrs",
+       *     "member_name": "Octo Lisa",
+       *     "member_email": "octo_lisa@github.com"
+       *   }
+       * ]
        */
       readonly members: readonly {
         /**
@@ -9702,7 +9853,12 @@ export interface components {
       readonly deliveries_url?: string
       /** @example web */
       readonly name: string
-      /** @example push,pull_request */
+      /**
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
+       */
       readonly events: readonly string[]
       /** @example true */
       readonly active: boolean
@@ -10302,7 +10458,18 @@ export interface components {
     readonly 'group-mapping': {
       /**
        * @description Array of groups to be mapped to this team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": "111a1a11-aaa1-1aaa-11a1-a1a1a1a1a1aa",
+       *     "group_name": "saml-azuread-test",
+       *     "group_description": "A group of Developers working on AzureAD SAML SSO"
+       *   },
+       *   {
+       *     "group_id": "2bb2bb2b-bb22-22bb-2bb2-bb2bbb2bb2b2",
+       *     "group_name": "saml-azuread-test2",
+       *     "group_description": "Another group of Developers working on AzureAD SAML SSO"
+       *   }
+       * ]
        */
       readonly groups?: readonly {
         /**
@@ -11227,7 +11394,14 @@ export interface components {
       readonly open_issues_count: number
       /** @example true */
       readonly is_template?: boolean
-      /** @example octocat,atom,electron,API */
+      /**
+       * @example [
+       *   "octocat",
+       *   "atom",
+       *   "electron",
+       *   "API"
+       * ]
+       */
       readonly topics?: readonly string[]
       /** @example true */
       readonly has_issues: boolean
@@ -11441,7 +11615,11 @@ export interface components {
       readonly check_run_url: string
       /**
        * @description Labels for the workflow job. Specified by the "runs_on" attribute in the action's workflow file.
-       * @example self-hosted,foo,bar
+       * @example [
+       *   "self-hosted",
+       *   "foo",
+       *   "bar"
+       * ]
        */
       readonly labels: readonly string[]
       /**
@@ -12309,7 +12487,11 @@ export interface components {
       readonly url: string
       /** @example true */
       readonly strict: boolean
-      /** @example continuous-integration/travis-ci */
+      /**
+       * @example [
+       *   "continuous-integration/travis-ci"
+       * ]
+       */
       readonly contexts: readonly string[]
       readonly checks: readonly {
         /** @example continuous-integration/travis-ci */
@@ -14115,7 +14297,44 @@ export interface components {
       readonly truncated: boolean
       /**
        * @description Objects specifying a tree structure
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "path": "file.rb",
+       *     "mode": "100644",
+       *     "type": "blob",
+       *     "size": 30,
+       *     "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "properties": {
+       *       "path": {
+       *         "type": "string"
+       *       },
+       *       "mode": {
+       *         "type": "string"
+       *       },
+       *       "type": {
+       *         "type": "string"
+       *       },
+       *       "size": {
+       *         "type": "integer"
+       *       },
+       *       "sha": {
+       *         "type": "string"
+       *       },
+       *       "url": {
+       *         "type": "string"
+       *       }
+       *     },
+       *     "required": [
+       *       "path",
+       *       "mode",
+       *       "type",
+       *       "sha",
+       *       "url",
+       *       "size"
+       *     ]
+       *   }
+       * ]
        */
       readonly tree: readonly {
         /** @example test/file.rb */
@@ -14161,7 +14380,10 @@ export interface components {
       readonly active: boolean
       /**
        * @description Determines what events the hook is triggered for. Default: ['push'].
-       * @example push,pull_request
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
        */
       readonly events: readonly string[]
       readonly config: {
@@ -14339,7 +14561,10 @@ export interface components {
       readonly user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       readonly labels: readonly (
         | string
@@ -15406,7 +15631,10 @@ export interface components {
       readonly description: string
       /**
        * @description Array of the domain set and its alternate name (if it is configured)
-       * @example example.com,www.example.com
+       * @example [
+       *   "example.com",
+       *   "www.example.com"
+       * ]
        */
       readonly domains: readonly string[]
       /** Format: date */
@@ -16480,7 +16708,17 @@ export interface components {
      * @description Commit Activity
      */
     readonly 'commit-activity': {
-      /** @example 0,3,26,20,39,1,0 */
+      /**
+       * @example [
+       *   0,
+       *   3,
+       *   26,
+       *   20,
+       *   39,
+       *   1,
+       *   0
+       * ]
+       */
       readonly days: readonly number[]
       /** @example 89 */
       readonly total: number
@@ -16495,7 +16733,16 @@ export interface components {
       readonly author: components['schemas']['nullable-simple-user']
       /** @example 135 */
       readonly total: number
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "w": "1367712000",
+       *     "a": 6898,
+       *     "d": 77,
+       *     "c": 10
+       *   }
+       * ]
+       */
       readonly weeks: readonly {
         readonly w?: number
         readonly a?: number
@@ -16746,7 +16993,12 @@ export interface components {
        * @example Jon Doe
        */
       readonly displayName?: string | null
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "givenName": "Jane",
+       *   "familyName": "User"
+       * }
+       */
       readonly name: {
         readonly givenName: string | null
         readonly familyName: string | null
@@ -16754,7 +17006,16 @@ export interface components {
       }
       /**
        * @description user emails
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "value": "someone@example.com",
+       *     "primary": true
+       *   },
+       *   {
+       *     "value": "another@example.com",
+       *     "primary": false
+       *   }
+       * ]
        */
       readonly emails: readonly {
         readonly value: string
@@ -16788,7 +17049,14 @@ export interface components {
       readonly organization_id?: number
       /**
        * @description Set of operations to be performed
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "op": "replace",
+       *     "value": {
+       *       "active": false
+       *     }
+       *   }
+       * ]
        */
       readonly operations?: readonly {
         /** @enum {string} */
@@ -16848,7 +17116,12 @@ export interface components {
       readonly language?: string | null
       /** Format: date-time */
       readonly last_modified_at?: string
-      /** @example 73..77,77..78 */
+      /**
+       * @example [
+       *   "73..77",
+       *   "77..78"
+       * ]
+       */
       readonly line_numbers?: readonly string[]
       readonly text_matches?: components['schemas']['search-result-text-matches']
     }
@@ -17427,12 +17700,36 @@ export interface components {
       readonly key_id: string
       /** @example xsBNBFayYZ... */
       readonly public_key: string
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "email": "mastahyeti@users.noreply.github.com",
+       *     "verified": true
+       *   }
+       * ]
+       */
       readonly emails: readonly {
         readonly email?: string
         readonly verified?: boolean
       }[]
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "id": 4,
+       *     "primary_key_id": 3,
+       *     "key_id": "4A595D4C72EE49C7",
+       *     "public_key": "zsBNBFayYZ...",
+       *     "emails": [],
+       *     "subkeys": [],
+       *     "can_sign": false,
+       *     "can_encrypt_comms": true,
+       *     "can_encrypt_storage": true,
+       *     "can_certify": false,
+       *     "created_at": "2016-03-24T11:31:04-06:00",
+       *     "expires_at": null
+       *   }
+       * ]
+       */
       readonly subkeys: readonly {
         readonly id?: number
         readonly primary_key_id?: number
@@ -18289,7 +18586,9 @@ export interface operations {
           readonly repositories?: readonly string[]
           /**
            * @description List of repository IDs that the token should have access to
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           readonly repository_ids?: readonly number[]
           readonly permissions?: components['schemas']['app-permissions']
@@ -18545,7 +18844,9 @@ export interface operations {
           readonly repositories?: readonly string[]
           /**
            * @description The list of repository IDs to scope the user-to-server access token to. `repository_ids` may not be specified if `repositories` is specified.
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           readonly repository_ids?: readonly number[]
           readonly permissions?: components['schemas']['app-permissions']
@@ -18638,7 +18939,10 @@ export interface operations {
         readonly 'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           readonly scopes?: readonly string[] | null
           /**
@@ -18707,7 +19011,10 @@ export interface operations {
           readonly client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           readonly scopes?: readonly string[] | null
           /**
@@ -18768,7 +19075,10 @@ export interface operations {
           readonly client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           readonly scopes?: readonly string[] | null
           /**
@@ -18846,7 +19156,10 @@ export interface operations {
         readonly 'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           readonly scopes?: readonly string[] | null
           /** @description A list of scopes to add to this authorization. */
@@ -20011,7 +20324,11 @@ export interface operations {
           readonly description?: string
           /**
            * @description Names and content for the files that make up the gist
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "puts \"Hello, World!\""
+           *   }
+           * }
            */
           readonly files: {
             readonly [key: string]: {
@@ -20140,7 +20457,12 @@ export interface operations {
           readonly description?: string
           /**
            * @description Names of files to be updated
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "blah",
+           *     "filename": "goodbye.rb"
+           *   }
+           * }
            */
           readonly files?: { readonly [key: string]: Partial<{ readonly [key: string]: unknown }> }
         } | null
@@ -23042,7 +23364,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           readonly events?: readonly string[]
           /**
@@ -23115,7 +23439,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           readonly events?: readonly string[]
           /**
@@ -27464,7 +27790,10 @@ export interface operations {
         readonly 'application/json': {
           /**
            * @description The list of environment ids to approve or reject
-           * @example 161171787,161171795
+           * @example [
+           *   161171787,
+           *   161171795
+           * ]
            */
           readonly environment_ids: readonly number[]
           /**
@@ -32564,7 +32893,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           readonly events?: readonly string[]
           /**
@@ -32644,7 +32975,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           readonly events?: readonly string[]
           /** @description Determines a list of events to be added to the list of events that the Hook triggers for. */
@@ -37878,7 +38211,12 @@ export interface operations {
            * @example Jon Doe
            */
           readonly displayName?: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           readonly name: {
             readonly givenName: string
             readonly familyName: string
@@ -37886,7 +38224,16 @@ export interface operations {
           }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           readonly emails: readonly {
             readonly value: string
@@ -37964,7 +38311,12 @@ export interface operations {
            * @example someone@example.com
            */
           readonly userName: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           readonly name: {
             readonly givenName: string
             readonly familyName: string
@@ -37972,7 +38324,16 @@ export interface operations {
           }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           readonly emails: readonly {
             readonly type?: string
@@ -38049,7 +38410,14 @@ export interface operations {
           readonly schemas?: readonly string[]
           /**
            * @description Set of operations to be performed
-           * @example [object Object]
+           * @example [
+           *   {
+           *     "op": "replace",
+           *     "value": {
+           *       "active": false
+           *     }
+           *   }
+           * ]
            */
           readonly Operations: readonly {
             /** @enum {string} */
@@ -40243,7 +40611,7 @@ export interface operations {
           | {
               /**
                * @description Adds one or more email addresses to your GitHub account. Must contain at least one email address. **Note:** Alternatively, you can pass a single email address or an `array` of emails addresses directly, but we recommend that you pass an object using the `emails` key.
-               * @example
+               * @example []
                */
               readonly emails: readonly string[]
             }
@@ -40938,7 +41306,9 @@ export interface operations {
           readonly exclude_owner_projects?: boolean
           /**
            * @description Exclude attributes from the API response to improve performance
-           * @example repositories
+           * @example [
+           *   "repositories"
+           * ]
            */
           readonly exclude?: readonly 'repositories'[]
           readonly repositories: readonly string[]

--- a/test/v3/expected/github.support-array-length.ts
+++ b/test/v3/expected/github.support-array-length.ts
@@ -6085,7 +6085,10 @@ export interface components {
       updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       permissions: {
         issues?: string
@@ -6096,7 +6099,10 @@ export interface components {
       } & { [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       events: string[]
       /**
@@ -6447,7 +6453,12 @@ export interface components {
     /**
      * App Permissions
      * @description The permissions granted to the user-to-server access token.
-     * @example [object Object]
+     * @example {
+     *   "contents": "read",
+     *   "issues": "read",
+     *   "deployments": "write",
+     *   "single_file": "read"
+     * }
      */
     'app-permissions': {
       /**
@@ -6648,7 +6659,12 @@ export interface components {
       single_file_name: string | null
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
       /** @example github-actions */
       app_slug: string
@@ -7099,7 +7115,12 @@ export interface components {
       single_file?: string
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
     }
     /**
@@ -7130,7 +7151,11 @@ export interface components {
        * @example 2011-09-06T20:39:23Z
        */
       updated_at: string
-      /** @example public_repo */
+      /**
+       * @example [
+       *   "public_repo"
+       * ]
+       */
       scopes: string[]
       user?: components['schemas']['nullable-simple-user']
     }
@@ -7146,7 +7171,12 @@ export interface components {
       single_file_name: string | null
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
       /**
        * Format: uri
@@ -7402,7 +7432,12 @@ export interface components {
        * @example 2016-07-11T22:14:10Z
        */
       expires_at: string
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
+       */
       permissions?: { [key: string]: unknown }
       /** @description The repositories this token has access to */
       repositories?: components['schemas']['repository'][]
@@ -8313,7 +8348,10 @@ export interface components {
       updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       permissions: {
         issues?: string
@@ -8324,7 +8362,10 @@ export interface components {
       } & { [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       events: string[]
       /**
@@ -8407,7 +8448,10 @@ export interface components {
       user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       labels: (
         | string
@@ -8558,7 +8602,11 @@ export interface components {
       current_user_actor_url?: string
       /** @example https://github.com/octocat-org */
       current_user_organization_url?: string
-      /** @example https://github.com/organizations/github/octocat.private.atom?token=abc123 */
+      /**
+       * @example [
+       *   "https://github.com/organizations/github/octocat.private.atom?token=abc123"
+       * ]
+       */
       current_user_organization_urls?: string[]
       /** @example https://github.com/security-advisories */
       security_advisories_url?: string
@@ -8924,11 +8972,27 @@ export interface components {
       description: string
       /** @example Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. */
       implementation: string
-      /** @example commercial-use,modifications,distribution,sublicense,private-use */
+      /**
+       * @example [
+       *   "commercial-use",
+       *   "modifications",
+       *   "distribution",
+       *   "sublicense",
+       *   "private-use"
+       * ]
+       */
       permissions: string[]
-      /** @example include-copyright */
+      /**
+       * @example [
+       *   "include-copyright"
+       * ]
+       */
       conditions: string[]
-      /** @example no-liability */
+      /**
+       * @example [
+       *   "no-liability"
+       * ]
+       */
       limitations: string[]
       /**
        * @example
@@ -8993,7 +9057,12 @@ export interface components {
       unit_name: string | null
       /** @example published */
       state: string
-      /** @example Up to 25 private repositories,11 concurrent builds */
+      /**
+       * @example [
+       *   "Up to 25 private repositories",
+       *   "11 concurrent builds"
+       * ]
+       */
       bullets: string[]
     }
     /**
@@ -9038,25 +9107,71 @@ export interface components {
         SHA256_ECDSA?: string
         SHA256_ED25519?: string
       }
-      /** @example ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl */
+      /**
+       * @example [
+       *   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+       * ]
+       */
       ssh_keys?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       hooks?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       web?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       api?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       git?: string[]
-      /** @example 13.65.0.0/16,157.55.204.33/32,2a01:111:f403:f90c::/62 */
+      /**
+       * @example [
+       *   "13.65.0.0/16",
+       *   "157.55.204.33/32",
+       *   "2a01:111:f403:f90c::/62"
+       * ]
+       */
       packages?: string[]
-      /** @example 192.30.252.153/32,192.30.252.154/32 */
+      /**
+       * @example [
+       *   "192.30.252.153/32",
+       *   "192.30.252.154/32"
+       * ]
+       */
       pages?: string[]
-      /** @example 54.158.161.132,54.226.70.38 */
+      /**
+       * @example [
+       *   "54.158.161.132",
+       *   "54.226.70.38"
+       * ]
+       */
       importer?: string[]
-      /** @example 13.64.0.0/16,13.65.0.0/16 */
+      /**
+       * @example [
+       *   "13.64.0.0/16",
+       *   "13.65.0.0/16"
+       * ]
+       */
       actions?: string[]
-      /** @example 192.168.7.15/32,192.168.7.16/32 */
+      /**
+       * @example [
+       *   "192.168.7.15/32",
+       *   "192.168.7.16/32"
+       * ]
+       */
       dependabot?: string[]
     }
     /**
@@ -9125,7 +9240,18 @@ export interface components {
     'external-groups': {
       /**
        * @description An array of external groups available to be mapped to a team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": 1,
+       *     "group_name": "group-azuread-test",
+       *     "updated_at": "2021-01-03 22:27:15:000 -700"
+       *   },
+       *   {
+       *     "group_id": 2,
+       *     "group_name": "group-azuread-test2",
+       *     "updated_at": "2021-06-03 22:27:15:000 -700"
+       *   }
+       * ]
        */
       groups?: {
         /**
@@ -9523,7 +9649,10 @@ export interface components {
       credential_authorized_at: string
       /**
        * @description List of oauth scopes the token has been granted.
-       * @example user,repo
+       * @example [
+       *   "user",
+       *   "repo"
+       * ]
        */
       scopes?: string[]
       /**
@@ -9618,7 +9747,16 @@ export interface components {
       updated_at?: string
       /**
        * @description An array of teams linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "team_id": 1,
+       *     "team_name": "team-test"
+       *   },
+       *   {
+       *     "team_id": 2,
+       *     "team_name": "team-test2"
+       *   }
+       * ]
        */
       teams: {
         /**
@@ -9634,7 +9772,20 @@ export interface components {
       }[]
       /**
        * @description An array of external members linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "member_id": 1,
+       *     "member_login": "mona-lisa_eocsaxrs",
+       *     "member_name": "Mona Lisa",
+       *     "member_email": "mona_lisa@github.com"
+       *   },
+       *   {
+       *     "member_id": 2,
+       *     "member_login": "octo-lisa_eocsaxrs",
+       *     "member_name": "Octo Lisa",
+       *     "member_email": "octo_lisa@github.com"
+       *   }
+       * ]
        */
       members: {
         /**
@@ -9702,7 +9853,12 @@ export interface components {
       deliveries_url?: string
       /** @example web */
       name: string
-      /** @example push,pull_request */
+      /**
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
+       */
       events: string[]
       /** @example true */
       active: boolean
@@ -10302,7 +10458,18 @@ export interface components {
     'group-mapping': {
       /**
        * @description Array of groups to be mapped to this team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": "111a1a11-aaa1-1aaa-11a1-a1a1a1a1a1aa",
+       *     "group_name": "saml-azuread-test",
+       *     "group_description": "A group of Developers working on AzureAD SAML SSO"
+       *   },
+       *   {
+       *     "group_id": "2bb2bb2b-bb22-22bb-2bb2-bb2bbb2bb2b2",
+       *     "group_name": "saml-azuread-test2",
+       *     "group_description": "Another group of Developers working on AzureAD SAML SSO"
+       *   }
+       * ]
        */
       groups?: {
         /**
@@ -11227,7 +11394,14 @@ export interface components {
       open_issues_count: number
       /** @example true */
       is_template?: boolean
-      /** @example octocat,atom,electron,API */
+      /**
+       * @example [
+       *   "octocat",
+       *   "atom",
+       *   "electron",
+       *   "API"
+       * ]
+       */
       topics?: string[]
       /** @example true */
       has_issues: boolean
@@ -11441,7 +11615,11 @@ export interface components {
       check_run_url: string
       /**
        * @description Labels for the workflow job. Specified by the "runs_on" attribute in the action's workflow file.
-       * @example self-hosted,foo,bar
+       * @example [
+       *   "self-hosted",
+       *   "foo",
+       *   "bar"
+       * ]
        */
       labels: string[]
       /**
@@ -12309,7 +12487,11 @@ export interface components {
       url: string
       /** @example true */
       strict: boolean
-      /** @example continuous-integration/travis-ci */
+      /**
+       * @example [
+       *   "continuous-integration/travis-ci"
+       * ]
+       */
       contexts: string[]
       checks: {
         /** @example continuous-integration/travis-ci */
@@ -14115,7 +14297,44 @@ export interface components {
       truncated: boolean
       /**
        * @description Objects specifying a tree structure
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "path": "file.rb",
+       *     "mode": "100644",
+       *     "type": "blob",
+       *     "size": 30,
+       *     "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "properties": {
+       *       "path": {
+       *         "type": "string"
+       *       },
+       *       "mode": {
+       *         "type": "string"
+       *       },
+       *       "type": {
+       *         "type": "string"
+       *       },
+       *       "size": {
+       *         "type": "integer"
+       *       },
+       *       "sha": {
+       *         "type": "string"
+       *       },
+       *       "url": {
+       *         "type": "string"
+       *       }
+       *     },
+       *     "required": [
+       *       "path",
+       *       "mode",
+       *       "type",
+       *       "sha",
+       *       "url",
+       *       "size"
+       *     ]
+       *   }
+       * ]
        */
       tree: {
         /** @example test/file.rb */
@@ -14161,7 +14380,10 @@ export interface components {
       active: boolean
       /**
        * @description Determines what events the hook is triggered for. Default: ['push'].
-       * @example push,pull_request
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
        */
       events: string[]
       config: {
@@ -14339,7 +14561,10 @@ export interface components {
       user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       labels: (
         | string
@@ -15406,7 +15631,10 @@ export interface components {
       description: string
       /**
        * @description Array of the domain set and its alternate name (if it is configured)
-       * @example example.com,www.example.com
+       * @example [
+       *   "example.com",
+       *   "www.example.com"
+       * ]
        */
       domains: string[]
       /** Format: date */
@@ -16480,7 +16708,17 @@ export interface components {
      * @description Commit Activity
      */
     'commit-activity': {
-      /** @example 0,3,26,20,39,1,0 */
+      /**
+       * @example [
+       *   0,
+       *   3,
+       *   26,
+       *   20,
+       *   39,
+       *   1,
+       *   0
+       * ]
+       */
       days: number[]
       /** @example 89 */
       total: number
@@ -16495,7 +16733,16 @@ export interface components {
       author: components['schemas']['nullable-simple-user']
       /** @example 135 */
       total: number
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "w": "1367712000",
+       *     "a": 6898,
+       *     "d": 77,
+       *     "c": 10
+       *   }
+       * ]
+       */
       weeks: {
         w?: number
         a?: number
@@ -16746,7 +16993,12 @@ export interface components {
        * @example Jon Doe
        */
       displayName?: string | null
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "givenName": "Jane",
+       *   "familyName": "User"
+       * }
+       */
       name: {
         givenName: string | null
         familyName: string | null
@@ -16754,7 +17006,16 @@ export interface components {
       }
       /**
        * @description user emails
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "value": "someone@example.com",
+       *     "primary": true
+       *   },
+       *   {
+       *     "value": "another@example.com",
+       *     "primary": false
+       *   }
+       * ]
        */
       emails: [
         {
@@ -16794,7 +17055,14 @@ export interface components {
       organization_id?: number
       /**
        * @description Set of operations to be performed
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "op": "replace",
+       *     "value": {
+       *       "active": false
+       *     }
+       *   }
+       * ]
        */
       operations?: [
         {
@@ -16862,7 +17130,12 @@ export interface components {
       language?: string | null
       /** Format: date-time */
       last_modified_at?: string
-      /** @example 73..77,77..78 */
+      /**
+       * @example [
+       *   "73..77",
+       *   "77..78"
+       * ]
+       */
       line_numbers?: string[]
       text_matches?: components['schemas']['search-result-text-matches']
     }
@@ -17441,12 +17714,36 @@ export interface components {
       key_id: string
       /** @example xsBNBFayYZ... */
       public_key: string
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "email": "mastahyeti@users.noreply.github.com",
+       *     "verified": true
+       *   }
+       * ]
+       */
       emails: {
         email?: string
         verified?: boolean
       }[]
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "id": 4,
+       *     "primary_key_id": 3,
+       *     "key_id": "4A595D4C72EE49C7",
+       *     "public_key": "zsBNBFayYZ...",
+       *     "emails": [],
+       *     "subkeys": [],
+       *     "can_sign": false,
+       *     "can_encrypt_comms": true,
+       *     "can_encrypt_storage": true,
+       *     "can_certify": false,
+       *     "created_at": "2016-03-24T11:31:04-06:00",
+       *     "expires_at": null
+       *   }
+       * ]
+       */
       subkeys: {
         id?: number
         primary_key_id?: number
@@ -18303,7 +18600,9 @@ export interface operations {
           repositories?: string[]
           /**
            * @description List of repository IDs that the token should have access to
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           repository_ids?: number[]
           permissions?: components['schemas']['app-permissions']
@@ -18559,7 +18858,9 @@ export interface operations {
           repositories?: string[]
           /**
            * @description The list of repository IDs to scope the user-to-server access token to. `repository_ids` may not be specified if `repositories` is specified.
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           repository_ids?: number[]
           permissions?: components['schemas']['app-permissions']
@@ -18652,7 +18953,10 @@ export interface operations {
         'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18721,7 +19025,10 @@ export interface operations {
           client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18782,7 +19089,10 @@ export interface operations {
           client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18860,7 +19170,10 @@ export interface operations {
         'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /** @description A list of scopes to add to this authorization. */
@@ -20025,7 +20338,11 @@ export interface operations {
           description?: string
           /**
            * @description Names and content for the files that make up the gist
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "puts \"Hello, World!\""
+           *   }
+           * }
            */
           files: {
             [key: string]: {
@@ -20154,7 +20471,12 @@ export interface operations {
           description?: string
           /**
            * @description Names of files to be updated
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "blah",
+           *     "filename": "goodbye.rb"
+           *   }
+           * }
            */
           files?: { [key: string]: Partial<{ [key: string]: unknown }> }
         } | null
@@ -23056,7 +23378,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -23129,7 +23453,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -27478,7 +27804,10 @@ export interface operations {
         'application/json': {
           /**
            * @description The list of environment ids to approve or reject
-           * @example 161171787,161171795
+           * @example [
+           *   161171787,
+           *   161171795
+           * ]
            */
           environment_ids: number[]
           /**
@@ -32674,7 +33003,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -32754,7 +33085,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /** @description Determines a list of events to be added to the list of events that the Hook triggers for. */
@@ -38016,7 +38349,12 @@ export interface operations {
            * @example Jon Doe
            */
           displayName?: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           name: {
             givenName: string
             familyName: string
@@ -38024,7 +38362,16 @@ export interface operations {
           }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           emails: [
             {
@@ -38109,7 +38456,12 @@ export interface operations {
            * @example someone@example.com
            */
           userName: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           name: {
             givenName: string
             familyName: string
@@ -38117,7 +38469,16 @@ export interface operations {
           }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           emails: [
             {
@@ -38201,7 +38562,14 @@ export interface operations {
           schemas?: string[]
           /**
            * @description Set of operations to be performed
-           * @example [object Object]
+           * @example [
+           *   {
+           *     "op": "replace",
+           *     "value": {
+           *       "active": false
+           *     }
+           *   }
+           * ]
            */
           Operations: [
             {
@@ -40415,7 +40783,7 @@ export interface operations {
           | {
               /**
                * @description Adds one or more email addresses to your GitHub account. Must contain at least one email address. **Note:** Alternatively, you can pass a single email address or an `array` of emails addresses directly, but we recommend that you pass an object using the `emails` key.
-               * @example
+               * @example []
                */
               emails: string[]
             }
@@ -41110,7 +41478,9 @@ export interface operations {
           exclude_owner_projects?: boolean
           /**
            * @description Exclude attributes from the API response to improve performance
-           * @example repositories
+           * @example [
+           *   "repositories"
+           * ]
            */
           exclude?: 'repositories'[]
           repositories: string[]

--- a/test/v3/expected/github.ts
+++ b/test/v3/expected/github.ts
@@ -6085,7 +6085,10 @@ export interface components {
       updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       permissions: {
         issues?: string
@@ -6096,7 +6099,10 @@ export interface components {
       } & { [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       events: string[]
       /**
@@ -6447,7 +6453,12 @@ export interface components {
     /**
      * App Permissions
      * @description The permissions granted to the user-to-server access token.
-     * @example [object Object]
+     * @example {
+     *   "contents": "read",
+     *   "issues": "read",
+     *   "deployments": "write",
+     *   "single_file": "read"
+     * }
      */
     'app-permissions': {
       /**
@@ -6648,7 +6659,12 @@ export interface components {
       single_file_name: string | null
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
       /** @example github-actions */
       app_slug: string
@@ -7099,7 +7115,12 @@ export interface components {
       single_file?: string
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
     }
     /**
@@ -7130,7 +7151,11 @@ export interface components {
        * @example 2011-09-06T20:39:23Z
        */
       updated_at: string
-      /** @example public_repo */
+      /**
+       * @example [
+       *   "public_repo"
+       * ]
+       */
       scopes: string[]
       user?: components['schemas']['nullable-simple-user']
     }
@@ -7146,7 +7171,12 @@ export interface components {
       single_file_name: string | null
       /** @example true */
       has_multiple_single_files?: boolean
-      /** @example config.yml,.github/issue_TEMPLATE.md */
+      /**
+       * @example [
+       *   "config.yml",
+       *   ".github/issue_TEMPLATE.md"
+       * ]
+       */
       single_file_paths?: string[]
       /**
        * Format: uri
@@ -7402,7 +7432,12 @@ export interface components {
        * @example 2016-07-11T22:14:10Z
        */
       expires_at: string
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
+       */
       permissions?: { [key: string]: unknown }
       /** @description The repositories this token has access to */
       repositories?: components['schemas']['repository'][]
@@ -8313,7 +8348,10 @@ export interface components {
       updated_at: string
       /**
        * @description The set of permissions for the GitHub app
-       * @example [object Object]
+       * @example {
+       *   "issues": "read",
+       *   "deployments": "write"
+       * }
        */
       permissions: {
         issues?: string
@@ -8324,7 +8362,10 @@ export interface components {
       } & { [key: string]: string }
       /**
        * @description The list of events for the GitHub app
-       * @example label,deployment
+       * @example [
+       *   "label",
+       *   "deployment"
+       * ]
        */
       events: string[]
       /**
@@ -8407,7 +8448,10 @@ export interface components {
       user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       labels: (
         | string
@@ -8558,7 +8602,11 @@ export interface components {
       current_user_actor_url?: string
       /** @example https://github.com/octocat-org */
       current_user_organization_url?: string
-      /** @example https://github.com/organizations/github/octocat.private.atom?token=abc123 */
+      /**
+       * @example [
+       *   "https://github.com/organizations/github/octocat.private.atom?token=abc123"
+       * ]
+       */
       current_user_organization_urls?: string[]
       /** @example https://github.com/security-advisories */
       security_advisories_url?: string
@@ -8924,11 +8972,27 @@ export interface components {
       description: string
       /** @example Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. */
       implementation: string
-      /** @example commercial-use,modifications,distribution,sublicense,private-use */
+      /**
+       * @example [
+       *   "commercial-use",
+       *   "modifications",
+       *   "distribution",
+       *   "sublicense",
+       *   "private-use"
+       * ]
+       */
       permissions: string[]
-      /** @example include-copyright */
+      /**
+       * @example [
+       *   "include-copyright"
+       * ]
+       */
       conditions: string[]
-      /** @example no-liability */
+      /**
+       * @example [
+       *   "no-liability"
+       * ]
+       */
       limitations: string[]
       /**
        * @example
@@ -8993,7 +9057,12 @@ export interface components {
       unit_name: string | null
       /** @example published */
       state: string
-      /** @example Up to 25 private repositories,11 concurrent builds */
+      /**
+       * @example [
+       *   "Up to 25 private repositories",
+       *   "11 concurrent builds"
+       * ]
+       */
       bullets: string[]
     }
     /**
@@ -9038,25 +9107,71 @@ export interface components {
         SHA256_ECDSA?: string
         SHA256_ED25519?: string
       }
-      /** @example ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl */
+      /**
+       * @example [
+       *   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+       * ]
+       */
       ssh_keys?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       hooks?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       web?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       api?: string[]
-      /** @example 127.0.0.1/32 */
+      /**
+       * @example [
+       *   "127.0.0.1/32"
+       * ]
+       */
       git?: string[]
-      /** @example 13.65.0.0/16,157.55.204.33/32,2a01:111:f403:f90c::/62 */
+      /**
+       * @example [
+       *   "13.65.0.0/16",
+       *   "157.55.204.33/32",
+       *   "2a01:111:f403:f90c::/62"
+       * ]
+       */
       packages?: string[]
-      /** @example 192.30.252.153/32,192.30.252.154/32 */
+      /**
+       * @example [
+       *   "192.30.252.153/32",
+       *   "192.30.252.154/32"
+       * ]
+       */
       pages?: string[]
-      /** @example 54.158.161.132,54.226.70.38 */
+      /**
+       * @example [
+       *   "54.158.161.132",
+       *   "54.226.70.38"
+       * ]
+       */
       importer?: string[]
-      /** @example 13.64.0.0/16,13.65.0.0/16 */
+      /**
+       * @example [
+       *   "13.64.0.0/16",
+       *   "13.65.0.0/16"
+       * ]
+       */
       actions?: string[]
-      /** @example 192.168.7.15/32,192.168.7.16/32 */
+      /**
+       * @example [
+       *   "192.168.7.15/32",
+       *   "192.168.7.16/32"
+       * ]
+       */
       dependabot?: string[]
     }
     /**
@@ -9125,7 +9240,18 @@ export interface components {
     'external-groups': {
       /**
        * @description An array of external groups available to be mapped to a team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": 1,
+       *     "group_name": "group-azuread-test",
+       *     "updated_at": "2021-01-03 22:27:15:000 -700"
+       *   },
+       *   {
+       *     "group_id": 2,
+       *     "group_name": "group-azuread-test2",
+       *     "updated_at": "2021-06-03 22:27:15:000 -700"
+       *   }
+       * ]
        */
       groups?: {
         /**
@@ -9523,7 +9649,10 @@ export interface components {
       credential_authorized_at: string
       /**
        * @description List of oauth scopes the token has been granted.
-       * @example user,repo
+       * @example [
+       *   "user",
+       *   "repo"
+       * ]
        */
       scopes?: string[]
       /**
@@ -9618,7 +9747,16 @@ export interface components {
       updated_at?: string
       /**
        * @description An array of teams linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "team_id": 1,
+       *     "team_name": "team-test"
+       *   },
+       *   {
+       *     "team_id": 2,
+       *     "team_name": "team-test2"
+       *   }
+       * ]
        */
       teams: {
         /**
@@ -9634,7 +9772,20 @@ export interface components {
       }[]
       /**
        * @description An array of external members linked to this group
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "member_id": 1,
+       *     "member_login": "mona-lisa_eocsaxrs",
+       *     "member_name": "Mona Lisa",
+       *     "member_email": "mona_lisa@github.com"
+       *   },
+       *   {
+       *     "member_id": 2,
+       *     "member_login": "octo-lisa_eocsaxrs",
+       *     "member_name": "Octo Lisa",
+       *     "member_email": "octo_lisa@github.com"
+       *   }
+       * ]
        */
       members: {
         /**
@@ -9702,7 +9853,12 @@ export interface components {
       deliveries_url?: string
       /** @example web */
       name: string
-      /** @example push,pull_request */
+      /**
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
+       */
       events: string[]
       /** @example true */
       active: boolean
@@ -10302,7 +10458,18 @@ export interface components {
     'group-mapping': {
       /**
        * @description Array of groups to be mapped to this team
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "group_id": "111a1a11-aaa1-1aaa-11a1-a1a1a1a1a1aa",
+       *     "group_name": "saml-azuread-test",
+       *     "group_description": "A group of Developers working on AzureAD SAML SSO"
+       *   },
+       *   {
+       *     "group_id": "2bb2bb2b-bb22-22bb-2bb2-bb2bbb2bb2b2",
+       *     "group_name": "saml-azuread-test2",
+       *     "group_description": "Another group of Developers working on AzureAD SAML SSO"
+       *   }
+       * ]
        */
       groups?: {
         /**
@@ -11227,7 +11394,14 @@ export interface components {
       open_issues_count: number
       /** @example true */
       is_template?: boolean
-      /** @example octocat,atom,electron,API */
+      /**
+       * @example [
+       *   "octocat",
+       *   "atom",
+       *   "electron",
+       *   "API"
+       * ]
+       */
       topics?: string[]
       /** @example true */
       has_issues: boolean
@@ -11441,7 +11615,11 @@ export interface components {
       check_run_url: string
       /**
        * @description Labels for the workflow job. Specified by the "runs_on" attribute in the action's workflow file.
-       * @example self-hosted,foo,bar
+       * @example [
+       *   "self-hosted",
+       *   "foo",
+       *   "bar"
+       * ]
        */
       labels: string[]
       /**
@@ -12309,7 +12487,11 @@ export interface components {
       url: string
       /** @example true */
       strict: boolean
-      /** @example continuous-integration/travis-ci */
+      /**
+       * @example [
+       *   "continuous-integration/travis-ci"
+       * ]
+       */
       contexts: string[]
       checks: {
         /** @example continuous-integration/travis-ci */
@@ -14115,7 +14297,44 @@ export interface components {
       truncated: boolean
       /**
        * @description Objects specifying a tree structure
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "path": "file.rb",
+       *     "mode": "100644",
+       *     "type": "blob",
+       *     "size": 30,
+       *     "sha": "44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "url": "https://api.github.com/repos/octocat/Hello-World/git/blobs/44b4fc6d56897b048c772eb4087f854f46256132",
+       *     "properties": {
+       *       "path": {
+       *         "type": "string"
+       *       },
+       *       "mode": {
+       *         "type": "string"
+       *       },
+       *       "type": {
+       *         "type": "string"
+       *       },
+       *       "size": {
+       *         "type": "integer"
+       *       },
+       *       "sha": {
+       *         "type": "string"
+       *       },
+       *       "url": {
+       *         "type": "string"
+       *       }
+       *     },
+       *     "required": [
+       *       "path",
+       *       "mode",
+       *       "type",
+       *       "sha",
+       *       "url",
+       *       "size"
+       *     ]
+       *   }
+       * ]
        */
       tree: {
         /** @example test/file.rb */
@@ -14161,7 +14380,10 @@ export interface components {
       active: boolean
       /**
        * @description Determines what events the hook is triggered for. Default: ['push'].
-       * @example push,pull_request
+       * @example [
+       *   "push",
+       *   "pull_request"
+       * ]
        */
       events: string[]
       config: {
@@ -14339,7 +14561,10 @@ export interface components {
       user: components['schemas']['nullable-simple-user']
       /**
        * @description Labels to associate with this issue; pass one or more label names to replace the set of labels on this issue; send an empty array to clear all labels from the issue; note that the labels are silently dropped for users without push access to the repository
-       * @example bug,registration
+       * @example [
+       *   "bug",
+       *   "registration"
+       * ]
        */
       labels: (
         | string
@@ -15406,7 +15631,10 @@ export interface components {
       description: string
       /**
        * @description Array of the domain set and its alternate name (if it is configured)
-       * @example example.com,www.example.com
+       * @example [
+       *   "example.com",
+       *   "www.example.com"
+       * ]
        */
       domains: string[]
       /** Format: date */
@@ -16480,7 +16708,17 @@ export interface components {
      * @description Commit Activity
      */
     'commit-activity': {
-      /** @example 0,3,26,20,39,1,0 */
+      /**
+       * @example [
+       *   0,
+       *   3,
+       *   26,
+       *   20,
+       *   39,
+       *   1,
+       *   0
+       * ]
+       */
       days: number[]
       /** @example 89 */
       total: number
@@ -16495,7 +16733,16 @@ export interface components {
       author: components['schemas']['nullable-simple-user']
       /** @example 135 */
       total: number
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "w": "1367712000",
+       *     "a": 6898,
+       *     "d": 77,
+       *     "c": 10
+       *   }
+       * ]
+       */
       weeks: {
         w?: number
         a?: number
@@ -16746,7 +16993,12 @@ export interface components {
        * @example Jon Doe
        */
       displayName?: string | null
-      /** @example [object Object] */
+      /**
+       * @example {
+       *   "givenName": "Jane",
+       *   "familyName": "User"
+       * }
+       */
       name: {
         givenName: string | null
         familyName: string | null
@@ -16754,7 +17006,16 @@ export interface components {
       }
       /**
        * @description user emails
-       * @example [object Object],[object Object]
+       * @example [
+       *   {
+       *     "value": "someone@example.com",
+       *     "primary": true
+       *   },
+       *   {
+       *     "value": "another@example.com",
+       *     "primary": false
+       *   }
+       * ]
        */
       emails: {
         value: string
@@ -16788,7 +17049,14 @@ export interface components {
       organization_id?: number
       /**
        * @description Set of operations to be performed
-       * @example [object Object]
+       * @example [
+       *   {
+       *     "op": "replace",
+       *     "value": {
+       *       "active": false
+       *     }
+       *   }
+       * ]
        */
       operations?: {
         /** @enum {string} */
@@ -16848,7 +17116,12 @@ export interface components {
       language?: string | null
       /** Format: date-time */
       last_modified_at?: string
-      /** @example 73..77,77..78 */
+      /**
+       * @example [
+       *   "73..77",
+       *   "77..78"
+       * ]
+       */
       line_numbers?: string[]
       text_matches?: components['schemas']['search-result-text-matches']
     }
@@ -17427,12 +17700,36 @@ export interface components {
       key_id: string
       /** @example xsBNBFayYZ... */
       public_key: string
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "email": "mastahyeti@users.noreply.github.com",
+       *     "verified": true
+       *   }
+       * ]
+       */
       emails: {
         email?: string
         verified?: boolean
       }[]
-      /** @example [object Object] */
+      /**
+       * @example [
+       *   {
+       *     "id": 4,
+       *     "primary_key_id": 3,
+       *     "key_id": "4A595D4C72EE49C7",
+       *     "public_key": "zsBNBFayYZ...",
+       *     "emails": [],
+       *     "subkeys": [],
+       *     "can_sign": false,
+       *     "can_encrypt_comms": true,
+       *     "can_encrypt_storage": true,
+       *     "can_certify": false,
+       *     "created_at": "2016-03-24T11:31:04-06:00",
+       *     "expires_at": null
+       *   }
+       * ]
+       */
       subkeys: {
         id?: number
         primary_key_id?: number
@@ -18289,7 +18586,9 @@ export interface operations {
           repositories?: string[]
           /**
            * @description List of repository IDs that the token should have access to
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           repository_ids?: number[]
           permissions?: components['schemas']['app-permissions']
@@ -18545,7 +18844,9 @@ export interface operations {
           repositories?: string[]
           /**
            * @description The list of repository IDs to scope the user-to-server access token to. `repository_ids` may not be specified if `repositories` is specified.
-           * @example 1
+           * @example [
+           *   1
+           * ]
            */
           repository_ids?: number[]
           permissions?: components['schemas']['app-permissions']
@@ -18638,7 +18939,10 @@ export interface operations {
         'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18707,7 +19011,10 @@ export interface operations {
           client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18768,7 +19075,10 @@ export interface operations {
           client_secret: string
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /**
@@ -18846,7 +19156,10 @@ export interface operations {
         'application/json': {
           /**
            * @description A list of scopes that this authorization is in.
-           * @example public_repo,user
+           * @example [
+           *   "public_repo",
+           *   "user"
+           * ]
            */
           scopes?: string[] | null
           /** @description A list of scopes to add to this authorization. */
@@ -20011,7 +20324,11 @@ export interface operations {
           description?: string
           /**
            * @description Names and content for the files that make up the gist
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "puts \"Hello, World!\""
+           *   }
+           * }
            */
           files: {
             [key: string]: {
@@ -20140,7 +20457,12 @@ export interface operations {
           description?: string
           /**
            * @description Names of files to be updated
-           * @example [object Object]
+           * @example {
+           *   "hello.rb": {
+           *     "content": "blah",
+           *     "filename": "goodbye.rb"
+           *   }
+           * }
            */
           files?: { [key: string]: Partial<{ [key: string]: unknown }> }
         } | null
@@ -23042,7 +23364,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -23115,7 +23439,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -27464,7 +27790,10 @@ export interface operations {
         'application/json': {
           /**
            * @description The list of environment ids to approve or reject
-           * @example 161171787,161171795
+           * @example [
+           *   161171787,
+           *   161171795
+           * ]
            */
           environment_ids: number[]
           /**
@@ -32564,7 +32893,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /**
@@ -32644,7 +32975,9 @@ export interface operations {
           }
           /**
            * @description Determines what [events](https://docs.github.com/webhooks/event-payloads) the hook is triggered for. This replaces the entire array of events.
-           * @default push
+           * @default [
+           *   "push"
+           * ]
            */
           events?: string[]
           /** @description Determines a list of events to be added to the list of events that the Hook triggers for. */
@@ -37877,7 +38210,12 @@ export interface operations {
            * @example Jon Doe
            */
           displayName?: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           name: {
             givenName: string
             familyName: string
@@ -37885,7 +38223,16 @@ export interface operations {
           }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           emails: {
             value: string
@@ -37963,7 +38310,12 @@ export interface operations {
            * @example someone@example.com
            */
           userName: string
-          /** @example [object Object] */
+          /**
+           * @example {
+           *   "givenName": "Jane",
+           *   "familyName": "User"
+           * }
+           */
           name: {
             givenName: string
             familyName: string
@@ -37971,7 +38323,16 @@ export interface operations {
           }
           /**
            * @description user emails
-           * @example [object Object],[object Object]
+           * @example [
+           *   {
+           *     "value": "someone@example.com",
+           *     "primary": true
+           *   },
+           *   {
+           *     "value": "another@example.com",
+           *     "primary": false
+           *   }
+           * ]
            */
           emails: {
             type?: string
@@ -38048,7 +38409,14 @@ export interface operations {
           schemas?: string[]
           /**
            * @description Set of operations to be performed
-           * @example [object Object]
+           * @example [
+           *   {
+           *     "op": "replace",
+           *     "value": {
+           *       "active": false
+           *     }
+           *   }
+           * ]
            */
           Operations: {
             /** @enum {string} */
@@ -40242,7 +40610,7 @@ export interface operations {
           | {
               /**
                * @description Adds one or more email addresses to your GitHub account. Must contain at least one email address. **Note:** Alternatively, you can pass a single email address or an `array` of emails addresses directly, but we recommend that you pass an object using the `emails` key.
-               * @example
+               * @example []
                */
               emails: string[]
             }
@@ -40937,7 +41305,9 @@ export interface operations {
           exclude_owner_projects?: boolean
           /**
            * @description Exclude attributes from the API response to improve performance
-           * @example repositories
+           * @example [
+           *   "repositories"
+           * ]
            */
           exclude?: 'repositories'[]
           repositories: string[]


### PR DESCRIPTION
Complex `default` and `example` values were serialized in comments at `[Object object]`.
This PR attempts to recognize these values, and to serialize them in a more-useful way.

This PR depends on both https://github.com/drwpow/openapi-typescript/pull/909 and https://github.com/drwpow/openapi-typescript/pull/906