### PR TITLE
Fix property escaping for discriminators

### DIFF
--- a/.changeset/five-eels-call.md
+++ b/.changeset/five-eels-call.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix property escaping for discriminators

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -184,7 +184,7 @@ export function defaultSchemaObjectTransform(schemaObject: SchemaObject | Refere
         const matchedValue = Object.entries(discriminator.mapping).find(([_, v]) => (!v.startsWith("#") && v === value) || (v.startsWith("#") && parseRef(v).path.pop() === value));
         if (matchedValue) value = matchedValue[0]; // why was this designed backwards!?
       }
-      coreType.unshift(indent(`${discriminator.propertyName}: ${escStr(value)};`, indentLv + 1));
+      coreType.unshift(indent(`${escObjKey(discriminator.propertyName)}: ${escStr(value)};`, indentLv + 1));
       break;
     }
   }

--- a/packages/openapi-typescript/test/schema-object.test.ts
+++ b/packages/openapi-typescript/test/schema-object.test.ts
@@ -351,6 +351,35 @@ describe("Schema Object", () => {
   string?: string;
 }`);
       });
+
+      test("discriminator escape", () => {
+        const schema: SchemaObject = {
+          type: "object",
+          allOf: [
+            { $ref: 'components["schemas"]["parent"]' },
+            { type: "object", properties: { string: { type: "string" } } },
+          ],
+        };
+        const generated = transformSchemaObject(schema, {
+          path: options.path,
+          ctx: {
+            ...options.ctx,
+            discriminators: {
+              'components["schemas"]["parent"]': {
+                propertyName: "@type",
+                mapping: {
+                  test: options.path,
+                },
+              },
+            },
+          },
+        });
+        expect(generated).toBe(`{
+  "@type": "test";
+} & Omit<components["schemas"]["parent"], "@type"> & {
+  string?: string;
+}`);
+      });
     });
 
     describe("allOf", () => {

--- a/packages/openapi-typescript/test/utils.test.ts
+++ b/packages/openapi-typescript/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { bench } from "vitest";
-import { parseRef, tsIntersectionOf, tsUnionOf } from "../src/utils.js";
+import { escObjKey, parseRef, tsIntersectionOf, tsUnionOf } from "../src/utils.js";
 
 describe("utils", () => {
   describe("tsUnionOf", () => {
@@ -80,4 +80,30 @@ describe("utils", () => {
       expect(parseRef('components["schemas"]["SchemaObject"]')).toStrictEqual({ filename: ".", path: ["components", "schemas", "SchemaObject"] });
     });
   });
+
+  describe("escObjKey", () => {
+    it("basic", () => {
+      expect(escObjKey("some-prop")).toStrictEqual("\"some-prop\"");
+    });
+
+    it("@ escapes", () => {
+      expect(escObjKey("@type")).toStrictEqual("\"@type\"");
+    });
+
+    it("number escapes", () => {
+      expect(escObjKey("123var")).toStrictEqual("\"123var\"");
+    });
+
+    it("only number no escapes", () => {
+      expect(escObjKey("123")).toStrictEqual("123");
+    });
+
+    it("$ no escapes", () => {
+      expect(escObjKey("$ref")).toStrictEqual("$ref");
+    });
+
+    it("_ no escapes", () => {
+      expect(escObjKey("_ref_")).toStrictEqual("_ref_");
+    })
+  })
 });


### PR DESCRIPTION
## Changes

Fix #1162. Also added some additional object key escaping tests.

## How to Review
 
Nothing special

## Checklist

- [x] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (only applicable for openapi-typescript)
