### PR TITLE
build(openapi-fetch): bundle commonjs

### DIFF
--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -9,6 +9,15 @@
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "homepage": "https://openapi-ts.pages.dev",
   "repository": {
     "type": "git",
@@ -32,10 +41,11 @@
     "svelte"
   ],
   "scripts": {
-    "build": "pnpm run build:clean && pnpm run build:ts && pnpm run build:ts-min",
+    "build": "pnpm run build:clean && pnpm run build:ts && pnpm run build:ts-min && pnpm run build:cjs",
     "build:clean": "del dist",
     "build:ts": "tsc -p tsconfig.build.json",
     "build:ts-min": "esbuild --bundle src/index.ts --format=esm --minify --outfile=dist/index.min.js && cp dist/index.d.ts dist/index.min.d.ts",
+    "build:cjs": "esbuild --bundle src/index.ts --format=cjs --outfile=dist/index.cjs",
     "lint": "pnpm run lint:js",
     "lint:js": "prettier --check \"{src,test}/**/*\"",
     "test": "pnpm run test:ts && npm run test:js",

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -16,7 +16,8 @@
       "require": "./dist/index.cjs",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "*": "./*"
   },
   "homepage": "https://openapi-ts.pages.dev",
   "repository": {


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

Also to fix #1102, but unlike #1103, this PR reuses `esbuild` instead of adding a new dependency.

Just change the `--format` flag to bundle cjs.

Ref https://esbuild.github.io/api/#format-commonjs

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

Is this type of bundling acceptable?

## Checklist

N/A

- [ ] ~~Unit tests updated~~
- [ ] ~~README updated~~
- [ ] ~~`examples/` directory updated (only applicable for openapi-typescript)~~

## Other

If your project/package is being blocked by the lack of cjs distribution for openapi-fetch, you can temporarily try using [`@kecrily/openapi-fetch`](https://www.npmjs.com/package/@kecrily/openapi-fetch) based on this PR before this PR is merged.