### PR TITLE
Add Algolia env vars

### DIFF
--- a/docs/src/components/Header/Search.tsx
+++ b/docs/src/components/Header/Search.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource react */
 import { useState, useCallback, useRef } from "react";
-import { ALGOLIA } from "../../consts";
 import "@docsearch/css";
 import "./Search.css";
 
@@ -71,9 +70,9 @@ export default function Search() {
             initialQuery={initialQuery}
             initialScrollY={window.scrollY}
             onClose={onClose}
-            indexName={ALGOLIA.indexName}
-            appId={ALGOLIA.appId}
-            apiKey={ALGOLIA.apiKey}
+            indexName={import.meta.env.ALGOLIA_INDEX_NAME}
+            appId={import.meta.env.ALGOLIA_APP_ID}
+            apiKey={import.meta.env.ALGOLIA_SEARCH_KEY}
             transformItems={(items) => {
               return items.map((item) => {
                 // We transform the absolute URL into a relative URL to

--- a/docs/src/consts.ts
+++ b/docs/src/consts.ts
@@ -17,13 +17,6 @@ export const KNOWN_LANGUAGES = {
 } as const;
 export const KNOWN_LANGUAGE_CODES = Object.values(KNOWN_LANGUAGES);
 
-// See "Algolia" section of the README for more information.
-export const ALGOLIA = {
-  indexName: "XXXXXXXXXX",
-  appId: "XXXXXXXXXX",
-  apiKey: "XXXXXXXXXX",
-};
-
 export const OPENAPI_TS_CONTRIBUTORS = [
   ...new Set([
     "drwpow",


### PR DESCRIPTION
## Changes

Moves Algolia settings to env vars. These aren’t really secret, but are easier to manage in Cloudflare Pages.