### PR TITLE
feat: introduce excludeDeprecated option

### DIFF
--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -54,6 +54,7 @@ _Thanks, [@psmyrdek](https://github.com/psmyrdek)!_
 | `--path-params-as-types`  |       | `false`  | Allow dynamic string lookups on the `paths` object                                                                           |
 | `--support-array-length`  |       | `false`  | Generate tuples using array `minItems` / `maxItems`                                                                          |
 | `--alphabetize`           |       | `false`  | Sort types alphabetically                                                                                                    |
+| `--exclude-deprecated`    |       | `false`  | Exclude deprecated fields from types                                                                                         |
 
 ### `--path-params-as-types`
 

--- a/packages/openapi-typescript/README.md
+++ b/packages/openapi-typescript/README.md
@@ -124,6 +124,7 @@ The following flags can be appended to the CLI command.
 | `--path-params-as-types`  |       | `false`  | Allow dynamic string lookups on the `paths` object                                                                           |
 | `--support-array-length`  |       | `false`  | Generate tuples using array `minItems` / `maxItems`                                                                          |
 | `--alphabetize`           |       | `false`  | Sort types alphabetically                                                                                                    |
+| `--exclude-deprecated`    |       | `false`  | Exclude deprecated fields from types                                                                                         |
 
 #### 🚩 `--path-params-as-types`
 

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -27,6 +27,7 @@ Options
   --support-array-length       (optional) Generate tuples using array minItems / maxItems
   --path-params-as-types       (optional) Substitute path parameter names with their respective types
   --alphabetize                (optional) Sort types alphabetically
+  --exclude-deprecated         (optional) Exclude deprecated fields from types
 `;
 
 const OUTPUT_FILE = "FILE";
@@ -54,6 +55,7 @@ const flags = parser(args, {
     "supportArrayLength",
     "pathParamsAsTypes",
     "alphabetize",
+    "excludeDeprecated",
   ],
   string: ["auth", "header", "headersObject", "httpMethod"],
   alias: {
@@ -104,6 +106,7 @@ async function generateSchema(pathToSpec) {
     supportArrayLength: flags.supportArrayLength,
     pathParamsAsTypes: flags.pathParamsAsTypes,
     alphabetize: flags.alphabetize,
+    excludeDeprecated: flags.excludeDeprecated,
   });
 
   // output

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -51,6 +51,7 @@ async function openapiTS(schema: string | URL | OpenAPI3 | Readable, options: Op
     parameters: {},
     silent: options.silent ?? false,
     supportArrayLength: options.supportArrayLength ?? false,
+    excludeDeprecated: options.excludeDeprecated ?? false,
   };
 
   // note: we may be loading many large schemas into memory at once; take care to reuse references without cloning
@@ -129,7 +130,7 @@ async function openapiTS(schema: string | URL | OpenAPI3 | Readable, options: Op
           if (!Object.keys(subschemaTypes).length) break;
           output.push(indent(`${key}: {`, indentLv));
           indentLv++;
-          for (const [k, v] of getEntries(subschemaTypes, options.alphabetize)) {
+          for (const [k, v] of getEntries(subschemaTypes, options.alphabetize, options.excludeDeprecated)) {
             if (EMPTY_OBJECT_RE.test(v)) output.push(indent(`${escObjKey(k)}: Record<string, never>;`, indentLv));
             else output.push(indent(`${escObjKey(k)}: ${v};`, indentLv));
           }

--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -16,7 +16,7 @@ export default function transformComponentsObject(components: ComponentsObject, 
   if (components.schemas) {
     output.push(indent("schemas: {", indentLv));
     indentLv++;
-    for (const [name, schemaObject] of getEntries(components.schemas, ctx.alphabetize)) {
+    for (const [name, schemaObject] of getEntries(components.schemas, ctx.alphabetize, ctx.excludeDeprecated)) {
       const c = getSchemaObjectComment(schemaObject, indentLv);
       if (c) output.push(indent(c, indentLv));
       let key = escObjKey(name);
@@ -37,7 +37,7 @@ export default function transformComponentsObject(components: ComponentsObject, 
   if (components.responses) {
     output.push(indent("responses: {", indentLv));
     indentLv++;
-    for (const [name, responseObject] of getEntries(components.responses, ctx.alphabetize)) {
+    for (const [name, responseObject] of getEntries(components.responses, ctx.alphabetize, ctx.excludeDeprecated)) {
       const c = getSchemaObjectComment(responseObject, indentLv);
       if (c) output.push(indent(c, indentLv));
       let key = escObjKey(name);
@@ -62,7 +62,7 @@ export default function transformComponentsObject(components: ComponentsObject, 
   if (components.parameters) {
     output.push(indent("parameters: {", indentLv));
     indentLv++;
-    for (const [name, parameterObject] of getEntries(components.parameters, ctx.alphabetize)) {
+    for (const [name, parameterObject] of getEntries(components.parameters, ctx.alphabetize, ctx.excludeDeprecated)) {
       const c = getSchemaObjectComment(parameterObject, indentLv);
       if (c) output.push(indent(c, indentLv));
       let key = escObjKey(name);
@@ -90,7 +90,7 @@ export default function transformComponentsObject(components: ComponentsObject, 
   if (components.requestBodies) {
     output.push(indent("requestBodies: {", indentLv));
     indentLv++;
-    for (const [name, requestBodyObject] of getEntries(components.requestBodies, ctx.alphabetize)) {
+    for (const [name, requestBodyObject] of getEntries(components.requestBodies, ctx.alphabetize, ctx.excludeDeprecated)) {
       const c = getSchemaObjectComment(requestBodyObject, indentLv);
       if (c) output.push(indent(c, indentLv));
       let key = escObjKey(name);
@@ -125,7 +125,7 @@ export default function transformComponentsObject(components: ComponentsObject, 
   if (components.headers) {
     output.push(indent("headers: {", indentLv));
     indentLv++;
-    for (const [name, headerObject] of getEntries(components.headers, ctx.alphabetize)) {
+    for (const [name, headerObject] of getEntries(components.headers, ctx.alphabetize, ctx.excludeDeprecated)) {
       const c = getSchemaObjectComment(headerObject, indentLv);
       if (c) output.push(indent(c, indentLv));
       let key = escObjKey(name);
@@ -150,7 +150,7 @@ export default function transformComponentsObject(components: ComponentsObject, 
   if (components.pathItems) {
     output.push(indent("pathItems: {", indentLv));
     indentLv++;
-    for (const [name, pathItemObject] of getEntries(components.pathItems, ctx.alphabetize)) {
+    for (const [name, pathItemObject] of getEntries(components.pathItems, ctx.alphabetize, ctx.excludeDeprecated)) {
       let key = escObjKey(name);
       if (ctx.immutableTypes) key = tsReadonly(key);
       if ("$ref" in pathItemObject) {

--- a/packages/openapi-typescript/src/transform/header-object.ts
+++ b/packages/openapi-typescript/src/transform/header-object.ts
@@ -14,7 +14,7 @@ export default function transformHeaderObject(headerObject: HeaderObject, { path
     let { indentLv } = ctx;
     const output: string[] = ["{"];
     indentLv++;
-    for (const [contentType, mediaTypeObject] of getEntries(headerObject.content, ctx.alphabetize)) {
+    for (const [contentType, mediaTypeObject] of getEntries(headerObject.content, ctx.alphabetize, ctx.excludeDeprecated)) {
       const c = getSchemaObjectComment(mediaTypeObject, indentLv);
       if (c) output.push(indent(c, indentLv));
       let key = escStr(contentType);

--- a/packages/openapi-typescript/src/transform/operation-object.ts
+++ b/packages/openapi-typescript/src/transform/operation-object.ts
@@ -88,7 +88,7 @@ export default function transformOperationObject(operationObject: OperationObjec
     if (operationObject.responses) {
       output.push(indent(`responses: {`, indentLv));
       indentLv++;
-      for (const [responseCode, responseObject] of getEntries(operationObject.responses, ctx.alphabetize)) {
+      for (const [responseCode, responseObject] of getEntries(operationObject.responses, ctx.alphabetize, ctx.excludeDeprecated)) {
         const key = escObjKey(responseCode);
         const c = getSchemaObjectComment(responseObject, indentLv);
         if (c) output.push(indent(c, indentLv));

--- a/packages/openapi-typescript/src/transform/paths-object.ts
+++ b/packages/openapi-typescript/src/transform/paths-object.ts
@@ -7,7 +7,7 @@ export default function transformPathsObject(pathsObject: PathsObject, ctx: Glob
   let { indentLv } = ctx;
   const output: string[] = ["{"];
   indentLv++;
-  for (const [url, pathItemObject] of getEntries(pathsObject, ctx.alphabetize)) {
+  for (const [url, pathItemObject] of getEntries(pathsObject, ctx.alphabetize, ctx.excludeDeprecated)) {
     let path = url;
 
     // build dynamic string template literal index

--- a/packages/openapi-typescript/src/transform/request-body-object.ts
+++ b/packages/openapi-typescript/src/transform/request-body-object.ts
@@ -15,7 +15,7 @@ export default function transformRequestBodyObject(requestBodyObject: RequestBod
   output.push(indent(ctx.immutableTypes ? tsReadonly("content: {") : "content: {", indentLv));
   if (!Object.keys(requestBodyObject.content).length) return `${escStr("*/*")}: never`;
   indentLv++;
-  for (const [contentType, mediaTypeObject] of getEntries(requestBodyObject.content, ctx.alphabetize)) {
+  for (const [contentType, mediaTypeObject] of getEntries(requestBodyObject.content, ctx.alphabetize, ctx.excludeDeprecated)) {
     const c = getSchemaObjectComment(mediaTypeObject, indentLv);
     if (c) output.push(indent(c, indentLv));
     let key = escStr(contentType);

--- a/packages/openapi-typescript/src/transform/response-object.ts
+++ b/packages/openapi-typescript/src/transform/response-object.ts
@@ -22,7 +22,7 @@ export default function transformResponseObject(responseObject: ResponseObject, 
     indentLv++;
     output.push(indent(`headers: {`, indentLv));
     indentLv++;
-    for (const [name, headerObject] of getEntries(responseObject.headers, ctx.alphabetize)) {
+    for (const [name, headerObject] of getEntries(responseObject.headers, ctx.alphabetize, ctx.excludeDeprecated)) {
       const c = getSchemaObjectComment(headerObject, indentLv);
       if (c) output.push(indent(c, indentLv));
       let key = escObjKey(name);
@@ -52,7 +52,7 @@ export default function transformResponseObject(responseObject: ResponseObject, 
     indentLv++;
     output.push(indent("content: {", indentLv));
     indentLv++;
-    for (const [contentType, mediaTypeObject] of getEntries(responseObject.content, ctx.alphabetize)) {
+    for (const [contentType, mediaTypeObject] of getEntries(responseObject.content, ctx.alphabetize, ctx.excludeDeprecated)) {
       let key = escStr(contentType);
       if (ctx.immutableTypes) key = tsReadonly(key);
       output.push(

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -145,7 +145,7 @@ export function defaultSchemaObjectTransform(schemaObject: SchemaObject | Refere
   const coreType: string[] = [];
   if (("properties" in schemaObject && schemaObject.properties && Object.keys(schemaObject.properties).length) || ("additionalProperties" in schemaObject && schemaObject.additionalProperties)) {
     indentLv++;
-    for (const [k, v] of getEntries(schemaObject.properties ?? {}, ctx.alphabetize)) {
+    for (const [k, v] of getEntries(schemaObject.properties ?? {}, ctx.alphabetize, ctx.excludeDeprecated)) {
       const c = getSchemaObjectComment(v, indentLv);
       if (c) coreType.push(indent(c, indentLv));
       let key = escObjKey(k);

--- a/packages/openapi-typescript/src/transform/webhooks-object.ts
+++ b/packages/openapi-typescript/src/transform/webhooks-object.ts
@@ -6,7 +6,7 @@ export default function transformWebhooksObject(webhooksObject: WebhooksObject, 
   let { indentLv } = ctx;
   const output: string[] = ["{"];
   indentLv++;
-  for (const [name, pathItemObject] of getEntries(webhooksObject, ctx.alphabetize)) {
+  for (const [name, pathItemObject] of getEntries(webhooksObject, ctx.alphabetize, ctx.excludeDeprecated)) {
     output.push(
       indent(
         `${escStr(name)}: ${transformPathItemObject(pathItemObject, {

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -621,6 +621,8 @@ export interface OpenAPITSOptions {
    * function if available; else, it will use unidici's fetch function.
    */
   fetch?: Fetch;
+  /** Exclude deprecated fields from types? (default: false) */
+  excludeDeprecated?: boolean;
 }
 
 /** Subschema discriminator (note: only valid $ref types accepted here) */
@@ -661,6 +663,7 @@ export interface GlobalContext {
   pathParamsAsTypes: boolean;
   silent: boolean;
   supportArrayLength: boolean;
+  excludeDeprecated: boolean;
 }
 
 // Fetch is available in the global scope starting with Node v18.

--- a/packages/openapi-typescript/src/utils.ts
+++ b/packages/openapi-typescript/src/utils.ts
@@ -260,9 +260,10 @@ export function indent(input: string, level: number) {
 }
 
 /** call Object.entries() and optionally sort */
-export function getEntries<T>(obj: ArrayLike<T> | Record<string, T>, alphabetize?: boolean) {
-  const entries = Object.entries(obj);
+export function getEntries<T>(obj: ArrayLike<T> | Record<string, T>, alphabetize?: boolean, excludeDeprecated?: boolean) {
+  let entries = Object.entries(obj);
   if (alphabetize) entries.sort(([a], [b]) => a.localeCompare(b, "en", { numeric: true }));
+  if (excludeDeprecated) entries = entries.filter(([, v]) => !(v && typeof v === "object" && "deprecated" in v && v.deprecated));
   return entries;
 }
 

--- a/packages/openapi-typescript/test/components-object.test.ts
+++ b/packages/openapi-typescript/test/components-object.test.ts
@@ -236,7 +236,7 @@ describe("Components Object", () => {
 }`);
       });
     });
-    describe.only("excludeDeprecated", () => {
+    describe("excludeDeprecated", () => {
       test("true", () => {
         const schema: ComponentsObject = {
           schemas: {

--- a/packages/openapi-typescript/test/components-object.test.ts
+++ b/packages/openapi-typescript/test/components-object.test.ts
@@ -16,6 +16,7 @@ const options: GlobalContext = {
   silent: true,
   supportArrayLength: false,
   transform: undefined,
+  excludeDeprecated: false,
 };
 
 const basicSchema: ComponentsObject = {
@@ -235,7 +236,35 @@ describe("Components Object", () => {
 }`);
       });
     });
-  });
+    describe.only("excludeDeprecated", () => {
+      test("true", () => {
+        const schema: ComponentsObject = {
+          schemas: {
+            Alpha: {
+              type: "object",
+              properties: {
+                a: { type: "boolean", deprecated: true },
+                z: { type: "boolean" },
+              },
+            },
+          },
+        };
+        const generated = transformComponentsObject(schema, { ...options, excludeDeprecated: true });
+        expect(generated).toBe(`{
+  schemas: {
+    Alpha: {
+      z?: boolean;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
+}`);
+          });
+        });
+      });
 
   test("parameters with required: false", () => {
     const generated = transformComponentsObject(optionalParamSchema, options);

--- a/packages/openapi-typescript/test/header-object.test.ts
+++ b/packages/openapi-typescript/test/header-object.test.ts
@@ -18,6 +18,7 @@ const options: TransformHeaderObjectOptions = {
     silent: true,
     supportArrayLength: false,
     transform: undefined,
+    excludeDeprecated: false,
   },
 };
 

--- a/packages/openapi-typescript/test/load.test.ts
+++ b/packages/openapi-typescript/test/load.test.ts
@@ -118,6 +118,7 @@ async function load(
     silent: true,
     supportArrayLength: false,
     transform: undefined,
+    excludeDeprecated: false,
     ...options,
   });
 }

