### PR TITLE
Support Type Arrays for OpenAPI 3.1

### DIFF
--- a/src/transform/schema.ts
+++ b/src/transform/schema.ts
@@ -105,8 +105,9 @@ export function transformSchemaObj(node: any, options: TransformSchemaObjOptions
   } else {
     // transform core type
     switch (nodeType(node)) {
-      case "multiple-types":
-        output += tsUnionOf((node.type as any[]).map(type => transformSchemaObj({ ...node, type }, options)))
+      case "type-array":
+        // This is an array of types as of the 3.1 specification - we should recursively evaluate them
+        output += tsUnionOf((node.type as any[]).map((type) => transformSchemaObj({ ...node, type }, options)));
         break;
       case "ref": {
         output += node.$ref; // these were transformed at load time when remote schemas were resolved; return as-is

--- a/src/transform/schema.ts
+++ b/src/transform/schema.ts
@@ -105,6 +105,9 @@ export function transformSchemaObj(node: any, options: TransformSchemaObjOptions
   } else {
     // transform core type
     switch (nodeType(node)) {
+      case "multiple-types":
+        output += tsUnionOf((node.type as any[]).map(type => transformSchemaObj({ ...node, type }, options)))
+        break;
       case "ref": {
         output += node.$ref; // these were transformed at load time when remote schemas were resolved; return as-is
         break;

--- a/src/transform/schema.ts
+++ b/src/transform/schema.ts
@@ -113,6 +113,7 @@ export function transformSchemaObj(node: any, options: TransformSchemaObjOptions
         output += node.$ref; // these were transformed at load time when remote schemas were resolved; return as-is
         break;
       }
+      case "null":
       case "string":
       case "number":
       case "boolean":

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,7 +133,7 @@ type SchemaObjectType =
   | "null"
   | "string"
   // Special type so the parent function knows to recursively evaluate each entry
-  | "multiple-types"
+  | "type-array"
   | "unknown";
 export function nodeType(obj: any): SchemaObjectType {
   if (!obj || typeof obj !== "object") {
@@ -143,7 +143,6 @@ export function nodeType(obj: any): SchemaObjectType {
   if (obj.$ref) {
     return "ref";
   }
-  
 
   // const
   if (obj.const) {
@@ -160,14 +159,19 @@ export function nodeType(obj: any): SchemaObjectType {
     return "object";
   }
 
+  // Type array from the 3.1 specification
+  if (Array.isArray(obj.type)) {
+    return "type-array";
+  }
+
   // boolean
   if (obj.type === "boolean") {
     return "boolean";
   }
 
   // null
-  if (obj.type === "null") { 
-    return "null"
+  if (obj.type === "null") {
+    return "null";
   }
   // string
   if (
@@ -195,11 +199,6 @@ export function nodeType(obj: any): SchemaObjectType {
   if (obj.type === "object" || obj.hasOwnProperty("properties") || obj.hasOwnProperty("additionalProperties")) {
     return "object";
   }
-
-  // Type array
-  if (Array.isArray(obj.type)) {
-    return "multiple-types";
-}
 
   // return unknown by default
   return "unknown";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,7 +130,10 @@ type SchemaObjectType =
   | "object"
   | "oneOf"
   | "ref"
+  | "null"
   | "string"
+  // Special type so the parent function knows to recursively evaluate each entry
+  | "multiple-types"
   | "unknown";
 export function nodeType(obj: any): SchemaObjectType {
   if (!obj || typeof obj !== "object") {
@@ -140,6 +143,7 @@ export function nodeType(obj: any): SchemaObjectType {
   if (obj.$ref) {
     return "ref";
   }
+  
 
   // const
   if (obj.const) {
@@ -161,6 +165,10 @@ export function nodeType(obj: any): SchemaObjectType {
     return "boolean";
   }
 
+  // null
+  if (obj.type === "null") { 
+    return "null"
+  }
   // string
   if (
     obj.type === "string" ||
@@ -187,6 +195,11 @@ export function nodeType(obj: any): SchemaObjectType {
   if (obj.type === "object" || obj.hasOwnProperty("properties") || obj.hasOwnProperty("additionalProperties")) {
     return "object";
   }
+
+  // Type array
+  if (Array.isArray(obj.type)) {
+    return "multiple-types";
+}
 
   // return unknown by default
   return "unknown";

--- a/test/core/schema.test.js
+++ b/test/core/schema.test.js
@@ -256,6 +256,27 @@ describe("SchemaObject", () => {
     });
   });
 
+  describe("(3.1) type arrays", () => {
+    it("nullable type array", () => {
+      expect(transform({ type: ["string", "null"] }, { ...defaults })).to.equal("(string) | (null)");
+    });
+
+    it("nullable type array within an object", () => {
+      const objectWithNullableTypeArray = {
+        type: "object",
+        properties: {
+          object: {
+            properties: { nullableNumber: { type: ["number", "null"] }, string: { type: "string" } },
+            type: "object",
+          },
+        },
+      };
+      expect(transform(objectWithNullableTypeArray, { ...defaults })).to.equal(
+        `{\n"object"?: {\n"nullableNumber"?: (number) | (null);\n"string"?: string;\n\n};\n\n}`
+      );
+    });
+  });
+
   describe("advanced", () => {
     it("additionalProperties", () => {
       // boolean


### PR DESCRIPTION
https://github.com/drwpow/openapi-typescript/issues/898

This PR allows arrays of types to be parsed properly, as per the 3.1 specification. 

## Changes
- Adds recursive functionality to parse "arrays" of types
- Supports the "null" type 

## Open questions
- I tested this locally using my company's openapi spec at https://developers.arcadia.com/openapi.yaml. I feel  a little weird about including this in a test because openapi-typescript does not support OpenAPI 3.1 - **How should I add a test for this?**