### PR TITLE
Make params non-nullable even if all params are optional

### DIFF
--- a/examples/github-api.ts
+++ b/examples/github-api.ts
@@ -86825,8 +86825,8 @@ export interface operations {
      * 
      * The permissions the installation has are included under the `permissions` key.
      */
-    parameters?: {
-      query?: {
+    parameters: {
+      query: {
         outdated?: string;
       };
     };
@@ -87147,10 +87147,10 @@ export interface operations {
      * 
      * For more information on creating a personal access token, see "[Creating a personal access token](/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)."
      */
-    parameters?: {
+    parameters: {
         /** @description A cursor, as given in the [Link header](https://docs.github.com/rest/overview/resources-in-the-rest-api#link-header). If specified, the query only searches for events after this cursor. */
         /** @description A cursor, as given in the [Link header](https://docs.github.com/rest/overview/resources-in-the-rest-api#link-header). If specified, the query only searches for events before this cursor. */
-      query?: {
+      query: {
         date_start?: string;
         date_end?: string;
       };
@@ -87827,10 +87827,10 @@ export interface operations {
      * To use this endpoint, you must be a member of the enterprise,
      * and you must use an access token with the `repo` scope or `security_events` scope.
      */
-    parameters?: {
+    parameters: {
         /** @description If specified, only code scanning alerts with this state will be returned. */
         /** @description The property by which to sort the results. */
-      query?: {
+      query: {
         state?: components["schemas"]["code-scanning-alert-state"];
         sort?: "created" | "updated";
       };
@@ -88426,11 +88426,11 @@ export interface operations {
      * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
      * request id, use the "[List pull requests](https://docs.github.com/rest/reference/pulls#list-pull-requests)" endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description Indicates which sorts of issues to return. `assigned` means issues assigned to you. `created` means issues created by you. `mentioned` means issues mentioning you. `subscribed` means issues you're subscribed to updates for. `all` or `repos` means all issues you can see, regardless of participation or creation. */
         /** @description Indicates the state of the issues to return. */
         /** @description What to sort results by. */
-      query?: {
+      query: {
         filter?: "assigned" | "created" | "mentioned" | "subscribed" | "repos" | "all";
         state?: "open" | "closed" | "all";
         sort?: "created" | "updated" | "comments";
@@ -88457,8 +88457,8 @@ export interface operations {
   };
   "licenses/get-all-commonly-used": {
     /** Get all commonly used licenses */
-    parameters?: {
-      query?: {
+    parameters: {
+      query: {
         featured?: boolean;
       };
     };
@@ -88601,9 +88601,9 @@ export interface operations {
      * 
      * GitHub Apps must use a [JWT](https://docs.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://docs.github.com/rest/overview/other-authentication-methods#basic-authentication) with their client ID and client secret to access this endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description To return the oldest accounts first, set to `asc`. Ignored without the `sort` parameter. */
-      query?: {
+      query: {
         direction?: "asc" | "desc";
       };
     };
@@ -88668,9 +88668,9 @@ export interface operations {
      * 
      * GitHub Apps must use a [JWT](https://docs.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://docs.github.com/rest/overview/other-authentication-methods#basic-authentication) with their client ID and client secret to access this endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description To return the oldest accounts first, set to `asc`. Ignored without the `sort` parameter. */
-      query?: {
+      query: {
         direction?: "asc" | "desc";
       };
     };
@@ -88724,9 +88724,9 @@ export interface operations {
      * List notifications for the authenticated user 
      * @description List all notifications for the current user, sorted by most recently updated.
      */
-    parameters?: {
+    parameters: {
         /** @description The number of results per page (max 50). */
-      query?: {
+      query: {
         per_page?: number;
       };
     };
@@ -88878,9 +88878,9 @@ export interface operations {
      * Get Octocat 
      * @description Get the octocat as ASCII art
      */
-    parameters?: {
+    parameters: {
         /** @description The words to show in Octocat's speech bubble */
-      query?: {
+      query: {
         s?: string;
       };
     };
@@ -90098,10 +90098,10 @@ export interface operations {
      * 
      * GitHub Apps must have the `security_events` read permission to use this endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description If specified, only code scanning alerts with this state will be returned. */
         /** @description The property by which to sort the results. */
-      query?: {
+      query: {
         state?: components["schemas"]["code-scanning-alert-state"];
         sort?: "created" | "updated";
       };
@@ -91259,11 +91259,11 @@ export interface operations {
      * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
      * request id, use the "[List pull requests](https://docs.github.com/rest/reference/pulls#list-pull-requests)" endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description Indicates which sorts of issues to return. `assigned` means issues assigned to you. `created` means issues created by you. `mentioned` means issues mentioning you. `subscribed` means issues you're subscribed to updates for. `all` or `repos` means all issues you can see, regardless of participation or creation. */
         /** @description Indicates the state of the issues to return. */
         /** @description What to sort results by. */
-      query?: {
+      query: {
         filter?: "assigned" | "created" | "mentioned" | "subscribed" | "repos" | "all";
         state?: "open" | "closed" | "all";
         sort?: "created" | "updated" | "comments";
@@ -91287,10 +91287,10 @@ export interface operations {
      * List organization members 
      * @description List all users who are members of an organization. If the authenticated user is also a member of this organization then both concealed and public members will be returned.
      */
-    parameters?: {
+    parameters: {
         /** @description Filter members returned in the list. `2fa_disabled` means that only members without [two-factor authentication](https://github.com/blog/1614-two-factor-authentication) enabled will be returned. This options is only available for organization owners. */
         /** @description Filter members returned by their role. */
-      query?: {
+      query: {
         filter?: "2fa_disabled" | "all";
         role?: "all" | "admin" | "member";
       };
@@ -91467,9 +91467,9 @@ export interface operations {
      * List organization migrations 
      * @description Lists the most recent migrations.
      */
-    parameters?: {
+    parameters: {
         /** @description Exclude attributes from the API response to improve performance */
-      query?: {
+      query: {
         exclude?: ("repositories")[];
       };
     };
@@ -91563,9 +91563,9 @@ export interface operations {
      * *   `exported`, which means the migration finished successfully.
      * *   `failed`, which means the migration failed.
      */
-    parameters?: {
+    parameters: {
         /** @description Exclude attributes from the API response to improve performance */
-      query?: {
+      query: {
         exclude?: ("repositories")[];
       };
     };
@@ -91640,9 +91640,9 @@ export interface operations {
      * List outside collaborators for an organization 
      * @description List all users who are outside collaborators of an organization.
      */
-    parameters?: {
+    parameters: {
         /** @description Filter the list of outside collaborators. `2fa_disabled` means that only outside collaborators without [two-factor authentication](https://github.com/blog/1614-two-factor-authentication) enabled will be returned. */
-      query?: {
+      query: {
         filter?: "2fa_disabled" | "all";
       };
     };
@@ -91779,9 +91779,9 @@ export interface operations {
      * - If `package_type` is not `container`, your token must also include the `repo` scope.
      * - If `package_type` is `container`, you must also have admin permissions to the container that you want to restore.
      */
-    parameters?: {
+    parameters: {
         /** @description package token */
-      query?: {
+      query: {
         token?: string;
       };
     };
@@ -91801,9 +91801,9 @@ export interface operations {
      * To use this endpoint, you must authenticate using an access token with the `packages:read` scope.
      * If `package_type` is not `container`, your token must also include the `repo` scope.
      */
-    parameters?: {
+    parameters: {
         /** @description The state of the package, either active or deleted. */
-      query?: {
+      query: {
         state?: "active" | "deleted";
       };
     };
@@ -91879,9 +91879,9 @@ export interface operations {
      * List organization projects 
      * @description Lists the projects in an organization. Returns a `404 Not Found` status if projects are disabled in the organization. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
      */
-    parameters?: {
+    parameters: {
         /** @description Indicates the state of the projects to return. */
-      query?: {
+      query: {
         state?: "open" | "closed" | "all";
       };
     };
@@ -91978,11 +91978,11 @@ export interface operations {
      * List organization repositories 
      * @description Lists repositories for the specified organization.
      */
-    parameters?: {
+    parameters: {
         /** @description Specifies the types of repositories you want returned. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, `type` can also be `internal`. However, the `internal` value is not yet supported when a GitHub App calls this API with an installation access token. */
         /** @description The property to sort the results by. */
         /** @description The order to sort by. Default: `asc` when using `full_name`, otherwise `desc`. */
-      query?: {
+      query: {
         type?: "all" | "public" | "private" | "forks" | "sources" | "member" | "internal";
         sort?: "created" | "updated" | "pushed" | "full_name";
         direction?: "asc" | "desc";
@@ -92458,9 +92458,9 @@ export interface operations {
      * 
      * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/{org_id}/team/{team_id}/discussions`.
      */
-    parameters?: {
+    parameters: {
         /** @description Pinned discussions only filter */
-      query?: {
+      query: {
         pinned?: string;
       };
     };
@@ -92667,9 +92667,9 @@ export interface operations {
      * 
      * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/comments/:comment_number/reactions`.
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to a team discussion comment. */
-      query?: {
+      query: {
         content?: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -92737,9 +92737,9 @@ export interface operations {
      * 
      * **Note:** You can also specify a team by `org_id` and `team_id` using the route `GET /organizations/:org_id/team/:team_id/discussions/:discussion_number/reactions`.
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to a team discussion. */
-      query?: {
+      query: {
         content?: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -92826,9 +92826,9 @@ export interface operations {
      * 
      * To list members in a team, the team must be visible to the authenticated user.
      */
-    parameters?: {
+    parameters: {
         /** @description Filters members returned by their role in the team. */
-      query?: {
+      query: {
         role?: "member" | "maintainer" | "all";
       };
     };
@@ -93304,9 +93304,9 @@ export interface operations {
   };
   "projects/list-cards": {
     /** List project cards */
-    parameters?: {
+    parameters: {
         /** @description Filters the project cards that are returned by the card's state. */
-      query?: {
+      query: {
         archived_state?: "all" | "archived" | "not_archived";
       };
     };
@@ -93511,9 +93511,9 @@ export interface operations {
      * List project collaborators 
      * @description Lists the collaborators for an organization project. For a project, the list of collaborators includes outside collaborators, organization members that are direct collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners. You must be an organization owner or a project `admin` to list collaborators.
      */
-    parameters?: {
+    parameters: {
         /** @description Filters the collaborators by their affiliation. `outside` means outside collaborators of a project that are not a member of the project's organization. `direct` means collaborators with permissions to a project, regardless of organization membership status. `all` means all collaborators the authenticated user can see. */
-      query?: {
+      query: {
         affiliation?: "outside" | "direct" | "all";
       };
     };
@@ -93883,9 +93883,9 @@ export interface operations {
      * List artifacts for a repository 
      * @description Lists all artifacts for a repository. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description Filters artifacts by exact match on their name field. */
-      query?: {
+      query: {
         name?: string;
       };
     };
@@ -94591,9 +94591,9 @@ export interface operations {
      * List jobs for a workflow run 
      * @description Lists jobs for a workflow run. Anyone with read access to the repository can use this endpoint. If the repository is private you must use an access token with the `repo` scope. GitHub Apps must have the `actions:read` permission to use this endpoint. You can use parameters to narrow the list of results. For more information about using parameters, see [Parameters](https://docs.github.com/rest/overview/resources-in-the-rest-api#parameters).
      */
-    parameters?: {
+    parameters: {
         /** @description Filters jobs by their `completed_at` timestamp. `latest` returns jobs from the most recent execution of the workflow run. `all` returns all jobs for a workflow run, including from old executions of the workflow run. */
-      query?: {
+      query: {
         filter?: "latest" | "all";
       };
     };
@@ -95186,9 +95186,9 @@ export interface operations {
   };
   "repos/list-branches": {
     /** List branches */
-    parameters?: {
+    parameters: {
         /** @description Setting to `true` returns only protected branches. When set to `false`, only unprotected branches are returned. Omitting this parameter returns all branches. */
-      query?: {
+      query: {
         protected?: boolean;
       };
     };
@@ -96329,9 +96329,9 @@ export interface operations {
      * 
      * Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.
      */
-    parameters?: {
+    parameters: {
         /** @description Filters check runs by their `completed_at` timestamp. `latest` returns the most recent check runs. */
-      query?: {
+      query: {
         filter?: "latest" | "all";
       };
     };
@@ -96380,10 +96380,10 @@ export interface operations {
      * This provides details of the most recent instance of this alert
      * for the default branch (or for the specified Git reference if you used `ref` in the request).
      */
-    parameters?: {
+    parameters: {
         /** @description The property by which to sort the results. */
         /** @description If specified, only code scanning alerts with this state will be returned. */
-      query?: {
+      query: {
         sort?: "created" | "updated";
         state?: components["schemas"]["code-scanning-alert-state"];
       };
@@ -96489,11 +96489,11 @@ export interface operations {
      * **Deprecation notice**:
      * The `tool_name` field is deprecated and will, in future, not be included in the response for this endpoint. The example response reflects this change. The tool name can now be found inside the `tool` field.
      */
-    parameters?: {
+    parameters: {
         /** @description The Git reference for the analyses you want to list. The `ref` for a branch can be formatted either as `refs/heads/<branch name>` or simply `<branch name>`. To reference a pull request use `refs/pull/<number>/merge`. */
         /** @description Filter analyses belonging to the same SARIF upload. */
         /** @description The property by which to sort the results. */
-      query?: {
+      query: {
         ref?: components["schemas"]["code-scanning-ref"];
         sarif_id?: components["schemas"]["code-scanning-analysis-sarif-id"];
         sort?: "created";
@@ -96626,7 +96626,7 @@ export interface operations {
      */
     parameters: {
         /** @description Allow deletion if the specified analysis is the last in a set. If you attempt to delete the final analysis in a set without setting this parameter to `true`, you'll get a 400 response with the message: `Analysis is last of its type and deletion may result in the loss of historical alert data. Please specify confirm_delete.` */
-      query?: {
+      query: {
         confirm_delete?: string | null;
       };
         /** @description The ID of the analysis, as returned from the `GET /repos/{owner}/{repo}/code-scanning/analyses` operation. */
@@ -96800,9 +96800,9 @@ export interface operations {
      * For more information about the correct CODEOWNERS syntax,
      * see "[About code owners](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)."
      */
-    parameters?: {
+    parameters: {
         /** @description A branch, tag or commit name used to determine which version of the CODEOWNERS file to use. Default: the repository's default branch (e.g. `main`) */
-      query?: {
+      query: {
         ref?: string;
       };
     };
@@ -96936,10 +96936,10 @@ export interface operations {
      * 
      * GitHub Apps must have write access to the `codespaces_metadata` repository permission to use this endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description The location to check for available machines. Assigned by IP if not provided. */
         /** @description IP for location auto-detection when proxying a request */
-      query?: {
+      query: {
         location?: string;
         client_ip?: string;
       };
@@ -96970,10 +96970,10 @@ export interface operations {
      * 
      * GitHub Apps must have write access to the `codespaces` repository permission to use this endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description The branch or commit to check for a default devcontainer path. If not specified, the default branch will be checked. */
         /** @description An alternative IP for default location auto-detection, such as when proxying a request. */
-      query?: {
+      query: {
         ref?: string;
         client_ip?: string;
       };
@@ -97167,10 +97167,10 @@ export interface operations {
      * endpoint. GitHub Apps must have the `members` organization permission and `metadata` repository permission to use this
      * endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description Filter collaborators returned by their affiliation. `outside` means all outside collaborators of an organization-owned repository. `direct` means all collaborators with permissions to an organization-owned repository, regardless of organization membership status. `all` means all collaborators the authenticated user can see. */
         /** @description Filter collaborators by the permissions they have on the repository. If not specified, all collaborators will be returned. */
-      query?: {
+      query: {
         affiliation?: "outside" | "direct" | "all";
         permission?: "pull" | "triage" | "push" | "maintain" | "admin";
       };
@@ -97346,9 +97346,9 @@ export interface operations {
      * List reactions for a commit comment 
      * @description List the reactions to a [commit comment](https://docs.github.com/rest/reference/repos#comments).
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to a commit comment. */
-      query?: {
+      query: {
         content?: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -97441,12 +97441,12 @@ export interface operations {
      * | `invalid` | The signature could not be cryptographically verified using the key whose key-id was found in the signature. |
      * | `valid` | None of the above errors applied, so the signature is considered to be verified. |
      */
-    parameters?: {
+    parameters: {
         /** @description SHA or branch to start listing commits from. Default: the repository’s default branch (usually `master`). */
         /** @description Only commits containing this file path will be returned. */
         /** @description GitHub login or email address by which to filter by commit author. */
         /** @description Only commits before this date will be returned. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`. */
-      query?: {
+      query: {
         sha?: string;
         path?: string;
         author?: string;
@@ -97624,7 +97624,7 @@ export interface operations {
      */
     parameters: {
         /** @description Filters check runs by their `completed_at` timestamp. `latest` returns the most recent check runs. */
-      query?: {
+      query: {
         filter?: "latest" | "all";
         app_id?: number;
       };
@@ -97660,7 +97660,7 @@ export interface operations {
          * @description Filters check suites by GitHub App `id`. 
          * @example 1
          */
-      query?: {
+      query: {
         app_id?: number;
       };
         /** @description ref parameter */
@@ -97868,7 +97868,7 @@ export interface operations {
      */
     parameters: {
         /** @description The name of the commit/branch/tag. Default: the repository’s default branch (usually `master`) */
-      query?: {
+      query: {
         ref?: string;
       };
         /** @description path parameter */
@@ -98017,9 +98017,9 @@ export interface operations {
      * 
      * GitHub identifies contributors by author email address. This endpoint groups contribution counts by GitHub user, which includes all associated email addresses. To improve performance, only the first 500 author email addresses in the repository link to GitHub users. The rest will appear as anonymous contributors without associated GitHub user information.
      */
-    parameters?: {
+    parameters: {
         /** @description Set to `1` or `true` to include anonymous contributors in results. */
-      query?: {
+      query: {
         anon?: string;
       };
     };
@@ -98046,7 +98046,7 @@ export interface operations {
      * You can also use tokens with the `public_repo` scope for public repositories only.
      * GitHub Apps must have **Dependabot alerts** read permission to use this endpoint.
      */
-    parameters?: {
+    parameters: {
         /**
          * @deprecated 
          * @description **Deprecated**. Page number of the results to fetch. Use cursor-based pagination with `before` or `after` instead.
@@ -98055,7 +98055,7 @@ export interface operations {
          * @deprecated 
          * @description **Deprecated**. The number of results per page (max 100). Use cursor-based pagination with `first` or `last` instead.
          */
-      query?: {
+      query: {
         page?: number;
         per_page?: number;
       };
@@ -98350,12 +98350,12 @@ export interface operations {
      * List deployments 
      * @description Simple filtering of deployments is available via query parameters:
      */
-    parameters?: {
+    parameters: {
         /** @description The SHA recorded at creation time. */
         /** @description The name of the ref. This can be a branch, tag, or SHA. */
         /** @description The name of the task for the deployment (e.g., `deploy` or `deploy:migrations`). */
         /** @description The name of the environment that was deployed to (e.g., `staging` or `production`). */
-      query?: {
+      query: {
         sha?: string;
         ref?: string;
         task?: string;
@@ -98847,9 +98847,9 @@ export interface operations {
   };
   "repos/list-forks": {
     /** List forks */
-    parameters?: {
+    parameters: {
         /** @description The sort order. `stargazers` will sort by star count. */
-      query?: {
+      query: {
         sort?: "newest" | "oldest" | "stargazers" | "watchers";
       };
     };
@@ -99415,7 +99415,7 @@ export interface operations {
      */
     parameters: {
         /** @description Setting this parameter to any value returns the objects or subtrees referenced by the tree specified in `:tree_sha`. For example, setting `recursive` to any of the following will enable returning objects or subtrees: `0`, `1`, `"true"`, and `"false"`. Omit this parameter to prevent recursively returning objects or subtrees. */
-      query?: {
+      query: {
         recursive?: string;
       };
       path: {
@@ -100039,14 +100039,14 @@ export interface operations {
      * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
      * request id, use the "[List pull requests](https://docs.github.com/rest/reference/pulls#list-pull-requests)" endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned. */
         /** @description Indicates the state of the issues to return. */
         /** @description Can be the name of a user. Pass in `none` for issues with no assigned user, and `*` for issues assigned to any user. */
         /** @description The user that created the issue. */
         /** @description A user that's mentioned in the issue. */
         /** @description What to sort results by. */
-      query?: {
+      query: {
         milestone?: string;
         state?: "open" | "closed" | "all";
         assignee?: string;
@@ -100122,9 +100122,9 @@ export interface operations {
      * List issue comments for a repository 
      * @description By default, Issue Comments are ordered by ascending ID.
      */
-    parameters?: {
+    parameters: {
         /** @description Either `asc` or `desc`. Ignored without the `sort` parameter. */
-      query?: {
+      query: {
         direction?: "asc" | "desc";
       };
     };
@@ -100186,9 +100186,9 @@ export interface operations {
      * List reactions for an issue comment 
      * @description List the reactions to an [issue comment](https://docs.github.com/rest/reference/issues#comments).
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to an issue comment. */
-      query?: {
+      query: {
         content?: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -100630,9 +100630,9 @@ export interface operations {
      * List reactions for an issue 
      * @description List the reactions to an [issue](https://docs.github.com/rest/reference/issues).
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to an issue. */
-      query?: {
+      query: {
         content?: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -100998,11 +100998,11 @@ export interface operations {
   };
   "issues/list-milestones": {
     /** List milestones */
-    parameters?: {
+    parameters: {
         /** @description The state of the milestone. Either `open`, `closed`, or `all`. */
         /** @description What to sort results by. Either `due_on` or `completeness`. */
         /** @description The direction of the sort. Either `asc` or `desc`. */
-      query?: {
+      query: {
         state?: "open" | "closed" | "all";
         sort?: "due_on" | "completeness";
         direction?: "asc" | "desc";
@@ -101404,9 +101404,9 @@ export interface operations {
      * List repository projects 
      * @description Lists the projects in a repository. Returns a `404 Not Found` status if projects are disabled in the repository. If you do not have sufficient privileges to perform this action, a `401 Unauthorized` or `410 Gone` status is returned.
      */
-    parameters?: {
+    parameters: {
         /** @description Indicates the state of the projects to return. */
-      query?: {
+      query: {
         state?: "open" | "closed" | "all";
       };
     };
@@ -101461,13 +101461,13 @@ export interface operations {
      * List pull requests 
      * @description Draft pull requests are available in public repositories with GitHub Free and GitHub Free for organizations, GitHub Pro, and legacy per-repository billing plans, and in public and private repositories with GitHub Team and GitHub Enterprise Cloud. For more information, see [GitHub's products](https://docs.github.com/github/getting-started-with-github/githubs-products) in the GitHub Help documentation.
      */
-    parameters?: {
+    parameters: {
         /** @description Either `open`, `closed`, or `all` to filter by state. */
         /** @description Filter pulls by head user or head organization and branch name in the format of `user:ref-name` or `organization:ref-name`. For example: `github:new-script-format` or `octocat:test-branch`. */
         /** @description Filter pulls by base branch name. Example: `gh-pages`. */
         /** @description What to sort results by. `popularity` will sort by the number of comments. `long-running` will sort by date created and will limit the results to pull requests that have been open for more than a month and have had activity within the past month. */
         /** @description The direction of the sort. Default: `desc` when sort is `created` or sort is not specified, otherwise `asc`. */
-      query?: {
+      query: {
         state?: "open" | "closed" | "all";
         head?: string;
         base?: string;
@@ -101541,9 +101541,9 @@ export interface operations {
      * List review comments in a repository 
      * @description Lists review comments for all pull requests in a repository. By default, review comments are in ascending order by ID.
      */
-    parameters?: {
+    parameters: {
         /** @description The direction to sort results. Ignored without `sort` parameter. */
-      query?: {
+      query: {
         sort?: "created" | "updated" | "created_at";
         direction?: "asc" | "desc";
       };
@@ -101613,9 +101613,9 @@ export interface operations {
      * List reactions for a pull request review comment 
      * @description List the reactions to a [pull request review comment](https://docs.github.com/rest/reference/pulls#review-comments).
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to a pull request review comment. */
-      query?: {
+      query: {
         content?: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -101802,9 +101802,9 @@ export interface operations {
      * List review comments on a pull request 
      * @description Lists all review comments for a pull request. By default, review comments are in ascending order by ID.
      */
-    parameters?: {
+    parameters: {
         /** @description The direction to sort results. Ignored without `sort` parameter. */
-      query?: {
+      query: {
         direction?: "asc" | "desc";
       };
     };
@@ -102306,9 +102306,9 @@ export interface operations {
      * 
      * READMEs support [custom media types](https://docs.github.com/rest/reference/repos#custom-media-types) for retrieving the raw content or rendered HTML.
      */
-    parameters?: {
+    parameters: {
         /** @description The name of the commit/branch/tag. Default: the repository’s default branch (usually `master`) */
-      query?: {
+      query: {
         ref?: string;
       };
     };
@@ -102332,7 +102332,7 @@ export interface operations {
      */
     parameters: {
         /** @description The name of the commit/branch/tag. Default: the repository’s default branch (usually `master`) */
-      query?: {
+      query: {
         ref?: string;
       };
         /** @description The alternate path to look for a README file */
@@ -102684,9 +102684,9 @@ export interface operations {
      * List reactions for a release 
      * @description List the reactions to a [release](https://docs.github.com/rest/reference/repos#releases).
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to a release. */
-      query?: {
+      query: {
         content?: "+1" | "laugh" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -104161,9 +104161,9 @@ export interface operations {
      * 
      * List the reactions to a [team discussion comment](https://docs.github.com/rest/reference/teams#discussion-comments). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to a team discussion comment. */
-      query?: {
+      query: {
         content?: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -104215,9 +104215,9 @@ export interface operations {
      * 
      * List the reactions to a [team discussion](https://docs.github.com/rest/reference/teams#discussions). OAuth access tokens require the `read:discussion` [scope](https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/).
      */
-    parameters?: {
+    parameters: {
         /** @description Returns a single [reaction type](https://docs.github.com/rest/reference/reactions#reaction-types). Omit this parameter to list all reactions to a team discussion. */
-      query?: {
+      query: {
         content?: "+1" | "-1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes";
       };
     };
@@ -104289,9 +104289,9 @@ export interface operations {
      * 
      * Team members will include the members of child teams.
      */
-    parameters?: {
+    parameters: {
         /** @description Filters members returned by their role in the team. */
-      query?: {
+      query: {
         role?: "member" | "maintainer" | "all";
       };
     };
@@ -105779,11 +105779,11 @@ export interface operations {
      * the `pull_request` key. Be aware that the `id` of a pull request returned from "Issues" endpoints will be an _issue id_. To find out the pull
      * request id, use the "[List pull requests](https://docs.github.com/rest/reference/pulls#list-pull-requests)" endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description Indicates which sorts of issues to return. `assigned` means issues assigned to you. `created` means issues created by you. `mentioned` means issues mentioning you. `subscribed` means issues you're subscribed to updates for. `all` or `repos` means all issues you can see, regardless of participation or creation. */
         /** @description Indicates the state of the issues to return. */
         /** @description What to sort results by. */
-      query?: {
+      query: {
         filter?: "assigned" | "created" | "mentioned" | "subscribed" | "repos" | "all";
         state?: "open" | "closed" | "all";
         sort?: "created" | "updated" | "comments";
@@ -105929,9 +105929,9 @@ export interface operations {
   };
   "orgs/list-memberships-for-authenticated-user": {
     /** List organization memberships for the authenticated user */
-    parameters?: {
+    parameters: {
         /** @description Indicates the state of the memberships to return. If not specified, the API returns both active and pending memberships. */
-      query?: {
+      query: {
         state?: "active" | "pending";
       };
     };
@@ -106089,8 +106089,8 @@ export interface operations {
      * 
      * Once the migration has been `exported` you can [download the migration archive](https://docs.github.com/rest/reference/migrations#download-a-user-migration-archive).
      */
-    parameters?: {
-      query?: {
+    parameters: {
+      query: {
         exclude?: (string)[];
       };
     };
@@ -106277,9 +106277,9 @@ export interface operations {
      * 
      * To use this endpoint, you must authenticate using an access token with the `packages:read` and `packages:write` scopes. If `package_type` is not `container`, your token must also include the `repo` scope.
      */
-    parameters?: {
+    parameters: {
         /** @description package token */
-      query?: {
+      query: {
         token?: string;
       };
     };
@@ -106299,9 +106299,9 @@ export interface operations {
      * To use this endpoint, you must authenticate using an access token with the `packages:read` scope.
      * If `package_type` is not `container`, your token must also include the `repo` scope.
      */
-    parameters?: {
+    parameters: {
         /** @description The state of the package, either active or deleted. */
-      query?: {
+      query: {
         state?: "active" | "deleted";
       };
     };
@@ -106431,7 +106431,7 @@ export interface operations {
      * 
      * The authenticated user has explicit permission to access repositories they own, repositories where they are a collaborator, and repositories that they can access through an organization membership.
      */
-    parameters?: {
+    parameters: {
         /** @description Limit results to repositories with the specified visibility. */
         /**
          * @description Comma-separated list of values. Can include:  
@@ -106442,7 +106442,7 @@ export interface operations {
         /** @description Limit results to repositories of the specified type. Will cause a `422` error if used in the same request as **visibility** or **affiliation**. */
         /** @description The property to sort the results by. */
         /** @description The order to sort by. Default: `asc` when using `full_name`, otherwise `desc`. */
-      query?: {
+      query: {
         visibility?: "all" | "public" | "private";
         affiliation?: string;
         type?: "all" | "owner" | "public" | "private" | "member";
@@ -107039,10 +107039,10 @@ export interface operations {
      *   https://api.github.com/users/octocat/hovercard?subject_type=repository&subject_id=1300192
      * ```
      */
-    parameters?: {
+    parameters: {
         /** @description Identifies which additional information you'd like to receive about the person's hovercard. Can be `organization`, `repository`, `issue`, `pull_request`. **Required** when using `subject_id`. */
         /** @description Uses the ID for the `subject_type` you specified. **Required** when using `subject_type`. */
-      query?: {
+      query: {
         subject_type?: "organization" | "repository" | "issue" | "pull_request";
         subject_id?: string;
       };
@@ -107182,9 +107182,9 @@ export interface operations {
      * - If `package_type` is not `container`, your token must also include the `repo` scope.
      * - If `package_type` is `container`, you must also have admin permissions to the container that you want to restore.
      */
-    parameters?: {
+    parameters: {
         /** @description package token */
-      query?: {
+      query: {
         token?: string;
       };
     };
@@ -107273,9 +107273,9 @@ export interface operations {
   };
   "projects/list-for-user": {
     /** List user projects */
-    parameters?: {
+    parameters: {
         /** @description Indicates the state of the projects to return. */
-      query?: {
+      query: {
         state?: "open" | "closed" | "all";
       };
     };
@@ -107322,11 +107322,11 @@ export interface operations {
      * List repositories for a user 
      * @description Lists public repositories for the specified user. Note: For GitHub AE, this endpoint will list internal repositories for the specified user.
      */
-    parameters?: {
+    parameters: {
         /** @description Limit results to repositories of the specified type. */
         /** @description The property to sort the results by. */
         /** @description The order to sort by. Default: `asc` when using `full_name`, otherwise `desc`. */
-      query?: {
+      query: {
         type?: "all" | "owner" | "member";
         sort?: "created" | "updated" | "pushed" | "full_name";
         direction?: "asc" | "desc";

--- a/examples/octokit-ghes-3.6-diff-to-api.ts
+++ b/examples/octokit-ghes-3.6-diff-to-api.ts
@@ -5928,9 +5928,9 @@ export interface operations {
   };
   "enterprise-admin/list-public-keys": {
     /** List public keys */
-    parameters?: {
+    parameters: {
         /** @description Only show public keys accessed after the given time. */
-      query?: {
+      query: {
         sort?: "created" | "updated" | "accessed";
         since?: string;
       };
@@ -6074,8 +6074,8 @@ export interface operations {
   };
   "enterprise-admin/list-pre-receive-environments": {
     /** List pre-receive environments */
-    parameters?: {
-      query?: {
+    parameters: {
+      query: {
         sort?: "created" | "updated" | "name";
       };
     };
@@ -6236,9 +6236,9 @@ export interface operations {
   };
   "enterprise-admin/list-pre-receive-hooks": {
     /** List pre-receive hooks */
-    parameters?: {
+    parameters: {
         /** @description The property to sort the results by. */
-      query?: {
+      query: {
         sort?: "created" | "updated" | "name";
       };
     };
@@ -6467,8 +6467,8 @@ export interface operations {
      * 
      * The permissions the installation has are included under the `permissions` key.
      */
-    parameters?: {
-      query?: {
+    parameters: {
+      query: {
         outdated?: string;
       };
     };
@@ -6545,9 +6545,9 @@ export interface operations {
      * 
      * You can use this API to list the set of OAuth applications that have been granted access to your account. Unlike the [list your authorizations](https://docs.github.com/enterprise-server@3.6/rest/reference/oauth-authorizations#list-your-authorizations) API, this API does not manage individual tokens. This API will return one entry for each OAuth application that has been granted access to your account, regardless of the number of tokens an application has generated for your user. The list of OAuth applications returned matches what is shown on [the application authorizations settings screen within GitHub](https://github.com/settings/applications#authorized). The `scopes` returned are the union of scopes authorized for the application. For example, if an application has one token with `repo` scope and another token with `user` scope, the grant will return `["repo", "user"]`.
      */
-    parameters?: {
+    parameters: {
         /** @description The client ID of your GitHub app. */
-      query?: {
+      query: {
         client_id?: string;
       };
     };
@@ -6703,9 +6703,9 @@ export interface operations {
      * @deprecated 
      * @description **Deprecation Notice:** GitHub Enterprise Server will discontinue the [OAuth Authorizations API](https://docs.github.com/enterprise-server@3.6/rest/reference/oauth-authorizations), which is used by integrations to create personal access tokens and OAuth tokens, and you must now create these tokens using our [web application flow](https://docs.github.com/enterprise-server@3.6/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow). The [OAuth Authorizations API](https://docs.github.com/enterprise-server@3.6/rest/reference/oauth-authorizations) will be removed on November, 13, 2020. For more information, including scheduled brownouts, see the [blog post](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).
      */
-    parameters?: {
+    parameters: {
         /** @description The client ID of your GitHub app. */
-      query?: {
+      query: {
         client_id?: string;
       };
     };
@@ -7502,10 +7502,10 @@ export interface operations {
      * 
      * You can manage team membership with your identity provider using Enterprise Managed Users for GitHub Enterprise Cloud. For more information, see "[GitHub's products](https://docs.github.com/enterprise-server@3.6/github/getting-started-with-github/githubs-products)" in the GitHub Help documentation.
      */
-    parameters?: {
+    parameters: {
         /** @description Page token */
         /** @description Limits the list to groups containing the text in the group name */
-      query?: {
+      query: {
         page?: number;
         display_name?: string;
       };
@@ -7564,9 +7564,9 @@ export interface operations {
      * List pre-receive hooks for an organization 
      * @description List all pre-receive hooks that are enabled or testing for this organization as well as any disabled hooks that can be configured at the organization level. Globally disabled pre-receive hooks that do not allow downstream configuration are not listed.
      */
-    parameters?: {
+    parameters: {
         /** @description The sort order for the response collection. */
-      query?: {
+      query: {
         sort?: "created" | "updated" | "name";
       };
     };
@@ -8016,10 +8016,10 @@ export interface operations {
      * **Deprecation notice**:
      * The `tool_name` field is deprecated and will, in future, not be included in the response for this endpoint. The example response reflects this change. The tool name can now be found inside the `tool` field.
      */
-    parameters?: {
+    parameters: {
         /** @description The Git reference for the analyses you want to list. The `ref` for a branch can be formatted either as `refs/heads/<branch name>` or simply `<branch name>`. To reference a pull request use `refs/pull/<number>/merge`. */
         /** @description Filter analyses belonging to the same SARIF upload. */
-      query?: {
+      query: {
         ref?: components["schemas"]["code-scanning-ref"];
         sarif_id?: components["schemas"]["code-scanning-analysis-sarif-id"];
       };
@@ -8048,10 +8048,10 @@ export interface operations {
      * endpoint. GitHub Apps must have the `members` organization permission and `metadata` repository permission to use this
      * endpoint.
      */
-    parameters?: {
+    parameters: {
         /** @description Filter collaborators returned by their affiliation. `outside` means all outside collaborators of an organization-owned repository. `direct` means all collaborators with permissions to an organization-owned repository, regardless of organization membership status. `all` means all collaborators the authenticated user can see. */
         /** @description Filter collaborators by the permissions they have on the repository. If not specified, all collaborators will be returned. */
-      query?: {
+      query: {
         affiliation?: "outside" | "direct" | "all";
         permission?: "pull" | "triage" | "push" | "maintain" | "admin";
       };
@@ -8221,8 +8221,8 @@ export interface operations {
      * List pre-receive hooks for a repository 
      * @description List all pre-receive hooks that are enabled or testing for this repository as well as any disabled hooks that are allowed to be enabled at the repository level. Pre-receive hooks that are disabled at a higher level and are not configurable will not be listed.
      */
-    parameters?: {
-      query?: {
+    parameters: {
+      query: {
         sort?: "created" | "updated" | "name";
       };
     };
@@ -8552,9 +8552,9 @@ export interface operations {
      * - For GitHub Enterprise Server, this endpoint will only list repositories available to all users on the enterprise.
      * - Pagination is powered exclusively by the `since` parameter. Use the [Link header](https://docs.github.com/enterprise-server@3.6/rest/overview/resources-in-the-rest-api#link-header) to get the URL for the next page of repositories.
      */
-    parameters?: {
+    parameters: {
         /** @description Specifies the types of repositories to return. This endpoint will only list repositories available to all users on the enterprise. */
-      query?: {
+      query: {
         visibility?: "all" | "public";
       };
     };
@@ -8578,10 +8578,10 @@ export interface operations {
      * List provisioned SCIM groups for an enterprise 
      * @description **Note:** The SCIM API endpoints for enterprise accounts are currently in beta and are subject to change.
      */
-    parameters?: {
+    parameters: {
         /** @description filter results */
         /** @description attributes to exclude */
-      query?: {
+      query: {
         filter?: string;
         excludedAttributes?: string;
       };
@@ -8630,9 +8630,9 @@ export interface operations {
      * Get SCIM provisioning information for an enterprise group 
      * @description **Note:** The SCIM API endpoints for enterprise accounts are currently in beta and are subject to change.
      */
-    parameters?: {
+    parameters: {
         /** @description Attributes to exclude. */
-      query?: {
+      query: {
         excludedAttributes?: string;
       };
     };
@@ -8739,9 +8739,9 @@ export interface operations {
      *    - If the user signs in, their GitHub Enterprise Server account is linked to this entry.
      *    - If the user does not sign in (or does not create a new account when prompted), they are not added to the GitHub Enterprise Server enterprise, and the external identity `null` entry remains in place.
      */
-    parameters?: {
+    parameters: {
         /** @description filter results */
-      query?: {
+      query: {
         filter?: string;
       };
     };

--- a/examples/stripe-api.ts
+++ b/examples/stripe-api.ts
@@ -15235,9 +15235,9 @@ export interface operations {
 
   GetAccount: {
     /** @description <p>Retrieves the details of an account.</p> */
-    parameters?: {
+    parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
     };
@@ -15304,12 +15304,12 @@ export interface operations {
   };
   GetAccounts: {
     /** @description <p>Returns a list of accounts connected to your platform via <a href="/docs/connect">Connect</a>. If you’re not a platform, the list is empty.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -15836,7 +15836,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an account.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -16416,7 +16416,7 @@ export interface operations {
     /** @description <p>Retrieve a specified external account for a given account.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -16547,7 +16547,7 @@ export interface operations {
     /** @description <p>Returns a list of capabilities associated with the account. The capabilities are returned sorted by creation date, with the most recent capability appearing first.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -16589,7 +16589,7 @@ export interface operations {
     /** @description <p>Retrieves information about the specified Account Capability.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -16657,7 +16657,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -16755,7 +16755,7 @@ export interface operations {
     /** @description <p>Retrieve a specified external account for a given account.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -16924,7 +16924,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Filters on the list of people returned based on the person's relationship to the account's company. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -17145,7 +17145,7 @@ export interface operations {
     /** @description <p>Retrieves an existing person.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -17380,7 +17380,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Filters on the list of people returned based on the person's relationship to the account's company. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -17601,7 +17601,7 @@ export interface operations {
     /** @description <p>Retrieves an existing person.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -17866,12 +17866,12 @@ export interface operations {
   };
   GetApplePayDomains: {
     /** @description <p>List apple pay domains.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         domain_name?: string;
         ending_before?: string;
         expand?: (string)[];
@@ -17940,7 +17940,7 @@ export interface operations {
     /** @description <p>Retrieve an apple pay domain.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -17996,13 +17996,13 @@ export interface operations {
   };
   GetApplicationFees: {
     /** @description <p>Returns a list of application fees you’ve previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return application fees for the charge specified by this charge ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         charge?: string;
         created?: {
           gt?: number;
@@ -18051,7 +18051,7 @@ export interface operations {
     /** @description <p>By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -18122,7 +18122,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an application fee that your account has collected. The same information is returned when refunding the application fee.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -18187,7 +18187,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -18446,9 +18446,9 @@ export interface operations {
      * @description <p>Retrieves the current account balance, based on the authentication that was used to make the request.
      *  For a sample request, see <a href="/docs/connect/account-balances#accounting-for-negative-balances">Accounting for negative balances</a>.</p>
      */
-    parameters?: {
+    parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
     };
@@ -18478,7 +18478,7 @@ export interface operations {
      * 
      * <p>Note that this endpoint was previously called “Balance history” and used the path <code>/v1/balance/history</code>.</p>
      */
-    parameters?: {
+    parameters: {
         /** @description Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
@@ -18487,7 +18487,7 @@ export interface operations {
         /** @description Only returns the original transaction. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only returns transactions of the given type. One of: `adjustment`, `advance`, `advance_funding`, `anticipation_repayment`, `application_fee`, `application_fee_refund`, `charge`, `connect_collection_transfer`, `contribution`, `issuing_authorization_hold`, `issuing_authorization_release`, `issuing_dispute`, `issuing_transaction`, `payment`, `payment_failure_refund`, `payment_refund`, `payout`, `payout_cancel`, `payout_failure`, `refund`, `refund_failure`, `reserve_transaction`, `reserved_funds`, `stripe_fee`, `stripe_fx_fee`, `tax_fee`, `topup`, `topup_reversal`, `transfer`, `transfer_cancel`, `transfer_failure`, or `transfer_refund`. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -18543,7 +18543,7 @@ export interface operations {
      */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -18576,7 +18576,7 @@ export interface operations {
      * 
      * <p>Note that this endpoint was previously called “Balance history” and used the path <code>/v1/balance/history</code>.</p>
      */
-    parameters?: {
+    parameters: {
         /** @description Only return transactions in a certain currency. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
@@ -18585,7 +18585,7 @@ export interface operations {
         /** @description Only returns the original transaction. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only returns transactions of the given type. One of: `adjustment`, `advance`, `advance_funding`, `anticipation_repayment`, `application_fee`, `application_fee_refund`, `charge`, `connect_collection_transfer`, `contribution`, `issuing_authorization_hold`, `issuing_authorization_release`, `issuing_dispute`, `issuing_transaction`, `payment`, `payment_failure_refund`, `payment_refund`, `payout`, `payout_cancel`, `payout_failure`, `refund`, `refund_failure`, `reserve_transaction`, `reserved_funds`, `stripe_fee`, `stripe_fx_fee`, `tax_fee`, `topup`, `topup_reversal`, `transfer`, `transfer_cancel`, `transfer_failure`, or `transfer_refund`. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -18641,7 +18641,7 @@ export interface operations {
      */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -18670,14 +18670,14 @@ export interface operations {
   };
   GetBillingPortalConfigurations: {
     /** @description <p>Returns a list of configurations that describe the functionality of the customer portal.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return configurations that are active or inactive (e.g., pass `true` to only list active configurations). */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description Only return the default or non-default configurations (e.g., pass `true` to only list the default configuration). */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         active?: boolean;
         ending_before?: string;
         expand?: (string)[];
@@ -18815,7 +18815,7 @@ export interface operations {
     /** @description <p>Retrieves a configuration that describes the functionality of the customer portal.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -18983,7 +18983,7 @@ export interface operations {
   };
   GetCharges: {
     /** @description <p>Returns a list of charges you’ve previously created. The charges are returned in sorted order, with the most recent charges appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return charges for the customer specified by this customer ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
@@ -18991,7 +18991,7 @@ export interface operations {
         /** @description Only return charges that were created by the PaymentIntent specified by this PaymentIntent ID. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return charges for this transfer group. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -19204,7 +19204,7 @@ export interface operations {
     /** @description <p>Retrieves the details of a charge that has previously been created. Supply the unique charge ID that was returned from your previous request, and Stripe will return the corresponding charge information. The same information is returned when creating or refunding the charge.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -19359,7 +19359,7 @@ export interface operations {
     /** @description <p>Retrieve a dispute for a specified charge.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -19543,7 +19543,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -19641,7 +19641,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing refund.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -19705,7 +19705,7 @@ export interface operations {
   };
   GetCheckoutSessions: {
     /** @description <p>Returns a list of Checkout Sessions.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return the Checkout Sessions for the Customer specified. */
         /** @description Only return the Checkout Sessions for the Customer details specified. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -19714,7 +19714,7 @@ export interface operations {
         /** @description Only return the Checkout Session for the PaymentIntent specified. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return the Checkout Session for the subscription specified. */
-      query?: {
+      query: {
         customer?: string;
         customer_details?: {
           email: string;
@@ -20303,7 +20303,7 @@ export interface operations {
     /** @description <p>Retrieves a Session object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -20371,7 +20371,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -20415,12 +20415,12 @@ export interface operations {
   };
   GetCountrySpecs: {
     /** @description <p>Lists all Country Spec objects available in the API.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -20462,7 +20462,7 @@ export interface operations {
     /** @description <p>Returns a Country Spec for a given Country code.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -20491,13 +20491,13 @@ export interface operations {
   };
   GetCoupons: {
     /** @description <p>Returns a list of your coupons.</p> */
-    parameters?: {
+    parameters: {
         /** @description A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -20615,7 +20615,7 @@ export interface operations {
     /** @description <p>Retrieves the coupon with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -20713,14 +20713,14 @@ export interface operations {
   };
   GetCreditNotes: {
     /** @description <p>Returns a list of credit notes.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return credit notes for the customer specified by this customer ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description Only return credit notes for the invoice specified by this invoice ID. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         customer?: string;
         ending_before?: string;
         expand?: (string)[];
@@ -20983,7 +20983,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -21029,7 +21029,7 @@ export interface operations {
     /** @description <p>Retrieves the credit note object with the given identifier.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -21124,14 +21124,14 @@ export interface operations {
   };
   GetCustomers: {
     /** @description <p>Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description A case-sensitive filter on the list based on the customer's `email` field. The value must be a string. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Provides a list of customers that are associated with the specified test clock. The response will not include customers with test clocks if this parameter is not set. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -21352,7 +21352,7 @@ export interface operations {
     /** @description <p>Retrieves a Customer object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -21578,7 +21578,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -21664,7 +21664,7 @@ export interface operations {
     /** @description <p>Retrieves a specific customer balance transaction that updated the customer’s <a href="/docs/billing/customer/balance">balances</a>.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -21739,7 +21739,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -21863,7 +21863,7 @@ export interface operations {
      */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -22042,7 +22042,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -22165,7 +22165,7 @@ export interface operations {
      */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -22303,7 +22303,7 @@ export interface operations {
     /** @description <p>Retrieves a customer’s cash balance.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -22375,7 +22375,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -22421,7 +22421,7 @@ export interface operations {
     /** @description <p>Retrieves a specific cash balance transaction, which updated the customer’s <a href="/docs/payments/customer-balance">cash balance</a>.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -22452,7 +22452,7 @@ export interface operations {
   GetCustomersCustomerDiscount: {
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -22614,7 +22614,7 @@ export interface operations {
     /** @description <p>Retrieves a PaymentMethod object for a given Customer.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -22650,7 +22650,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Filter sources according to a particular object type. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -22772,7 +22772,7 @@ export interface operations {
     /** @description <p>Retrieve a specified source for a given customer.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -22946,7 +22946,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -23220,7 +23220,7 @@ export interface operations {
     /** @description <p>Retrieves the subscription with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -23517,7 +23517,7 @@ export interface operations {
   GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount: {
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -23580,7 +23580,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -23663,7 +23663,7 @@ export interface operations {
     /** @description <p>Retrieves the <code>TaxID</code> object with the given identifier.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -23721,14 +23721,14 @@ export interface operations {
   };
   GetDisputes: {
     /** @description <p>Returns a list of your disputes.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return disputes associated to the charge specified by this charge ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Only return disputes associated to the PaymentIntent specified by this PaymentIntent ID. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         charge?: string;
         created?: {
           gt?: number;
@@ -23778,7 +23778,7 @@ export interface operations {
     /** @description <p>Retrieves the dispute with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -23973,7 +23973,7 @@ export interface operations {
   };
   GetEvents: {
     /** @description <p>List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in <a href="/docs/api/events/object">event object</a> <code>api_version</code> attribute (not according to your current Stripe API version or <code>Stripe-Version</code> header).</p> */
-    parameters?: {
+    parameters: {
         /** @description Filter events by whether all webhooks were successfully delivered. If false, events which are still pending or have failed all delivery attempts to a webhook endpoint will be returned. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
@@ -23981,7 +23981,7 @@ export interface operations {
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description A string containing a specific event name, or group of events using * as a wildcard. The list will be filtered to include only events with a matching event property. */
         /** @description An array of up to 20 strings containing specific event names. The list will be filtered to include only events with a matching event property. You may pass either `type` or `types`, but not both. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -24032,7 +24032,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an event. Supply the unique identifier of the event, which you might have received in a webhook.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -24061,12 +24061,12 @@ export interface operations {
   };
   GetExchangeRates: {
     /** @description <p>Returns a list of objects that contain the rates at which foreign currencies are converted to one another. Only shows the currencies for which Stripe supports.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is the currency that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with the exchange rate for currency X your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and total number of supported payout currencies, and the default is the max. */
         /** @description A cursor for use in pagination. `starting_after` is the currency that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with the exchange rate for currency X, your subsequent call can include `starting_after=X` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -24108,7 +24108,7 @@ export interface operations {
     /** @description <p>Retrieves the exchange rates from the given currency to every supported currency.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -24137,14 +24137,14 @@ export interface operations {
   };
   GetFileLinks: {
     /** @description <p>Returns a list of file links.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description Filter links by their expiration status. By default, all links are returned. */
         /** @description Only return links for the given file. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -24231,7 +24231,7 @@ export interface operations {
     /** @description <p>Retrieves the file link with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -24296,13 +24296,13 @@ export interface operations {
   };
   GetFiles: {
     /** @description <p>Returns a list of the files that your account has access to. The files are returned sorted by creation date, with the most recently created files appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description The file purpose to filter queries by. If none is provided, files will not be filtered by purpose. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -24399,7 +24399,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing file object. Supply the unique file ID from a file, and Stripe will return the corresponding file object. To access file contents, see the <a href="/docs/file-upload#download-file-contents">File Upload Guide</a>.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -24428,14 +24428,14 @@ export interface operations {
   };
   GetFinancialConnectionsAccounts: {
     /** @description <p>Returns a list of Financial Connections <code>Account</code> objects.</p> */
-    parameters?: {
+    parameters: {
         /** @description If present, only return accounts that belong to the specified account holder. `account_holder[customer]` and `account_holder[account]` are mutually exclusive. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description If present, only return accounts that were collected as part of the given session. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         account_holder?: {
           account?: string;
           customer?: string;
@@ -24483,7 +24483,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an Financial Connections <code>Account</code>.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -24677,7 +24677,7 @@ export interface operations {
     /** @description <p>Retrieves the details of a Financial Connections <code>Session</code></p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -24706,14 +24706,14 @@ export interface operations {
   };
   GetIdentityVerificationReports: {
     /** @description <p>List all verification reports.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return VerificationReports of this type */
         /** @description Only return VerificationReports created by this VerificationSession ID. It is allowed to provide a VerificationIntent ID. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -24763,7 +24763,7 @@ export interface operations {
     /** @description <p>Retrieves an existing VerificationReport</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -24792,13 +24792,13 @@ export interface operations {
   };
   GetIdentityVerificationSessions: {
     /** @description <p>Returns a list of VerificationSessions</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return VerificationSessions with this status. [Learn more about the lifecycle of sessions](https://stripe.com/docs/identity/how-sessions-work). */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -24908,7 +24908,7 @@ export interface operations {
      */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -25077,7 +25077,7 @@ export interface operations {
   };
   GetInvoiceitems: {
     /** @description <p>Returns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description The identifier of the customer whose invoice items to return. If none is provided, all invoice items will be returned. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
@@ -25085,7 +25085,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Set to `true` to only show pending invoice items, which are not yet attached to any invoices. Set to `false` to only show invoice items already attached to invoices. If unspecified, no filter is applied. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -25227,7 +25227,7 @@ export interface operations {
     /** @description <p>Retrieves the invoice item with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -25371,7 +25371,7 @@ export interface operations {
   };
   GetInvoices: {
     /** @description <p>You can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description The collection method of the invoice to retrieve. Either `charge_automatically` or `send_invoice`. */
         /** @description Only return invoices for the customer specified by this customer ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -25380,7 +25380,7 @@ export interface operations {
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description The status of the invoice, one of `draft`, `open`, `paid`, `uncollectible`, or `void`. [Learn more](https://stripe.com/docs/billing/invoices/workflow#workflow-overview) */
         /** @description Only return invoices for the subscription specified by this subscription ID. */
-      query?: {
+      query: {
         collection_method?: "charge_automatically" | "send_invoice";
         created?: {
           gt?: number;
@@ -25663,7 +25663,7 @@ export interface operations {
      * 
      * <p>You can preview the effects of updating a subscription, including a preview of what proration will take place. To ensure that the actual proration is calculated exactly the same as the previewed proration, you should pass a <code>proration_date</code> parameter when doing the actual subscription update. The value passed in should be the same as the <code>subscription_proration_date</code> returned on the upcoming invoice resource. The recommended way to get only the prorations being previewed is to consider only proration line items where <code>period[start]</code> is equal to the <code>subscription_proration_date</code> on the upcoming invoice resource.</p>
      */
-    parameters?: {
+    parameters: {
         /** @description Settings for automatic tax lookup for this invoice preview. */
         /** @description The code of the coupon to apply. If `subscription` or `subscription_items` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. The invoice can be previewed without a coupon by passing this value as an empty string. */
         /** @description The currency to preview this invoice in. Defaults to that of `customer` if not specified. */
@@ -25685,7 +25685,7 @@ export interface operations {
         /** @description Date a subscription is intended to start (can be future or past) */
         /** @description If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_items` or `subscription` is required. */
         /** @description Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more. */
-      query?: {
+      query: {
         automatic_tax?: {
           enabled: boolean;
         };
@@ -25837,7 +25837,7 @@ export interface operations {
   };
   GetInvoicesUpcomingLines: {
     /** @description <p>When retrieving an upcoming invoice, you’ll get a <strong>lines</strong> property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p> */
-    parameters?: {
+    parameters: {
         /** @description Settings for automatic tax lookup for this invoice preview. */
         /** @description The code of the coupon to apply. If `subscription` or `subscription_items` is provided, the invoice returned will preview updating or creating a subscription with that coupon. Otherwise, it will preview applying that coupon to the customer for the next upcoming invoice from among the customer's subscriptions. The invoice can be previewed without a coupon by passing this value as an empty string. */
         /** @description The currency to preview this invoice in. Defaults to that of `customer` if not specified. */
@@ -25862,7 +25862,7 @@ export interface operations {
         /** @description Date a subscription is intended to start (can be future or past) */
         /** @description If provided, the invoice returned will preview updating or creating a subscription with that trial end. If set, one of `subscription_items` or `subscription` is required. */
         /** @description Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more. */
-      query?: {
+      query: {
         automatic_tax?: {
           enabled: boolean;
         };
@@ -26031,7 +26031,7 @@ export interface operations {
     /** @description <p>Retrieves the invoice with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -26283,7 +26283,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -26467,7 +26467,7 @@ export interface operations {
   };
   GetIssuingAuthorizations: {
     /** @description <p>Returns a list of Issuing <code>Authorization</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return authorizations that belong to the given card. */
         /** @description Only return authorizations that belong to the given cardholder. */
         /** @description Only return authorizations that were created during the given date interval. */
@@ -26476,7 +26476,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return authorizations with the given status. One of `pending`, `closed`, or `reversed`. */
-      query?: {
+      query: {
         card?: string;
         cardholder?: string;
         created?: {
@@ -26527,7 +26527,7 @@ export interface operations {
     /** @description <p>Retrieves an Issuing <code>Authorization</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -26666,7 +26666,7 @@ export interface operations {
   };
   GetIssuingCardholders: {
     /** @description <p>Returns a list of Issuing <code>Cardholder</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return cardholders that were created during the given date interval. */
         /** @description Only return cardholders that have the given email address. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -26676,7 +26676,7 @@ export interface operations {
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return cardholders that have the given status. One of `active`, `inactive`, or `blocked`. */
         /** @description Only return cardholders that have the given type. One of `individual` or `company`. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -26832,7 +26832,7 @@ export interface operations {
     /** @description <p>Retrieves an Issuing <code>Cardholder</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -26963,7 +26963,7 @@ export interface operations {
   };
   GetIssuingCards: {
     /** @description <p>Returns a list of Issuing <code>Card</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return cards belonging to the Cardholder with the provided ID. */
         /** @description Only return cards that were issued during the given date interval. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -26975,7 +26975,7 @@ export interface operations {
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return cards that have the given status. One of `active`, `inactive`, or `canceled`. */
         /** @description Only return cards that have the given type. One of `virtual` or `physical`. */
-      query?: {
+      query: {
         cardholder?: string;
         created?: {
           gt?: number;
@@ -27120,7 +27120,7 @@ export interface operations {
     /** @description <p>Retrieves an Issuing <code>Card</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -27214,7 +27214,7 @@ export interface operations {
   };
   GetIssuingDisputes: {
     /** @description <p>Returns a list of Issuing <code>Dispute</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Select Issuing disputes that were created during the given date interval. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
@@ -27222,7 +27222,7 @@ export interface operations {
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Select Issuing disputes with the given status. */
         /** @description Select the Issuing dispute for the given transaction. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -27377,7 +27377,7 @@ export interface operations {
     /** @description <p>Retrieves an Issuing <code>Dispute</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -27541,13 +27541,13 @@ export interface operations {
   };
   GetIssuingSettlements: {
     /** @description <p>Returns a list of Issuing <code>Settlement</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return issuing settlements that were created during the given date interval. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -27595,7 +27595,7 @@ export interface operations {
     /** @description <p>Retrieves an Issuing <code>Settlement</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -27658,7 +27658,7 @@ export interface operations {
   };
   GetIssuingTransactions: {
     /** @description <p>Returns a list of Issuing <code>Transaction</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return transactions that belong to the given card. */
         /** @description Only return transactions that belong to the given cardholder. */
         /** @description Only return transactions that were created during the given date interval. */
@@ -27667,7 +27667,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return transactions that have the given type. One of `capture` or `refund`. */
-      query?: {
+      query: {
         card?: string;
         cardholder?: string;
         created?: {
@@ -27718,7 +27718,7 @@ export interface operations {
     /** @description <p>Retrieves an Issuing <code>Transaction</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -27833,7 +27833,7 @@ export interface operations {
     /** @description <p>Retrieves the details of a Financial Connections <code>Session</code></p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -27862,14 +27862,14 @@ export interface operations {
   };
   GetLinkedAccounts: {
     /** @description <p>Returns a list of Financial Connections <code>Account</code> objects.</p> */
-    parameters?: {
+    parameters: {
         /** @description If present, only return accounts that belong to the specified account holder. `account_holder[customer]` and `account_holder[account]` are mutually exclusive. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description If present, only return accounts that were collected as part of the given session. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         account_holder?: {
           account?: string;
           customer?: string;
@@ -27917,7 +27917,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an Financial Connections <code>Account</code>.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -28061,7 +28061,7 @@ export interface operations {
     /** @description <p>Retrieves a Mandate object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -28090,13 +28090,13 @@ export interface operations {
   };
   GetOrders: {
     /** @description <p>Returns a list of your orders. The orders are returned sorted by creation date, with the most recently created orders appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return orders for the given customer. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         customer?: string;
         ending_before?: string;
         expand?: (string)[];
@@ -28465,7 +28465,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing order. Supply the unique order ID from either an order creation request or the order list, and Stripe will return the corresponding order information.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -28846,7 +28846,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -28952,14 +28952,14 @@ export interface operations {
   };
   GetPaymentIntents: {
     /** @description <p>Returns a list of PaymentIntents.</p> */
-    parameters?: {
+    parameters: {
         /** @description A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         /** @description Only return PaymentIntents for the customer specified by this customer ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -29584,7 +29584,7 @@ export interface operations {
     parameters: {
         /** @description The client secret of the PaymentIntent. Required if a publishable key is used to retrieve the source. */
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         client_secret?: string;
         expand?: (string)[];
       };
@@ -30819,13 +30819,13 @@ export interface operations {
   };
   GetPaymentLinks: {
     /** @description <p>Returns a list of your payment links.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return payment links that are active or inactive (e.g., pass `false` to list all inactive payment links). */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         active?: boolean;
         ending_before?: string;
         expand?: (string)[];
@@ -31030,7 +31030,7 @@ export interface operations {
     /** @description <p>Retrieve a payment link.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -31161,7 +31161,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -31515,7 +31515,7 @@ export interface operations {
     /** @description <p>Retrieves a PaymentMethod object attached to the StripeAccount. To retrieve a payment method attached to a Customer, you should use <a href="/docs/api/payment_methods/customer">Retrieve a Customer’s PaymentMethods</a></p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -31692,14 +31692,14 @@ export interface operations {
   };
   GetPayouts: {
     /** @description <p>Returns a list of existing payouts sent to third-party bank accounts or that Stripe has sent you. The payouts are returned in sorted order, with the most recently created payouts appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description The ID of an external account - only return payouts sent to this external account. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return payouts that have the given status: `pending`, `paid`, `failed`, or `canceled`. */
-      query?: {
+      query: {
         arrival_date?: {
           gt?: number;
           gte?: number;
@@ -31810,7 +31810,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing payout. Supply the unique payout ID from either a payout creation request or the payout list, and Stripe will return the corresponding payout information.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -31941,7 +31941,7 @@ export interface operations {
   };
   GetPlans: {
     /** @description <p>Returns a list of your plans.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return plans that are active or inactive (e.g., pass `false` to list all inactive plans). */
         /** @description A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -31949,7 +31949,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Only return plans for the given product. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         active?: boolean;
         created?: {
           gt?: number;
@@ -32103,7 +32103,7 @@ export interface operations {
     /** @description <p>Retrieves the plan with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -32201,7 +32201,7 @@ export interface operations {
   };
   GetPrices: {
     /** @description <p>Returns a list of your prices.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return prices that are active or inactive (e.g., pass `false` to list all inactive prices). */
         /** @description A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         /** @description Only return prices for the given currency. */
@@ -32213,7 +32213,7 @@ export interface operations {
         /** @description Only return prices with these recurring fields. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return prices of type `recurring` or `one_time`. */
-      query?: {
+      query: {
         active?: boolean;
         created?: {
           gt?: number;
@@ -32470,7 +32470,7 @@ export interface operations {
     /** @description <p>Retrieves the price with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -32572,7 +32572,7 @@ export interface operations {
   };
   GetProducts: {
     /** @description <p>Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return products that are active or inactive (e.g., pass `false` to list all inactive products). */
         /** @description Only return products that were created during the given date interval. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -32582,7 +32582,7 @@ export interface operations {
         /** @description Only return products that can be shipped (i.e., physical, not digital products). */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return products with the given url. */
-      query?: {
+      query: {
         active?: boolean;
         created?: {
           gt?: number;
@@ -32793,7 +32793,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -32915,7 +32915,7 @@ export interface operations {
   };
   GetPromotionCodes: {
     /** @description <p>Returns a list of your promotion codes.</p> */
-    parameters?: {
+    parameters: {
         /** @description Filter promotion codes by whether they are active. */
         /** @description Only return promotion codes that have this case-insensitive code. */
         /** @description Only return promotion codes for this coupon. */
@@ -32925,7 +32925,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         active?: boolean;
         code?: string;
         coupon?: string;
@@ -33035,7 +33035,7 @@ export interface operations {
     /** @description <p>Retrieves the promotion code with the given ID. In order to retrieve a promotion code by the customer-facing <code>code</code> use <a href="/docs/api/promotion_codes/list">list</a> with the desired <code>code</code>.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -33111,7 +33111,7 @@ export interface operations {
   };
   GetQuotes: {
     /** @description <p>Returns a list of your quotes.</p> */
-    parameters?: {
+    parameters: {
         /** @description The ID of the customer whose quotes will be retrieved. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
@@ -33119,7 +33119,7 @@ export interface operations {
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description The status of the quote. */
         /** @description Provides a list of quotes that are associated with the specified test clock. The response will not include quotes with test clocks if this and the customer parameter is not set. */
-      query?: {
+      query: {
         customer?: string;
         ending_before?: string;
         expand?: (string)[];
@@ -33285,7 +33285,7 @@ export interface operations {
     /** @description <p>Retrieves the quote with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -33496,7 +33496,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -33580,7 +33580,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -33626,7 +33626,7 @@ export interface operations {
     /** @description <p>Download the PDF for a finalized quote</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -33655,14 +33655,14 @@ export interface operations {
   };
   GetRadarEarlyFraudWarnings: {
     /** @description <p>Returns a list of early fraud warnings.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return early fraud warnings for the charge specified by this charge ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Only return early fraud warnings for charges that were created by the PaymentIntent specified by this PaymentIntent ID. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         charge?: string;
         ending_before?: string;
         expand?: (string)[];
@@ -33710,7 +33710,7 @@ export interface operations {
      */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -33825,7 +33825,7 @@ export interface operations {
     /** @description <p>Retrieves a <code>ValueListItem</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -33881,14 +33881,14 @@ export interface operations {
   };
   GetRadarValueLists: {
     /** @description <p>Returns a list of <code>ValueList</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description The alias used to reference the value list when writing rules. */
         /** @description A value contained within a value list - returns all value lists containing this value. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         alias?: string;
         contains?: string;
         created?: {
@@ -33976,7 +33976,7 @@ export interface operations {
     /** @description <p>Retrieves a <code>ValueList</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -34070,14 +34070,14 @@ export interface operations {
   };
   GetRefunds: {
     /** @description <p>Returns a list of all refunds you’ve previously created. The refunds are returned in sorted order, with the most recent refunds appearing first. For convenience, the 10 most recent refunds are always available by default on the charge object.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return refunds for the charge specified by this charge ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Only return refunds for the PaymentIntent specified by this ID. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         charge?: string;
         created?: {
           gt?: number;
@@ -34175,7 +34175,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing refund.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -34276,12 +34276,12 @@ export interface operations {
   };
   GetReportingReportRuns: {
     /** @description <p>Returns a list of Report Runs, with the most recent appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -34374,7 +34374,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing Report Run.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -34403,9 +34403,9 @@ export interface operations {
   };
   GetReportingReportTypes: {
     /** @description <p>Returns a full list of Report Types.</p> */
-    parameters?: {
+    parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
     };
@@ -34444,7 +34444,7 @@ export interface operations {
     /** @description <p>Retrieves the details of a Report Type. (Certain report types require a <a href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.)</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -34473,12 +34473,12 @@ export interface operations {
   };
   GetReviews: {
     /** @description <p>Returns a list of <code>Review</code> objects that have <code>open</code> set to <code>true</code>. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -34526,7 +34526,7 @@ export interface operations {
     /** @description <p>Retrieves a <code>Review</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -34646,7 +34646,7 @@ export interface operations {
   };
   GetSetupIntents: {
     /** @description <p>Returns a list of SetupIntents.</p> */
-    parameters?: {
+    parameters: {
         /**
          * @description If present, the SetupIntent's payment method will be attached to the in-context Stripe Account.
          * 
@@ -34659,7 +34659,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description Only return SetupIntents associated with the specified payment method. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         attach_to_self?: boolean;
         created?: {
           gt?: number;
@@ -35018,7 +35018,7 @@ export interface operations {
     parameters: {
         /** @description The client secret of the SetupIntent. Required if a publishable key is used to retrieve the SetupIntent. */
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         client_secret?: string;
         expand?: (string)[];
       };
@@ -35671,7 +35671,7 @@ export interface operations {
   };
   GetShippingRates: {
     /** @description <p>Returns a list of your shipping rates.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return shipping rates that are active or inactive. */
         /** @description A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         /** @description Only return shipping rates for the given currency. */
@@ -35679,7 +35679,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         active?: boolean;
         created?: {
           gt?: number;
@@ -35805,7 +35805,7 @@ export interface operations {
     /** @description <p>Returns the shipping rate object with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -35888,12 +35888,12 @@ export interface operations {
   };
   GetSigmaScheduledQueryRuns: {
     /** @description <p>Returns a list of scheduled query runs.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -35935,7 +35935,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an scheduled query run.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -35964,7 +35964,7 @@ export interface operations {
   };
   GetSkus: {
     /** @description <p>Returns a list of your SKUs. The SKUs are returned sorted by creation date, with the most recently created SKUs appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return SKUs that are active or inactive (e.g., pass `false` to list all inactive products). */
         /** @description Only return SKUs that have the specified key-value pairs in this partially constructed dictionary. Can be specified only if `product` is also supplied. For instance, if the associated product has attributes `["color", "size"]`, passing in `attributes[color]=red` returns all the SKUs for this product that have `color` set to `red`. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -35974,7 +35974,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description The ID of the product whose SKUs will be retrieved. Must be a product with type `good`. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         active?: boolean;
         attributes?: {
           [key: string]: string | undefined;
@@ -36089,7 +36089,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing SKU. Supply the unique SKU identifier from either a SKU creation request or from the product, and Stripe will return the corresponding SKU information.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -36365,7 +36365,7 @@ export interface operations {
     parameters: {
         /** @description The client secret of the source. Required if a publishable key is used to retrieve the source. */
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         client_secret?: string;
         expand?: (string)[];
       };
@@ -36520,7 +36520,7 @@ export interface operations {
     /** @description <p>Retrieves a new Source MandateNotification.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -36555,7 +36555,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -36600,7 +36600,7 @@ export interface operations {
     /** @description <p>Retrieve an existing source transaction object. Supply the unique source ID from a source creation request and the source transaction ID and Stripe will return the corresponding up-to-date source object information.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -36792,7 +36792,7 @@ export interface operations {
     /** @description <p>Retrieves the subscription item with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -36956,7 +36956,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -37046,7 +37046,7 @@ export interface operations {
   };
   GetSubscriptionSchedules: {
     /** @description <p>Retrieves the list of your subscription schedules.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return subscription schedules that were created canceled the given date interval. */
         /** @description Only return subscription schedules that completed during the given date interval. */
         /** @description Only return subscription schedules that were created during the given date interval. */
@@ -37057,7 +37057,7 @@ export interface operations {
         /** @description Only return subscription schedules that were released during the given date interval. */
         /** @description Only return subscription schedules that have not started yet. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         canceled_at?: {
           gt?: number;
           gte?: number;
@@ -37276,7 +37276,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing subscription schedule. You only need to supply the unique subscription schedule identifier that was returned upon subscription schedule creation.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -37524,7 +37524,7 @@ export interface operations {
   };
   GetSubscriptions: {
     /** @description <p>By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify <code>status=canceled</code>.</p> */
-    parameters?: {
+    parameters: {
         /** @description The collection method of the subscriptions to retrieve. Either `charge_automatically` or `send_invoice`. */
         /** @description The ID of the customer whose subscriptions will be retrieved. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -37534,7 +37534,7 @@ export interface operations {
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description The status of the subscriptions to retrieve. Passing in a value of `canceled` will return all canceled subscriptions, including those belonging to deleted customers. Pass `ended` to find subscriptions that are canceled and subscriptions that are expired due to [incomplete payment](https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses). Passing in a value of `all` will return subscriptions of all statuses. If no value is supplied, all subscriptions that have not been canceled are returned. */
         /** @description Filter for subscriptions that are associated with the specified test clock. The response will not include subscriptions with test clocks if this and the customer parameter is not set. */
-      query?: {
+      query: {
         collection_method?: "charge_automatically" | "send_invoice";
         created?: {
           gt?: number;
@@ -37887,7 +37887,7 @@ export interface operations {
     /** @description <p>Retrieves the subscription with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -38211,12 +38211,12 @@ export interface operations {
   };
   GetTaxCodes: {
     /** @description <p>A list of <a href="https://stripe.com/docs/tax/tax-categories">all tax codes available</a> to add to Products in order to allow specific tax calculations.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -38258,7 +38258,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing tax code. Supply the unique tax code ID and Stripe will return the corresponding tax code information.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -38287,7 +38287,7 @@ export interface operations {
   };
   GetTaxRates: {
     /** @description <p>Returns a list of your tax rates. Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Optional flag to filter by tax rates that are either active or inactive (archived). */
         /** @description Optional range for filtering created date. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -38295,7 +38295,7 @@ export interface operations {
         /** @description Optional flag to filter by tax rates that are inclusive (or those that are not inclusive). */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         active?: boolean;
         created?: {
           gt?: number;
@@ -38395,7 +38395,7 @@ export interface operations {
     /** @description <p>Retrieves a tax rate with the given ID</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -38475,13 +38475,13 @@ export interface operations {
   };
   GetTerminalConfigurations: {
     /** @description <p>Returns a list of <code>Configuration</code> objects.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description if present, only return the account default or non-default configurations. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         is_account_default?: boolean;
@@ -38650,7 +38650,7 @@ export interface operations {
     /** @description <p>Retrieves a <code>Configuration</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -38858,12 +38858,12 @@ export interface operations {
   };
   GetTerminalLocations: {
     /** @description <p>Returns a list of <code>Location</code> objects.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -38953,7 +38953,7 @@ export interface operations {
     /** @description <p>Retrieves a <code>Location</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -39059,7 +39059,7 @@ export interface operations {
   };
   GetTerminalReaders: {
     /** @description <p>Returns a list of <code>Reader</code> objects.</p> */
-    parameters?: {
+    parameters: {
         /** @description Filters readers by device type */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
@@ -39067,7 +39067,7 @@ export interface operations {
         /** @description A location ID to filter the response list to only readers at the specific location */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description A status filter to filter readers to only offline or online readers */
-      query?: {
+      query: {
         device_type?: "bbpos_chipper2x" | "bbpos_wisepad3" | "bbpos_wisepos_e" | "simulated_wisepos_e" | "stripe_m2" | "verifone_P400";
         ending_before?: string;
         expand?: (string)[];
@@ -39148,7 +39148,7 @@ export interface operations {
     /** @description <p>Retrieves a <code>Reader</code> object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -39624,12 +39624,12 @@ export interface operations {
   };
   GetTestHelpersTestClocks: {
     /** @description <p>Returns a list of your test clocks.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -39703,7 +39703,7 @@ export interface operations {
     /** @description <p>Retrieves a test clock.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -40520,7 +40520,7 @@ export interface operations {
     /** @description <p>Retrieves the token with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -40549,7 +40549,7 @@ export interface operations {
   };
   GetTopups: {
     /** @description <p>Returns a list of top-ups.</p> */
-    parameters?: {
+    parameters: {
         /** @description A positive integer representing how much to transfer. */
         /** @description A filter on the list, based on the object `created` field. The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
@@ -40557,7 +40557,7 @@ export interface operations {
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return top-ups that have the given status. One of `canceled`, `failed`, `pending` or `succeeded`. */
-      query?: {
+      query: {
         amount?: {
           gt?: number;
           gte?: number;
@@ -40653,7 +40653,7 @@ export interface operations {
     /** @description <p>Retrieves the details of a top-up that has previously been created. Supply the unique top-up ID that was returned from your previous request, and Stripe will return the corresponding top-up information.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -40748,14 +40748,14 @@ export interface operations {
   };
   GetTransfers: {
     /** @description <p>Returns a list of existing transfers sent to connected accounts. The transfers are returned in sorted order, with the most recently created transfers appearing first.</p> */
-    parameters?: {
+    parameters: {
         /** @description Only return transfers for the destination specified by this account ID. */
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
         /** @description Only return transfers with the specified transfer group. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -40855,7 +40855,7 @@ export interface operations {
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -40947,7 +40947,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing transfer. Supply the unique transfer ID from either a transfer creation request or the transfer list, and Stripe will return the corresponding transfer information.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -41018,7 +41018,7 @@ export interface operations {
     /** @description <p>By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -41172,7 +41172,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing CreditReversal by passing the unique CreditReversal ID from either the CreditReversal creation request or CreditReversal list</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -41288,7 +41288,7 @@ export interface operations {
     /** @description <p>Retrieves a DebitReversal object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -41317,12 +41317,12 @@ export interface operations {
   };
   GetTreasuryFinancialAccounts: {
     /** @description <p>Returns a list of FinancialAccounts.</p> */
-    parameters?: {
+    parameters: {
         /** @description An object ID cursor for use in pagination. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit ranging from 1 to 100 (defaults to 10). */
         /** @description An object ID cursor for use in pagination. */
-      query?: {
+      query: {
         created?: {
           gt?: number;
           gte?: number;
@@ -41465,7 +41465,7 @@ export interface operations {
     /** @description <p>Retrieves the details of a FinancialAccount.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -41594,7 +41594,7 @@ export interface operations {
     /** @description <p>Retrieves Features information associated with the FinancialAccount.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -41815,7 +41815,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing InboundTransfer.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -42025,7 +42025,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing OutboundPayment by passing the unique OutboundPayment ID from either the OutboundPayment creation request or OutboundPayment list.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -42187,7 +42187,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing OutboundTransfer by passing the unique OutboundTransfer ID from either the OutboundTransfer creation request or OutboundTransfer list.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -42303,7 +42303,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing ReceivedCredit by passing the unique ReceivedCredit ID from the ReceivedCredit list.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -42384,7 +42384,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing ReceivedDebit by passing the unique ReceivedDebit ID from the ReceivedDebit list</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -42479,7 +42479,7 @@ export interface operations {
     /** @description <p>Retrieves a TransactionEntry object.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -42577,7 +42577,7 @@ export interface operations {
     /** @description <p>Retrieves the details of an existing Transaction.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {
@@ -42606,12 +42606,12 @@ export interface operations {
   };
   GetWebhookEndpoints: {
     /** @description <p>Returns a list of your webhook endpoints.</p> */
-    parameters?: {
+    parameters: {
         /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
         /** @description Specifies which fields in the response should be expanded. */
         /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
         /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
-      query?: {
+      query: {
         ending_before?: string;
         expand?: (string)[];
         limit?: number;
@@ -42695,7 +42695,7 @@ export interface operations {
     /** @description <p>Retrieves the webhook endpoint with the given ID.</p> */
     parameters: {
         /** @description Specifies which fields in the response should be expanded. */
-      query?: {
+      query: {
         expand?: (string)[];
       };
       path: {

--- a/src/transform/operation-object.ts
+++ b/src/transform/operation-object.ts
@@ -37,10 +37,8 @@ export default function transformOperationObject(
   {
     if (operationObject.parameters) {
       const parameterOutput: string[] = [];
-      let allParamsOptional = true;
       indentLv++;
       for (const paramIn of ["query", "header", "path", "cookie"] as ParameterObject["in"][]) {
-        let inlineParamsOptional = true;
         const inlineOutput: string[] = [];
         const refs: Record<string, string[]> = {};
         indentLv++;
@@ -51,9 +49,6 @@ export default function transformOperationObject(
             let key = escObjKey(p.name);
             if (paramIn !== "path" && !p.required) {
               key = tsOptionalProperty(key);
-            } else {
-              inlineParamsOptional = false;
-              allParamsOptional = false;
             }
             const c = getSchemaObjectComment(p, indentLv);
             if (c) parameterOutput.push(indent(c, indentLv));
@@ -90,13 +85,12 @@ export default function transformOperationObject(
           )
         );
         let key: string = paramIn;
-        if (inlineParamsOptional) key = tsOptionalProperty(key); // if all params are optional, so is this key
         if (ctx.immutableTypes) key = tsReadonly(key);
         parameterOutput.push(indent(`${key}: ${paramType};`, indentLv));
       }
       indentLv--;
       if (parameterOutput.length) {
-        output.push(indent(allParamsOptional ? `parameters?: {` : `parameters: {`, indentLv));
+        output.push(indent(`parameters: {`, indentLv));
         output.push(parameterOutput.join("\n"));
         output.push(indent("};", indentLv));
       }

--- a/test/paths-object.test.ts
+++ b/test/paths-object.test.ts
@@ -78,9 +78,9 @@ describe("Paths Object", () => {
         404: components["responses"]["NotFound"];
       };
     };
-    parameters?: {
+    parameters: {
         /** @description Page number. */
-      query?: {
+      query: {
         page?: number;
       };
     };
@@ -105,7 +105,7 @@ describe("Paths Object", () => {
     expect(generated).toBe(`{
   "/api/{version}/user/{user_id}": {
     parameters: {
-      query?: {
+      query: {
         page?: number;
       } & (Pick<NonNullable<components["parameters"]["query"]>, "utm_source" | "utm_email" | "utm_campaign">);
       path: {

--- a/test/webhooks-object.test.ts
+++ b/test/webhooks-object.test.ts
@@ -98,7 +98,7 @@ describe("Webhooks Object", () => {
       query: {
         signature: string;
       } & (Pick<NonNullable<components["parameters"]["query"]>, "utm_source" | "utm_email" | "utm_campaign">);
-      path?: Pick<components["parameters"]["path"], "version">;
+      path: Pick<components["parameters"]["path"], "version">;
     };
   };
 }`);


### PR DESCRIPTION
In 5.x, an optional query parameter's type could be referenced with an
expression such as

    type myQueryType = operations['myOperation']['parameters']['query']

In 6.0, that only works if there is at least one mandatory query
parameter in addition to the optional one. This makes query parameter
types much more awkward to reference in application code if all the
parameters are optional.

Revert to the 5.x behavior: if there are any parameters, optional or
not, the `parameters` object is always present. If there are any query
parameters, the `query` object is always present, same with `path` and
the other parameter types.

## Changes

Fixes #995

## How to Review

The actual code change here is trivial (the vast majority of changed lines 
are changes to the test cases). But per the discussion on #995, it's not
entirely clear why this behavior changed between 5.x and 6.0. Reverting to
the 5.x behavior will restore compatibility with existing application code,
but it may break code that relied on the 6.0 behavior depending on how that
code was constructing its type references.

## Checklist

- [X] Unit tests updated
- [ ] README updated - _no README changes needed_
- [X] `examples/` directory updated (if applicable)
