### PR TITLE
Fix generation of parameters with a dot in the description

### DIFF
--- a/src/transform/operation-object.ts
+++ b/src/transform/operation-object.ts
@@ -20,14 +20,15 @@ import transformSchemaObject from "./schema-object.js";
 export interface TransformOperationObjectOptions {
   path: string;
   ctx: GlobalContext;
+  wrapObject?: boolean;
 }
 
 export default function transformOperationObject(
   operationObject: OperationObject,
-  { path, ctx }: TransformOperationObjectOptions
+  { path, ctx, wrapObject = true }: TransformOperationObjectOptions
 ): string {
   let { indentLv } = ctx;
-  const output: string[] = ["{"];
+  const output: string[] = wrapObject ? ["{"] : [];
   indentLv++;
   const c = getSchemaObjectComment(operationObject, indentLv);
   if (c) output.push(indent(c, indentLv));
@@ -154,6 +155,8 @@ export default function transformOperationObject(
   }
 
   indentLv--;
-  output.push(indent("}", indentLv));
+  if (wrapObject) {
+    output.push(indent("}", indentLv));
+  }
   return output.join("\n");
 }

--- a/src/transform/path-item-object.ts
+++ b/src/transform/path-item-object.ts
@@ -9,8 +9,6 @@ export interface TransformPathItemObjectOptions {
 
 type Method = "get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace";
 
-const UNWRAP_OBJ_RE = /^\s*{\s*([^.]+)\s*}\s*$/;
-
 export default function transformPathItemObject(
   pathItem: PathItemObject,
   { path, ctx }: TransformPathItemObjectOptions
@@ -44,9 +42,7 @@ export default function transformPathItemObject(
   if (pathItem.parameters && pathItem.parameters.length) {
     output.push(
       indent(
-        transformOperationObject({ parameters: pathItem.parameters }, { path, ctx })
-          .replace(UNWRAP_OBJ_RE, "$1")
-          .trim(),
+        transformOperationObject({ parameters: pathItem.parameters }, { path, ctx, wrapObject: false }).trim(),
         indentLv
       )
     );

--- a/test/paths-object.test.ts
+++ b/test/paths-object.test.ts
@@ -20,7 +20,7 @@ describe("Paths Object", () => {
   test("basic", () => {
     const schema: PathsObject = {
       "/api/v1/user/{user_id}": {
-        parameters: [{ name: "page", in: "query", schema: { type: "number" } }],
+        parameters: [{ name: "page", in: "query", schema: { type: "number" }, description: "Page number." }],
         get: {
           parameters: [{ name: "user_id", in: "path" }],
           responses: {
@@ -79,6 +79,7 @@ describe("Paths Object", () => {
       };
     };
     parameters?: {
+        /** @description Page number. */
       query?: {
         page?: number;
       };


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

Fixes the generation of parameters containing a `.` in the description. See https://github.com/drwpow/openapi-typescript/issues/985

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [x] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
