### PR TITLE
Fix openapi-fetch version

### DIFF
--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-fetch",
   "description": "Ultra-fast fetching for TypeScript generated automatically from your OpenAPI schema. Weighs in at 1 kb and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"


### PR DESCRIPTION
## Changes

Fixes publish error. After moving from https://github.com/drwpow/openapi-fetch, this version was accidentally out-of-sync with npm. This is a one-time change due to migrating.
