### PR TITLE
Use Node 20.x in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
       - uses: pnpm/action-setup@v2
         with:
           version: latest
-      - uses: actions/setup-node@v3
       - run: pnpm i
       - run: pnpm run build
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
       - uses: pnpm/action-setup@v2
         with:
           version: latest
-      - uses: actions/setup-node@v3
       - run: pnpm i
       - run: pnpm run lint
   test-node-versions:
@@ -38,23 +42,23 @@ jobs:
         node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-        with:
-          version: latest
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
       - run: pnpm i
       - run: pnpm test
   test-macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
       - uses: pnpm/action-setup@v2
         with:
           version: latest
-      - uses: actions/setup-node@v3
-        with:
-          version: 20
       - run: pnpm i
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 20
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
       - run: pnpm i
       - run: pnpm run build
       - uses: changesets/action@v1


### PR DESCRIPTION
## Changes

Node 18.x is used in GitHub Actions when 20.x would be faster.

## How to Review

N/A

## Checklist

N/A