### PR TITLE
Fix incorrect check for protocol

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -114,7 +114,7 @@ async function generateSchema(pathToSpec) {
       const filename = pathToSpec.replace(EXT_RE, ".ts");
       const originalOutputFilePath = outputFilePath;
       outputFilePath = new URL(filename, originalOutputFilePath);
-      if (outputFilePath.protocol !== 'file') {
+      if (outputFilePath.protocol !== 'file:') {
         outputFilePath = new URL(outputFilePath.host.replace(EXT_RE, ".ts"), originalOutputFilePath);
       }
     }


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

I couldn't find an issue. But here is my error:

```
Error: EISDIR: illegal operation on a directory, open '/Users/don.denton/GitProjects/my-project/server-sdk/'
    at Object.openSync (node:fs:601:3)
    at Object.writeFileSync (node:fs:2249:35)
    at generateSchema (file:///Users/don.denton/.npm/_npx/f0a53e56ae94fd64/node_modules/openapi-typescript/bin/cli.js:136:8)
    at async file:///Users/don.denton/.npm/_npx/f0a53e56ae94fd64/node_modules/openapi-typescript/bin/cli.js:209:7
    at async Promise.all (index 0)
    at async main (file:///Users/don.denton/.npm/_npx/f0a53e56ae94fd64/node_modules/openapi-typescript/bin/cli.js:199:3) {
  errno: -21,
  syscall: 'open',
  code: 'EISDIR',
  path: '/Users/don.denton/GitProjects/my-project/server-sdk/'
}
```

When I log out the `outputFilePath.protocol` right before this check, it is `"file:"` (with a colon). After this change, my error goes away and the task completes.

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

Not sure how to reproduce the error without my exact setup... just haven't looked into it. Hence, not adding a test at the moment.

## Checklist

- [ ] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (if applicable)
