### PR TITLE
Fix response key for HTTP ranges

### DIFF
--- a/src/transform/operation-object.ts
+++ b/src/transform/operation-object.ts
@@ -129,12 +129,13 @@ export default function transformOperationObject(
       output.push(indent(`responses: {`, indentLv));
       indentLv++;
       for (const [responseCode, responseObject] of getEntries(operationObject.responses, ctx.alphabetize)) {
+        const key = escObjKey(responseCode);
         const c = getSchemaObjectComment(responseObject, indentLv);
         if (c) output.push(indent(c, indentLv));
         if ("$ref" in responseObject) {
           output.push(
             indent(
-              `${responseCode}: ${transformSchemaObject(responseObject, {
+              `${key}: ${transformSchemaObject(responseObject, {
                 path: `${path}/responses/${responseCode}`,
                 ctx,
               })};`,
@@ -146,7 +147,7 @@ export default function transformOperationObject(
             path: `${path}/responses/${responseCode}`,
             ctx: { ...ctx, indentLv },
           });
-          output.push(indent(`${responseCode}: ${responseType};`, indentLv));
+          output.push(indent(`${key}: ${responseType};`, indentLv));
         }
       }
       indentLv--;

--- a/test/path-item-object.test.ts
+++ b/test/path-item-object.test.ts
@@ -39,6 +39,21 @@ describe("Path Item Object", () => {
             },
           },
           404: { $ref: 'components["responses"]["NotFound"]' },
+          "5xx": {
+            description: "Server error",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    message: { type: "string" },
+                    code: { type: "string" },
+                  },
+                  required: ["message"],
+                },
+              },
+            },
+          },
         },
       },
       post: {
@@ -66,6 +81,15 @@ describe("Path Item Object", () => {
         };
       };
       404: components["responses"]["NotFound"];
+      /** @description Server error */
+      "5xx": {
+        content: {
+          "application/json": {
+            message: string;
+            code?: string;
+          };
+        };
+      };
     };
   };
   post: {


### PR DESCRIPTION
## Changes

OpenAPI allows to use HTTP ranges for response keys, see:
https://swagger.io/docs/specification/describing-responses/#status-codes

Before these changes, openapi-typescript would output invalid
TypeScript when processing schemas with HTTP ranges.

## How to Review

Are the test I added enough?

## Checklist

- [x] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
