### PR TITLE
Add type helpers only when used

### DIFF
--- a/examples/octokit-ghes-3.6-diff-to-api.ts
+++ b/examples/octokit-ghes-3.6-diff-to-api.ts
@@ -4,11 +4,6 @@
  */
 
 
-/** Type helpers */
-type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
-type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
-type OneOf<T extends any[]> = T extends [infer Only] ? Only : T extends [infer A, infer B, ...infer Rest] ? OneOf<[XOR<A, B>, ...Rest]> : never;
-
 export interface paths {
   "/admin/hooks": {
     /** List global webhooks */

--- a/examples/stripe-api.ts
+++ b/examples/stripe-api.ts
@@ -4,11 +4,6 @@
  */
 
 
-/** Type helpers */
-type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
-type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
-type OneOf<T extends any[]> = T extends [infer Only] ? Only : T extends [infer A, infer B, ...infer Rest] ? OneOf<[XOR<A, B>, ...Rest]> : never;
-
 export interface paths {
   "/v1/account": {
     /** @description <p>Retrieves the details of an account.</p> */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,9 @@ const BOILERPLATE = `/**
  * Do not make direct changes to the file.
  */
 
+`;
 
+const TYPE_HELPERS = `
 /** Type helpers */
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
@@ -432,6 +434,56 @@ export interface components {
   schemas: {
     /** Format: date-time */
     Date: DateOrTime;
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
+}
+
+export type external = Record<string, never>;
+
+export type operations = Record<string, never>;
+`);
+      });
+    });
+
+    describe("OneOf type helpers", () => {
+      test("should be added only when used", async () => {
+        const generated = await openapiTS(
+          {
+            openapi: "3.1",
+            info: { title: "Test", version: "1.0" },
+            components: {
+              schemas: {
+                User: {
+                  oneOf: [
+                    {
+                      type: "object",
+                      properties: { firstName: { type: "string" } },
+                    },
+                    {
+                      type: "object",
+                      properties: { name: { type: "string" } },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          { exportType: false }
+        );
+        expect(generated).toBe(`${BOILERPLATE}${TYPE_HELPERS}
+export type paths = Record<string, never>;
+
+export interface components {
+  schemas: {
+    User: OneOf<[{
+      firstName?: string;
+    }, {
+      name?: string;
+    }]>;
   };
   responses: never;
   parameters: never;


### PR DESCRIPTION
Fix https://github.com/drwpow/openapi-typescript/issues/976 by checking if `OneOf` type is added to the schema. The fix uses the easiest path, but perhaps not the best for long term (if there are other type helpers added especially). Perhaps, the context should be aware if type helpers are required? (if it's not already the case and that I miss something).