### PR TITLE
Support fully-qualified refs as discriminator mapping values

### DIFF
--- a/src/transform/schema-object.ts
+++ b/src/transform/schema-object.ts
@@ -199,7 +199,10 @@ export function defaultSchemaObjectTransform(
       const discriminator = ctx.discriminators[discriminatorRef.$ref];
       let value = parseRef(path).path.pop() as string;
       if (discriminator.mapping) {
-        const matchedValue = Object.entries(discriminator.mapping).find(([_, v]) => parseRef(v).path.pop() === value);
+        // Mapping value can either be a fully-qualified ref (#/components/schemas/XYZ) or a schema name (XYZ)
+        const matchedValue = Object.entries(discriminator.mapping).find(
+          ([_, v]) => (v[0] !== "#" && v === value) || (v[0] === "#" && parseRef(v).path.pop() === value)
+        );
         if (matchedValue) value = matchedValue[0]; // why was this designed backwards!?
       }
       coreType.unshift(indent(`${discriminator.propertyName}: ${escStr(value)};`, indentLv + 1));

--- a/src/transform/schema-object.ts
+++ b/src/transform/schema-object.ts
@@ -199,7 +199,7 @@ export function defaultSchemaObjectTransform(
       const discriminator = ctx.discriminators[discriminatorRef.$ref];
       let value = parseRef(path).path.pop() as string;
       if (discriminator.mapping) {
-        const matchedValue = Object.entries(discriminator.mapping).find(([_, v]) => v === value);
+        const matchedValue = Object.entries(discriminator.mapping).find(([_, v]) => parseRef(v).path.pop() === value);
         if (matchedValue) value = matchedValue[0]; // why was this designed backwards!?
       }
       coreType.unshift(indent(`${discriminator.propertyName}: ${escStr(value)};`, indentLv + 1));

--- a/test/schema-object.test.ts
+++ b/test/schema-object.test.ts
@@ -250,11 +250,11 @@ describe("Schema Object", () => {
               'components["schemas"]["parent"]': {
                 propertyName: "operation",
                 mapping: {
-                  "test": options.path
+                  test: options.path,
                 },
-              }
-            }
-          }
+              },
+            },
+          },
         });
         expect(generated).toBe(`{
   operation: "test";

--- a/test/schema-object.test.ts
+++ b/test/schema-object.test.ts
@@ -233,6 +233,35 @@ describe("Schema Object", () => {
   number: number;
 }]>`);
       });
+
+      test("discriminator", () => {
+        const schema: SchemaObject = {
+          type: "object",
+          allOf: [
+            { $ref: 'components["schemas"]["parent"]' },
+            { type: "object", properties: { string: { type: "string" } } },
+          ],
+        };
+        const generated = transformSchemaObject(schema, {
+          path: options.path,
+          ctx: {
+            ...options.ctx,
+            discriminators: {
+              'components["schemas"]["parent"]': {
+                propertyName: "operation",
+                mapping: {
+                  "test": options.path
+                },
+              }
+            }
+          }
+        });
+        expect(generated).toBe(`{
+  operation: "test";
+} & Omit<components["schemas"]["parent"], "operation"> & {
+  string?: string;
+}`);
+      });
     });
 
     describe("allOf", () => {


### PR DESCRIPTION
## Changes

Fixes #1016

## How to Review

I took my best guess at what the test for this should look like based on the existing test suite. The new test does demonstrate the bug (fails in the same way as my real-world case, passes with the code change). But it feels a bit brittle to me, in that it's hardwiring a bunch of context and the source of the original bug was a mismatch between what was really in that context and what the code expected to be there.

Happy to revise this if you think the test isn't adequate.

## Checklist

- [X] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
