### PR TITLE
fix: support nested path parameters in --path-params-as-types

### DIFF
--- a/.changeset/wise-badgers-kick.md
+++ b/.changeset/wise-badgers-kick.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+support nested path parameters in --path-params-as-types

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -719,6 +719,87 @@ export type operations = Record<string, never>;
       });
     });
 
+    describe("pathParamsAsTypes (with nested parameters)", () => {
+      const schema: OpenAPI3 = {
+        openapi: "3.1",
+        info: { title: "Test", version: "1.0" },
+        paths: {
+          "/user/{user_id}": {
+            get: {
+              parameters: [{ name: "user_id", in: "path" }],
+            },
+            put: {
+              parameters: [{ name: "user_id", in: "path" }],
+            }
+          },
+        },
+      };
+
+      test("false", async () => {
+        const generated = await openapiTS(schema, { pathParamsAsTypes: false });
+        expect(generated).toBe(`${BOILERPLATE}
+export interface paths {
+  "/user/{user_id}": {
+    get: {
+      parameters: {
+        path: {
+          user_id: string;
+        };
+      };
+    };
+    put: {
+      parameters: {
+        path: {
+          user_id: string;
+        };
+      };
+    };
+  };
+}
+
+export type webhooks = Record<string, never>;
+
+export type components = Record<string, never>;
+
+export type external = Record<string, never>;
+
+export type operations = Record<string, never>;
+`);
+      });
+
+      test("true", async () => {
+        const generated = await openapiTS(schema, { pathParamsAsTypes: true });
+        expect(generated).toBe(`${BOILERPLATE}
+export interface paths {
+  [path: \`/user/\${string}\`]: {
+    get: {
+      parameters: {
+        path: {
+          user_id: string;
+        };
+      };
+    };
+    put: {
+      parameters: {
+        path: {
+          user_id: string;
+        };
+      };
+    };
+  };
+}
+
+export type webhooks = Record<string, never>;
+
+export type components = Record<string, never>;
+
+export type external = Record<string, never>;
+
+export type operations = Record<string, never>;
+`);
+      });
+    });
+
     describe("transform/postTransform", () => {
       const schema: OpenAPI3 = {
         openapi: "3.1",


### PR DESCRIPTION
## Changes

The existing code for `--path-params-as-types` assumes path parameters are defined on the PathItemObject:
```javascript
{
  openapi: "3.1",
  info: { title: "Test", version: "1.0" },
  paths: {
    "/user/{user_id}": {
      parameters: [{ name: "user_id", in: "path" }],
    },
  },
}
```

But its valid to define them on the OperationObject:
```javascript
{
  openapi: "3.1",
  info: { title: "Test", version: "1.0" },
  paths: {
    "/user/{user_id}": {
      get: {
        parameters: [{ name: "user_id", in: "path" }],
      },
      put: {
        parameters: [{ name: "user_id", in: "path" }],
      }
    },
  },
}
```

[FastAPI](https://github.com/tiangolo/fastapi) does it this way.

## How to Review

This is both my first openapi-typescript PR _and_ my first typescript PR. Don't hold back.

## Checklist

- [x] Unit tests updated
- [x] README updated
- [x] `examples/` directory updated (only applicable for openapi-typescript)
