### PR TITLE
Fix missing parameters in operation object

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,15 +40,17 @@ This will compile the code as you change automatically.
 
 **Please fill out the template!** It’s a very lightweight template 🙂.
 
-### TDD
+### Use Test-driven Development!
 
-This library is a great usecase for [test-driven development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development). If you’re new to this, the basic workflow is:
+Contributing to this library is hard-bordering-on-impossible without a [test-driven development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development) strategy. If you’re new to this, the basic workflow is:
 
 1. First, write a [test](#testing) that fully outlines what you’d _like_ the output to be.
-2. Make sure this test **fails** when you run `npm test` (yes, _fails!_)
+2. Next, make sure this test **fails** when you run `npm test` (yes, _fails!_)
 3. Then, make changes to `src/` until the tests pass.
 
-_Code generation is hard!_ And for that reason, starting with a very clear expectation of your end-goal can make working easier.
+Reasoning about code generation can be quite difficult until you “invert your thinking” and approach it output-first. Adopting TDD can turn very unclear/abstract problems into concrete ones with clear steps to resolution.
+
+✨ When starting any task, **write a failing test first!** ✨
 
 #### Updating snapshot tests
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,7 +276,7 @@ export interface RequestBodyObject extends Extensable {
  */
 export interface MediaTypeObject extends Extensable {
   /** The schema defining the content of the request, response, or parameter. */
-  schema?: SchemaObject;
+  schema?: SchemaObject | ReferenceObject;
   /** Example of the media type. The example object SHOULD be in the correct format as specified by the media type. The example field is mutually exclusive of the examples field. Furthermore, if referencing a schema which contains an example, the example value SHALL override the example provided by the schema. */
   example?: any;
   /** Examples of the media type. Each example object SHOULD match the media type and specified schema if present. The examples field is mutually exclusive of the example field. Furthermore, if referencing a schema which contains an example, the examples value SHALL override the example provided by the schema. */


### PR DESCRIPTION
## Changes

Fixes #1065. This was a dumb bug where we just didn’t do a complete parameter lookup if it had an `operationId` 🤦. Was as easy as moving a couple lines of code above the `if()` statement.

## How to Review

Captured in tests; tests should pass.

## Checklist

- [x] Unit tests updated
- [x] README updated
- [x] `examples/` directory updated (if applicable)
