### PR TITLE
Don't attempt to double-escape double quotes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ interface CommentObject {
 
 const COMMENT_RE = /\*\//g;
 export const LB_RE = /\r?\n/g;
-export const DOUBLE_QUOTE_RE = /"/g;
+export const DOUBLE_QUOTE_RE = /(?<!\\)"/g;
 const ESC_0_RE = /~0/g;
 const ESC_1_RE = /~1/g;
 const TILDE_RE = /~/g;

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { tsIntersectionOf, tsUnionOf } from "../src/utils.js";
+import { parseRef, tsIntersectionOf, tsUnionOf } from "../src/utils.js";
 
 describe("utils", () => {
   describe("tsUnionOf", () => {
@@ -59,6 +59,24 @@ describe("utils", () => {
       test(name, () => {
         expect(tsIntersectionOf(...input)).toBe(output);
       });
+    });
+  });
+
+  describe("parseRef", () => {
+    it("basic", () => {
+        expect(parseRef("#/test/schema-object")).toStrictEqual({ filename: ".", path: [ "test", "schema-object" ] });
+    });
+
+    it("double quote", () => {
+        expect(parseRef("#/test/\"")).toStrictEqual({ filename: ".", path: [ "test", '\\\"' ] });
+    });
+
+    it("escaped double quote", () => {
+        expect(parseRef("#/test/\\\"")).toStrictEqual({ filename: ".", path: [ "test", '\\\"' ] });
+    });
+
+    it("tilde escapes", () => {
+        expect(parseRef("#/test/~1~0")).toStrictEqual({ filename: ".", path: [ "test", "/~" ] });
     });
   });
 });


### PR DESCRIPTION
## Changes

Fixes #915, added some regression tests for `parseRef`

Minimal repro on that issue now generates as:

```ts
export interface components {
  schemas: {
    someschema: components["schemas"]["\""];
    "\"": string;
  };
  responses: never;
  parameters: never;
  requestBodies: never;
  headers: never;
  pathItems: never;
}
```
as expected, and the original example also generates correctly:

```ts
export interface components {
  schemas: {
    IUserWithId: components["schemas"]["Partial<Pick<IUser,\"id\">>"] | string;
    "Partial<Pick<IUser,\"id\">>": {
      id?: number;
    };
    IUserWithName: {
      name: string;
    };
  }
}
```

## How to review

Tests

## Checklist

- [x] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
