### PR TITLE
Fix `oneOf` number const

### DIFF
--- a/src/transform/schema-object.ts
+++ b/src/transform/schema-object.ts
@@ -62,7 +62,7 @@ export function defaultSchemaObjectTransform(
   }
 
   // const (valid for any type)
-  if (schemaObject.const) {
+  if (schemaObject.const !== null && schemaObject.const !== undefined) {
     let schemaConst = schemaObject.const as any;
     if ("type" in schemaObject) {
       if (schemaObject.type === "string") {
@@ -98,7 +98,7 @@ export function defaultSchemaObjectTransform(
   // oneOf (no discriminator)
   if ("oneOf" in schemaObject && !schemaObject.oneOf.some((t) => "$ref" in t && ctx.discriminators[t.$ref])) {
     const maybeTypes = schemaObject.oneOf.map((item) => transformSchemaObject(item, { path, ctx }));
-    if (maybeTypes.some((t) => t.includes("{"))) return tsOneOf(...maybeTypes); // OneOf<> helper needed if any objects present ("{")
+    if (maybeTypes.some((t) => typeof t === "string" && t.includes("{"))) return tsOneOf(...maybeTypes); // OneOf<> helper needed if any objects present ("{")
     return tsUnionOf(...maybeTypes); // otherwise, TS union works for primitives
   }
 

--- a/test/schema-object.test.ts
+++ b/test/schema-object.test.ts
@@ -167,6 +167,32 @@ describe("Schema Object", () => {
 }`);
       });
 
+      test("const number field", () => {
+        const schema: SchemaObject = {
+          type: "object",
+          properties: { constant: { const: 1, type: "number" } },
+          required: ["constant"],
+        };
+        const generated = transformSchemaObject(schema, options);
+        expect(generated).toBe(`{
+  /** @constant */
+  constant: 1;
+}`);
+      });
+
+      test("const number field which is 0", () => {
+        const schema: SchemaObject = {
+          type: "object",
+          properties: { constant: { const: 0, type: "number" } },
+          required: ["constant"],
+        };
+        const generated = transformSchemaObject(schema, options);
+        expect(generated).toBe(`{
+  /** @constant */
+  constant: 0;
+}`);
+      });
+
       test("additionalProperties with properties", () => {
         const schema: SchemaObject = {
           type: "object",
@@ -247,6 +273,28 @@ describe("Schema Object", () => {
         };
         const generated = transformSchemaObject(schema, options);
         expect(generated).toBe("string | number");
+      });
+
+      test("const string", () => {
+        const schema: SchemaObject = {
+          oneOf: [
+            { type: "string", const: "hello" },
+            { type: "string", const: "world" },
+          ],
+        };
+        const generated = transformSchemaObject(schema, options);
+        expect(generated).toBe('"hello" | "world"');
+      });
+
+      test("const number", () => {
+        const schema: SchemaObject = {
+          oneOf: [
+            { type: "number", const: 0 },
+            { type: "number", const: 1 },
+          ],
+        };
+        const generated = transformSchemaObject(schema, options);
+        expect(generated).toBe("0 | 1");
       });
 
       test("complex", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,21 @@
+import { tsUnionOf } from "../src/utils";
+
+describe("utils", () => {
+  describe("tsUnionOf", () => {
+    test("primitive", () => {
+      return expect(tsUnionOf(...["string", "number", "boolean"])).toBe("string | number | boolean");
+    });
+    test("constant booleans", () => {
+      return expect(tsUnionOf(...[true, false])).toBe("true | false");
+    });
+    test("constant strings", () => {
+      return expect(tsUnionOf(...['"hello"', '"world"'])).toBe('"hello" | "world"');
+    });
+    test("constant numbers", () => {
+      return expect(tsUnionOf(...[0, 1, 2, 3])).toBe("0 | 1 | 2 | 3");
+    });
+    test("mixed", () => {
+      return expect(tsUnionOf(...[0, true, "string", '"hello"'])).toBe('0 | true | string | "hello"');
+    });
+  });
+});


### PR DESCRIPTION
## Changes

Fixing https://github.com/drwpow/openapi-typescript/issues/1051 alongside the fact that `0` as a const value was evicted.

## How to Review

I wrote tests, they all pass now.

FYI, I wanted to make sure everything is working as expected, so I added tests for the `tsOneOf` util. IMHO, all the utils should be tested (but I did not have time to write these tests).

## Checklist

- [x] Unit tests updated
- [ ] README updated => *Not relevant for the bugfix*
- [ ] `examples/` directory updated (if applicable)
