### PR TITLE
Fix path generation

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -108,8 +108,12 @@ async function generateSchema(pathToSpec) {
     let outputFilePath = new URL(flags.output, CWD); // note: may be directory
     const isDir = fs.existsSync(outputFilePath) && fs.lstatSync(outputFilePath).isDirectory();
     if (isDir) {
-      const filename = pathToSpec.replace(EXT_RE, ".ts").replace(/^https?:\/\//, '');
-      outputFilePath = new URL(filename, outputFilePath);
+      const filename = pathToSpec.replace(EXT_RE, ".ts");
+      const originalOutputFilePath = outputFilePath;
+      outputFilePath = new URL(filename, originalOutputFilePath);
+      if (outputFilePath.protocol !== 'file') {
+        outputFilePath = new URL(outputFilePath.host.replace(EXT_RE, ".ts"), originalOutputFilePath);
+      }
     }
 
     fs.writeFileSync(outputFilePath, result, "utf8");

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -108,7 +108,7 @@ async function generateSchema(pathToSpec) {
     let outputFilePath = new URL(flags.output, CWD); // note: may be directory
     const isDir = fs.existsSync(outputFilePath) && fs.lstatSync(outputFilePath).isDirectory();
     if (isDir) {
-      const filename = pathToSpec.replace(EXT_RE, ".ts");
+      const filename = pathToSpec.replace(EXT_RE, ".ts").replace(/^https?:\/\//, '');
       outputFilePath = new URL(filename, outputFilePath);
     }
 


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

Currently, if a url like `https://api-test.<website>/docs/json` is passed, then the regex creates a file with the `https://` prefix before it, and so it doesn't work. It creates a file like `https://api-test.<website>.ts`

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
