### PR TITLE
fix: tuples type generation bug, and unit test bug.

### DIFF
--- a/src/transform/schema-object.ts
+++ b/src/transform/schema-object.ts
@@ -127,9 +127,11 @@ export function defaultSchemaObjectTransform(
     if (schemaObject.type === "array") {
       indentLv++;
       let itemType = "unknown";
+      let isTupleType = false;
       if (schemaObject.items) {
         if (Array.isArray(schemaObject.items)) {
           // tuple type support
+          isTupleType = true;
           const result: string[] = [];
           schemaObject.items.forEach((item) => {
             result.push(transformSchemaObject(item, { path, ctx: { ...ctx, indentLv } }));
@@ -163,7 +165,10 @@ export function defaultSchemaObjectTransform(
           );
         }
       }
-      itemType = tsArrayOf(itemType);
+      if (!isTupleType) {
+        // Do not use tsArrayOf when it is a tuple type
+        itemType = tsArrayOf(itemType);
+      }
       itemType = ctx.immutableTypes || schemaObject.readOnly ? tsReadonly(itemType) : itemType;
       return schemaObject.nullable ? tsUnionOf(itemType, "null") : itemType;
     }

--- a/test/schema-object.test.ts
+++ b/test/schema-object.test.ts
@@ -112,7 +112,7 @@ describe("Schema Object", () => {
       test("tuple array", () => {
         const schema: SchemaObject = { type: "array", items: [{ type: "string" },{"type": "number"}],minItems:2,maxItems:2 };
         const generated = transformSchemaObject(schema, options);
-        expect(generated).toBe("([string,number])[]");
+        expect(generated).toBe("[string,number]");
       });
 
       test("ref", () => {


### PR DESCRIPTION
## Changes

Sorry, when solving the problem of generating tuples type before, the unit test assertion was written incorrectly, but now it is correct

## How to Review

test

tuples type schema
{ type: "array", items: [{ type: "string" },{"type": "number"}],minItems:2,maxItems:2 }
The corresponding data should be:
[string, number]

## Checklist

- [x] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
