### PR TITLE
fix: 🐛 change how additionalProperties are typed

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ devDependencies:
   typescript:
     specifier: ^5.0.3
     version: 5.0.3
+  vite:
+    specifier: ^4.1.4
+    version: 4.2.1(@types/node@18.15.11)
   vite-node:
     specifier: ^0.29.8
     version: 0.29.8(@types/node@18.15.11)(supports-color@9.3.1)

--- a/src/transform/schema-object.ts
+++ b/src/transform/schema-object.ts
@@ -191,7 +191,7 @@ export function defaultSchemaObjectTransform(
           });
         }
       }
-      coreType.push(indent(`[key: string]: ${tsUnionOf(addlType ? addlType : "unknown", "undefined")};`, indentLv)); // note: `| undefined` is required to mesh with possibly-undefined keys
+      coreType.push(indent(`[key: string]: ${addlType ? addlType : "unknown"};`, indentLv));
     }
     indentLv--;
   }

--- a/test/schema-object.test.ts
+++ b/test/schema-object.test.ts
@@ -14,6 +14,7 @@ const options: TransformSchemaObjectOptions = {
     operations: {},
     pathParamsAsTypes: false,
     postTransform: undefined,
+    parameters: {},
     silent: true,
     supportArrayLength: false,
     transform: undefined,
@@ -202,7 +203,7 @@ describe("Schema Object", () => {
         const generated = transformSchemaObject(schema, options);
         expect(generated).toBe(`{
   property?: boolean;
-  [key: string]: string | undefined;
+  [key: string]: string;
 }`);
       });
 
@@ -210,7 +211,7 @@ describe("Schema Object", () => {
         const schema: SchemaObject = { type: "object", additionalProperties: true };
         const generated = transformSchemaObject(schema, options);
         expect(generated).toBe(`{
-  [key: string]: unknown | undefined;
+  [key: string]: unknown;
 }`);
       });
 
@@ -221,7 +222,7 @@ describe("Schema Object", () => {
         };
         const generated = transformSchemaObject(schema, options);
         expect(generated).toBe(`{
-  [key: string]: string | undefined;
+  [key: string]: string;
 }`);
       });
 
@@ -229,7 +230,7 @@ describe("Schema Object", () => {
         const schema: SchemaObject = { type: "object", additionalProperties: {} };
         const generated = transformSchemaObject(schema, options);
         expect(generated).toBe(`{
-  [key: string]: unknown | undefined;
+  [key: string]: unknown;
 }`);
       });
 
@@ -424,7 +425,7 @@ describe("Schema Object", () => {
         });
         expect(generated).toBe(`{
   fixed: boolean;
-  [key: string]: unknown | undefined;
+  [key: string]: unknown;
 }`);
       });
     });
@@ -516,9 +517,9 @@ describe("Schema Object", () => {
           ctx: { ...options.ctx, immutableTypes: true },
         });
         expect(generated).toBe(`{
-  readonly array?: (readonly ({
-      [key: string]: unknown | undefined;
-    })[]) | null;
+  readonly array?: readonly ({
+      [key: string]: unknown;
+    })[] | null;
 }`);
       });
     });


### PR DESCRIPTION
## Changes

This removes the `| undefined` addition to additional properties in an object

## How to Review

It's a very simple PR, so review is more: "Is this the behavior that is desired?".

See issue #1070

## Checklist

- [x] Unit tests updated
- [ ] ~README updated~ N/A
- [ ] ~`examples/` directory updated (if applicable)~