--- a/packages/openapi-typescript/test/path-item-object.test.ts
+++ b/packages/openapi-typescript/test/path-item-object.test.ts
@@ -18,6 +18,7 @@ const options: TransformPathItemObjectOptions = {
     silent: true,
     supportArrayLength: false,
     transform: undefined,
+    excludeDeprecated: false,
   },
 };
 

--- a/packages/openapi-typescript/test/paths-object.test.ts
+++ b/packages/openapi-typescript/test/paths-object.test.ts
@@ -16,6 +16,7 @@ const options: GlobalContext = {
   silent: true,
   supportArrayLength: false,
   transform: undefined,
+  excludeDeprecated: false,
 };
 
 describe("Paths Object", () => {

--- a/packages/openapi-typescript/test/request-body-object.test.ts
+++ b/packages/openapi-typescript/test/request-body-object.test.ts
@@ -18,6 +18,7 @@ const options: TransformRequestBodyObjectOptions = {
     silent: true,
     supportArrayLength: false,
     transform: undefined,
+    excludeDeprecated: false,
   },
 };
 

--- a/packages/openapi-typescript/test/schema-object.test.ts
+++ b/packages/openapi-typescript/test/schema-object.test.ts
@@ -18,6 +18,7 @@ const options: TransformSchemaObjectOptions = {
     silent: true,
     supportArrayLength: false,
     transform: undefined,
+    excludeDeprecated: false,
   },
 };
 

--- a/packages/openapi-typescript/test/webhooks-object.test.ts
+++ b/packages/openapi-typescript/test/webhooks-object.test.ts
@@ -16,6 +16,7 @@ const options: GlobalContext = {
   silent: true,
   supportArrayLength: false,
   transform: undefined,
+  excludeDeprecated: false,
 };
 
 describe("Webhooks Object", () => {


### PR DESCRIPTION
## Changes

Often time we want to exclude deprecated fields completely from generated types so we can spot deprecated fields asap. 
Unfortunately, TS doesn't have a such option: https://github.com/microsoft/TypeScript/issues/49433
The code editor shows deprecated fields with scratched out, which is nice but not enough.

For example, you created a new version of SDK, then you wish TS would complain about use of deprecated fields asap but it doesn't. 

## How to Review

It should be straight forward to review but I'm not sure if I should add this option on every single `getEntries` usages. 

## Checklist

- [x] Unit tests updated
- [x] README updated
- [ ] `examples/` directory updated (if applicable)
