### PR TITLE
Fix monorepo release build

### DIFF
--- a/.changeset/spotty-eggs-tickle.md
+++ b/.changeset/spotty-eggs-tickle.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix CJS build

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "build": "run-p -s build:*",
-    "build:clean": "del packages/openapi-typescript/dist && del packages/openapi-fetch/dist",
-    "build:ts": "tsc -b packages/openapi-typescript/tsconfig.build.json packages/openapi-fetch/tsconfig.build.json",
+    "build:openapi-typescript": "cd packages/openapi-typescript && pnpm run build",
+    "build:openapi-fetch": "cd packages/openapi-fetch && pnpm run build",
     "lint": "run-p -s lint:*",
     "lint:openapi-typescript": "cd packages/openapi-typescript && pnpm run lint",
     "lint:openapi-fetch": "cd packages/openapi-fetch && pnpm run lint",


### PR DESCRIPTION
## Changes

Fixes #1185. The build triggered by the autorelease is different than the `build` script dictated by each package. While `openapi-typescript` was unaffected, `openapi-fetch` had missing files in the latest release.

## How to Review

Will have to release to check 🤞 

