### PR TITLE
Add Algolia search script, update openapi-fetch

### DIFF
--- a/docs/src/components/Header/Search.tsx
+++ b/docs/src/components/Header/Search.tsx
@@ -1,10 +1,9 @@
 /** @jsxImportSource react */
 import { useState, useCallback, useRef } from "react";
 import "@docsearch/css";
-import "./Search.css";
-
-import { createPortal } from "react-dom";
 import * as docSearchReact from "@docsearch/react";
+import { createPortal } from "react-dom";
+import "./Search.css";
 
 /** FIXME: This is still kinda nasty, but DocSearch is not ESM ready. */
 const DocSearchModal = docSearchReact.DocSearchModal || (docSearchReact as any).default.DocSearchModal;

--- a/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -1,6 +1,4 @@
 ---
-import { SIDEBAR } from "../../consts.js";
-
 type Props = {
   currentPage: string;
 };

--- a/docs/src/layouts/MainLayout.astro
+++ b/docs/src/layouts/MainLayout.astro
@@ -15,6 +15,11 @@ type Props = CollectionEntry<"docs">["data"] & {
   headings: MarkdownHeading[];
 };
 
+interface Link {
+  url: string;
+  text: string;
+}
+
 const { headings, ...data } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const currentPage = Astro.url.pathname;
@@ -138,5 +143,14 @@ const nextLink: Record<string, Link | undefined> = {
         <RightSidebar headings={headings} githubEditUrl={githubEditUrl} />
       </aside>
     </main>
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+    <script is:inline type="text/javascript">
+      docsearch({
+        appId: import.meta.env.VITE_ALGOLIA_APP_ID,
+        apiKey: import.meta.env.VITE_ALGOLIA_SEARCH_KEY,
+        indexName: import.meta.env.VITE_ALGOLIA_INDEX_NAME,
+        container: "#grid-main",
+      });
+    </script>
   </body>
 </html>

--- a/packages/openapi-fetch/CHANGELOG.md
+++ b/packages/openapi-fetch/CHANGELOG.md
@@ -1,5 +1,17 @@
 # openapi-fetch
 
+## 0.1.4
+
+### Patch Changes
+
+- 63ebe48: Fix request body type when optional (#48)
+
+## 0.1.3
+
+### Patch Changes
+
+- 8c01480: Fix querySerializer signature
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/openapi-fetch/src/index.test.ts
+++ b/packages/openapi-fetch/src/index.test.ts
@@ -351,6 +351,42 @@ describe("post()", () => {
     // assert error is empty
     expect(error).toBe(undefined);
   });
+
+  it("request body type when optional", async () => {
+    fetchMocker.mockResponse(() => ({ status: 201, body: "{}" }));
+    const client = createClient<paths>();
+
+    // expect error on wrong body type
+    // @ts-expect-error
+    await client.post("/post/optional", { body: { error: true } });
+
+    // (no error)
+    await client.post("/post/optional", {
+      body: {
+        title: "",
+        publish_date: 3,
+        body: "",
+      },
+    });
+  });
+
+  it("request body type when optional inline", async () => {
+    fetchMocker.mockResponse(() => ({ status: 201, body: "{}" }));
+    const client = createClient<paths>();
+
+    // expect error on wrong body type
+    // @ts-expect-error
+    await client.post("/post/optional/inline", { body: { error: true } });
+
+    // (no error)
+    await client.post("/post/optional/inline", {
+      body: {
+        title: "",
+        publish_date: 3,
+        body: "",
+      },
+    });
+  });
 });
 
 describe("delete()", () => {

--- a/packages/openapi-fetch/src/index.ts
+++ b/packages/openapi-fetch/src/index.ts
@@ -34,16 +34,19 @@ export type FilterKeys<Obj, Matchers> = { [K in keyof Obj]: K extends Matchers ?
 /** handle "application/json", "application/vnd.api+json", "appliacation/json;charset=utf-8" and more */
 export type JSONLike = `${string}json${string}`;
 
-// fetch types
+// general purpose types
 export type Params<O> = O extends { parameters: any } ? { params: NonNullable<O["parameters"]> } : BaseParams;
-export type RequestBodyObj<O> = O extends { requestBody: any } ? O["requestBody"] : never;
+export type RequestBodyObj<O> = O extends { requestBody?: any } ? O["requestBody"] : never;
 export type RequestBodyContent<O> = undefined extends RequestBodyObj<O> ? FilterKeys<NonNullable<RequestBodyObj<O>>, "content"> | undefined : FilterKeys<RequestBodyObj<O>, "content">;
 export type RequestBodyJSON<O> = FilterKeys<RequestBodyContent<O>, JSONLike> extends never ? FilterKeys<NonNullable<RequestBodyContent<O>>, JSONLike> | undefined : FilterKeys<RequestBodyContent<O>, JSONLike>;
 export type RequestBody<O> = undefined extends RequestBodyJSON<O> ? { body?: RequestBodyJSON<O> } : { body: RequestBodyJSON<O> };
 export type QuerySerializer<O> = (query: O extends { parameters: { query: any } } ? O["parameters"]["query"] : Record<string, unknown>) => string;
-export type FetchOptions<T> = Params<T> & RequestBody<T> & Omit<RequestInit, "body"> & { querySerializer?: QuerySerializer<T> };
+export type RequestOptions<T> = Params<T> & RequestBody<T> & { querySerializer?: QuerySerializer<T> };
 export type Success<O> = FilterKeys<FilterKeys<O, OkStatus>, "content">;
 export type Error<O> = FilterKeys<FilterKeys<O, ErrorStatus>, "content">;
+
+// fetch types
+export type FetchOptions<T> = RequestOptions<T> & Omit<RequestInit, "body">;
 export type FetchResponse<T> =
   | { data: T extends { responses: any } ? NonNullable<FilterKeys<Success<T["responses"]>, JSONLike>> : unknown; error?: never; response: Response }
   | { data?: never; error: T extends { responses: any } ? NonNullable<FilterKeys<Error<T["responses"]>, JSONLike>> : unknown; response: Response };

--- a/packages/openapi-fetch/test/v1.yaml
+++ b/packages/openapi-fetch/test/v1.yaml
@@ -1,5 +1,7 @@
-openapi:
-  version: '3.1'
+openapi: 3.1
+info:
+  title: Test Specification
+  version: '1.0'
 paths:
   /comment:
     put:
@@ -14,6 +16,27 @@ paths:
     put:
       requestBody:
         $ref: '#/components/requestBodies/CreatePost'
+      responses:
+        201:
+          $ref: '#/components/responses/CreatePost'
+        500:
+          $ref: '#/components/responses/Error'
+  /post/optional:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePostOptional'
+      responses:
+        201:
+          $ref: '#/components/responses/CreatePost'
+        500:
+          $ref: '#/components/responses/Error'
+  /post/optional/inline:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Post'
       responses:
         201:
           $ref: '#/components/responses/CreatePost'
@@ -199,6 +222,23 @@ components:
   requestBodies:
     CreatePost:
       required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              title:
+                type: string
+              body:
+                type: string
+              publish_date:
+                type: number
+            required:
+              - title
+              - body
+              - publish_date
+    CreatePostOptional:
+      required: false
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Changes

Adds search index for new docs site. No openapi-typescript changes.

Also updates openapi-fetch, but only mirrors changes from https://github.com/drwpow/openapi-fetch. Still not deploying that package from here yet (not until docs site is ready).