### PR TITLE
fix: export enum of operation paths

### DIFF
--- a/src/transform/paths.ts
+++ b/src/transform/paths.ts
@@ -101,7 +101,7 @@ export function transformPathsObj(paths: Record<string, PathItemObject>, options
  * Generate an Enum with operation names as keys and the corresponding paths as values.
  */
 export function makeApiPathsEnum(paths: Record<string, PathItemObject>): string {
-  let output = "enum ApiPaths {\n";
+  let output = "export enum ApiPaths {\n";
 
   for (const [url, pathItem] of Object.entries(paths)) {
     for (const [method, operation] of Object.entries(pathItem)) {

--- a/test/bin/expected/paths-enum.ts
+++ b/test/bin/expected/paths-enum.ts
@@ -489,7 +489,7 @@ export interface operations {
 
 export interface external {}
 
-enum ApiPaths {
+export enum ApiPaths {
   updatePet = "/pet",
   addPet = "/pet",
   findPetsByStatus = "/pet/findByStatus",


### PR DESCRIPTION
Closes #911

## 🗣 Discussion

Pretty straight-forward. I was just about to use this functionality myself when I encountered the unreachable enum.

The `enum` was being generated, but simply wasn't exported.
This PR adds the `export`, and updates the associated spec output.