### PR TITLE
Fix bug in generating multiple spec to folder

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from "node:fs";
+import path from "path";
 import { URL } from "node:url";
 import glob from "fast-glob";
 import parser from "yargs-parser";
@@ -177,8 +178,12 @@ async function main() {
   await Promise.all(
     inputSpecPaths.map(async (specPath) => {
       if (flags.output !== "." && output === OUTPUT_FILE) {
-        if (isGlob) outputDir = new URL(specPath, outputDir);
-        fs.mkdirSync(outputDir, { recursive: true }); // recursively make parent dirs
+        if (isGlob) {
+          fs.mkdirSync(new URL(path.dirname(specPath), outputDir), { recursive: true }); // recursively make parent dirs
+        }
+        else {
+          fs.mkdirSync(outputDir, { recursive: true }); // recursively make parent dirs
+        }
       }
       await generateSchema(specPath);
     })


### PR DESCRIPTION
## Changes

Fixes https://github.com/drwpow/openapi-typescript/issues/925

The issue is that the original `outputDir` was being mutated, so each itteration would create more nested folders.

## How to Review

1. Create 2 directories holding 2 different OpenAPI contracts (e.g. `src/contracts/service1/openapi.yaml` and `src/contracts/service2/openapi.yaml`
2. Attempt to generate types to different target directory, e.g. `src/generated` via `openapi-typescript src/contracts/**/openapi.yaml --output ./src/generated/api/`

In the non-pathed version the command will fail, multiple invalid directories will be created.

## Checklist

- [ ] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
