### PR TITLE
Update README.md with `transform` example for `Blob`

### DIFF
--- a/.changeset/nasty-windows-chew.md
+++ b/.changeset/nasty-windows-chew.md
@@ -1,0 +1,6 @@
+---
+"openapi-typescript": patch
+"openapi-typescript-docs": patch
+---
+
+Add example for `Blob` type transforms

--- a/docs/src/content/docs/node.md
+++ b/docs/src/content/docs/node.md
@@ -45,6 +45,8 @@ Use the `transform()` and `postTransform()` options to override the default Sche
 - `transform()` runs **BEFORE** the conversion to TypeScript (you’re working with the original OpenAPI nodes)
 - `postTransform()` runs **AFTER** the conversion to TypeScript (you’re working with TypeScript types)
 
+#### Example: `Date` types
+
 For example, say your schema has the following property:
 
 ```yaml
@@ -71,6 +73,41 @@ That would result in the following change:
 ```diff
 -  updated_at?: string;
 +  updated_at?: Date;
+```
+
+#### Example: `Blob` types
+
+Another common transformation is for file uploads, where the `body` of a request is a `multipart/form-data` with some `Blob` fields. Here's an example schema:
+
+```yaml
+Body_file_upload:
+  type: object;
+  properties:
+    file:
+      type: string;
+      format: binary;
+    }
+  }
+}
+```
+
+Use the same pattern to transform the types:
+
+```ts
+const types = openapiTS(mySchema, {
+  transform(schemaObject, metadata): string {
+    if ("format" in schemaObject && schemaObject.format === "binary") {
+      return schemaObject.nullable ? "Blob | null" : "Blob";
+    }
+  },
+});
+```
+
+Resultant diff with correctly-typed `file` property:
+
+```diff
+-    file?: string;
++    file?: Blob;
 ```
 
 Any [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object) present in your schema will be run through this formatter (even remote ones!). Also be sure to check the `metadata` parameter for additional context that may be helpful.

--- a/packages/openapi-typescript/README.md
+++ b/packages/openapi-typescript/README.md
@@ -255,6 +255,39 @@ That would result in the following change:
 +  updated_at?: Date;
 ```
 
+Another common transformation is for file uploads, where the `body` of a request is a `multipart/form-data` with some `Blob` fields. Here's an example schema:
+
+```yaml
+Body_file_upload:
+  type: object;
+  properties:
+    file:
+      type: string;
+      format: binary;
+    }
+  }
+}
+```
+
+Use the same pattern to transform the types:
+
+```ts
+const types = openapiTS(mySchema, {
+  transform(schemaObject, metadata): string {
+    if ("format" in schemaObject && schemaObject.format === "binary") {
+      return schemaObject.nullable ? "Blob | null" : "Blob";
+    }
+  },
+});
+```
+
+Resultant diff with correctly-typed `file` property:
+
+```diff
+-    file?: string;
++    file?: Blob;
+```
+
 Any [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object) present in your schema will be run through this formatter (even remote ones!). Also be sure to check the `metadata` parameter for additional context that may be helpful.
 
 There are many other uses for this besides checking `format`. Because this must return a **string** you can produce any arbitrary TypeScript code you’d like (even your own custom types).


### PR DESCRIPTION
Add example `transform` callback for file uploads, where the `multipart/form-data` has a field that should be typed as `Blob`.

## Changes

Update the README with additional example for what I think is a common use-case.

## How to Review

Maybe this is extraneous? Dunno. I see the `stripe` API in `examples` has some schemas that should have this transformation done.

Should this transformation be the default behaviour?

## Checklist

- ~~[ ] Unit tests updated~~
- [x] README updated
- ~~[ ] `examples/` directory updated (only applicable for openapi-typescript)~~
