### PR TITLE
docs(openapi-ts): add docs for using Node.js API in web projects

### DIFF
--- a/.changeset/quick-parrots-worry.md
+++ b/.changeset/quick-parrots-worry.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript-docs": patch
+---
+
+Add docs for using Node.js API in web projects


### PR DESCRIPTION
## Changes

Update docs with examples for using the Node.js API in a project with a browser build target. 

## How to Review

I'm not sure if this deserved to be in the docs as it's only tangential to `openapi-typescript`, and I imagine most devs know how to set this up already. 

I, however, didn't know, and it took me an hour of going down stack-overflow garden paths before discovering `ts-node --esm`, so I figured I'd propose the changes.

## Checklist

- ~~[ ] Unit tests updated~~
- [x] README updated
- ~~[ ] `examples/` directory updated (only applicable for openapi-typescript)~~
