### PR TITLE
Escape constant string in generated schema

### DIFF
--- a/src/transform/schema-object.ts
+++ b/src/transform/schema-object.ts
@@ -62,7 +62,13 @@ export function defaultSchemaObjectTransform(
 
   // const (valid for any type)
   if (schemaObject.const) {
-    return transformSchemaObject(schemaObject.const as any, {
+    let schemaConst = schemaObject.const as any;
+    if ("type" in schemaObject) {
+      if (schemaObject.type === "string") {
+        schemaConst = escStr(schemaConst)
+      }
+    }
+    return transformSchemaObject(schemaConst, {
       path,
       ctx: { ...ctx, immutableTypes: false, indentLv: indentLv + 1 }, // note: guarantee readonly happens once, here
     });

--- a/test/schema-object.test.ts
+++ b/test/schema-object.test.ts
@@ -137,7 +137,7 @@ describe("Schema Object", () => {
       test("const string field", () => {
         const schema: SchemaObject = {
           type: "object",
-          properties: { "constant": {"const": "a", "type": "string"} },
+          properties: { constant: { const: "a", type: "string" } },
           required: ["constant"],
         };
         const generated = transformSchemaObject(schema, options);
@@ -145,7 +145,7 @@ describe("Schema Object", () => {
   /** @constant */
   constant: "a";
 }`);
-      })
+      });
 
       test("additionalProperties with properties", () => {
         const schema: SchemaObject = {

--- a/test/schema-object.test.ts
+++ b/test/schema-object.test.ts
@@ -134,6 +134,19 @@ describe("Schema Object", () => {
 }`);
       });
 
+      test("const string field", () => {
+        const schema: SchemaObject = {
+          type: "object",
+          properties: { "constant": {"const": "a", "type": "string"} },
+          required: ["constant"],
+        };
+        const generated = transformSchemaObject(schema, options);
+        expect(generated).toBe(`{
+  /** @constant */
+  constant: "a";
+}`);
+      })
+
       test("additionalProperties with properties", () => {
         const schema: SchemaObject = {
           type: "object",
@@ -186,7 +199,7 @@ describe("Schema Object", () => {
     describe("const", () => {
       test("string", () => {
         const generated = transformSchemaObject({ type: "string", const: "duck" }, options);
-        expect(generated).toBe("duck");
+        expect(generated).toBe(`"duck"`);
       });
     });
 


### PR DESCRIPTION
## Changes

Given the schema
```ts
const schema: SchemaObject = {
  type: "object",
  properties: { "constant": {"const": "a", "type": "string"} },
  required: ["constant"],
};
```
the generator would build this
```
  /** @constant */
  constant: a;
```
which isn't valid typescript. I think the same issue was properly taken care of for enums in https://github.com/drwpow/openapi-typescript/blob/main/src/transform/schema-object.ts#L80, so I've used the same approach here.

## How to Review

I hope this should be pretty uncontroversial. Maybe the string cast should also be applied if no type is specified, but not sure about that. This would be the minimal fix for the API we're documenting.

## Checklist

- [x] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
