### PR TITLE
fix(openapi-typescript): Stringify primitive constant values

### DIFF
--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -41,13 +41,7 @@ export function defaultSchemaObjectTransform(schemaObject: SchemaObject | Refere
 
   // const (valid for any type)
   if (schemaObject.const !== null && schemaObject.const !== undefined) {
-    let schemaConst = schemaObject.const as any;
-    if ("type" in schemaObject) {
-      if (schemaObject.type === "string") {
-        schemaConst = escStr(schemaConst);
-      }
-    }
-    return transformSchemaObject(schemaConst, {
+    return transformSchemaObject(escStr(schemaObject.const) as any, {
       path,
       ctx: { ...ctx, immutableTypes: false, indentLv: indentLv + 1 }, // note: guarantee readonly happens once, here
     });

--- a/packages/openapi-typescript/src/utils.ts
+++ b/packages/openapi-typescript/src/utils.ts
@@ -257,7 +257,7 @@ export function tsUnionOf(...types: (string | number | boolean)[]): string {
 
 /** escape string value */
 export function escStr(input: any): string {
-  if (typeof input !== "string") return input;
+  if (typeof input !== "string") return JSON.stringify(input);
   return `"${input.trim().replace(DOUBLE_QUOTE_RE, '\\"')}"`;
 }
 

--- a/packages/openapi-typescript/test/schema-object.test.ts
+++ b/packages/openapi-typescript/test/schema-object.test.ts
@@ -255,6 +255,21 @@ describe("Schema Object", () => {
         const generated = transformSchemaObject({ type: "string", const: "duck" }, options);
         expect(generated).toBe(`"duck"`);
       });
+
+      test("number", () => {
+        const generated = transformSchemaObject({ type: "number", const: 42 }, options);
+        expect(generated).toBe("42");
+      });
+
+      test("string, no type specified", () => {
+        const generated = transformSchemaObject({ const: "99" }, options);
+        expect(generated).toBe(`"99"`);
+      });
+
+      test("number, no type specified", () => {
+        const generated = transformSchemaObject({ const: 300 }, options);
+        expect(generated).toBe("300");
+      });
     });
 
     describe("polymorphic", () => {


### PR DESCRIPTION
Closes #1118

## Changes

https://github.com/drwpow/openapi-typescript/issues/1118

The `escStr` function _claims_ to always return a string, but in fact would return whatever was passed into it, preserving the original type.
This PR aligns the behavior of the function with type signature, and keeps the original behavior _mostly_ the same.
Because these values were being turned into strings (through implicit `toString()` during backtick string expansion), the final generated output was mostly correct.
Additionally, because there was special handling for `const` values with a specified type, _some_ string consts were being quoted.

In this PR, I removed the special handling of `const` types, and instead pass every const value through `escStr`.
`escStr` then passes non-string arguments through `JSON.stringify`.

## How to Review

Ensure JSON stringification of primitive types is the correct treatment for OpenAPI `const` members, even with no `type` specified.

I added tests for `string` and `number` consts with both explicit and implicit `type` arguments.

* [ ] Where in the OpenAPI spec is `const` described? I couldn't find it in the 3.1 spec.
* [ ] How should other primitive constant types be treated? (eg, `true`, `false`)

## Checklist

- [x] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (only applicable for openapi-typescript)