### PR TITLE
fix(openapi-fetch): treat default response as error

### DIFF
--- a/.changeset/sixty-bobcats-jam.md
+++ b/.changeset/sixty-bobcats-jam.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Treat `default` response as error

--- a/docs/src/content/docs/openapi-fetch/index.md
+++ b/docs/src/content/docs/openapi-fetch/index.md
@@ -134,4 +134,5 @@ All methods return an object with **data**, **error**, and **response**.
 
 - **data** will contain that endpoint’s `2xx` response if the server returned `2xx`; otherwise it will be `undefined`
 - **error** likewise contains that endpoint’s `4xx`/`5xx` response if the server returned either; otherwise it will be `undefined`
+  - _Note: `default` will also be interpreted as `error`, since its intent is handling unexpected HTTP codes_
 - **response** has response info like `status`, `headers`, etc. It is not typechecked.

--- a/packages/openapi-fetch/README.md
+++ b/packages/openapi-fetch/README.md
@@ -129,6 +129,7 @@ All methods return an object with **data**, **error**, and **response**.
 
 - **data** will contain that endpoint’s `2xx` response if the server returned `2xx`; otherwise it will be `undefined`
 - **error** likewise contains that endpoint’s `4xx`/`5xx` response if the server returned either; otherwise it will be `undefined`
+  - _Note: `default` will also be interpreted as `error`, since its intent is handling unexpected HTTP codes_
 - **response** has response info like `status`, `headers`, etc. It is not typechecked.
 
 ## API

--- a/packages/openapi-fetch/src/index.test.ts
+++ b/packages/openapi-fetch/src/index.test.ts
@@ -194,6 +194,18 @@ describe("client", () => {
     });
     expect((await client.get("/self", {})).data).toBe(data);
   });
+
+  it("treats `default` as an error", async () => {
+    const client = createClient<paths>({ headers: { "Cache-Control": "max-age=10000000" } });
+    fetchMocker.mockResponseOnce(() => ({ status: 500, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ code: 500, message: "An unexpected error occurred" }) }));
+    const { error } = await client.get("/default-as-error", {});
+
+    // discard `data` object
+    if (!error) throw new Error("treats `default` as an error: error response should be present");
+
+    // assert `error.message` doesn’t throw TS error
+    expect(error.message).toBe("An unexpected error occurred");
+  });
 });
 
 describe("get()", () => {

--- a/packages/openapi-fetch/src/index.ts
+++ b/packages/openapi-fetch/src/index.ts
@@ -24,7 +24,8 @@ export interface OperationObject {
 }
 export type HttpMethod = "get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace";
 export type OkStatus = 200 | 201 | 202 | 203 | 204 | 206 | 207;
-export type ErrorStatus = 500 | 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 408 | 409 | 410 | 411 | 412 | 413 | 414 | 415 | 416 | 417 | 418 | 420 | 421 | 422 | 423 | 424 | 425 | 426 | 429 | 431 | 444 | 450 | 451 | 497 | 498 | 499;
+// prettier-ignore
+export type ErrorStatus = 500 | 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 408 | 409 | 410 | 411 | 412 | 413 | 414 | 415 | 416 | 417 | 418 | 420 | 421 | 422 | 423 | 424 | 425 | 426 | 429 | 431 | 444 | 450 | 451 | 497 | 498 | 499 | "default";
 
 // util
 /** Get a union of paths which have method */

--- a/packages/openapi-fetch/test/v1.d.ts
+++ b/packages/openapi-fetch/test/v1.d.ts
@@ -141,6 +141,13 @@ export interface paths {
       };
     };
   };
+  "/default-as-error": {
+    get: {
+      responses: {
+        default: components["responses"]["Error"];
+      };
+    };
+  };
   "/anyMethod": {
     get: {
       responses: {

--- a/packages/openapi-fetch/test/v1.yaml
+++ b/packages/openapi-fetch/test/v1.yaml
@@ -124,6 +124,11 @@ paths:
           $ref: '#/components/responses/CreateTag'
         500:
           $ref: '#/components/responses/Error'
+  /default-as-error:
+    get:
+      responses:
+        default:
+          $ref: '#/components/responses/Error'
   /anyMethod:
     get:
       responses:


### PR DESCRIPTION
## Changes

`response.default` was simply ignored. Instead, treat it as an error.

While some may disagree—technically it can be either—in my observation this is how most people use it since its purpose is handling **unexpected** HTTP codes (aka exceptions aka errors).

At any rate, interpreting `default` as _something_ rather than ignoring it is an improvement.

## How to Review

Tests added; CI should pass

## Checklist

- [x] Unit tests updated
- [x] README updated
- [x] `examples/` directory updated (only applicable for openapi-typescript)
