### PR TITLE
Bump up test timeout

### DIFF
--- a/packages/openapi-typescript/test/cli.test.ts
+++ b/packages/openapi-typescript/test/cli.test.ts
@@ -4,43 +4,68 @@ import { URL } from "node:url";
 
 const cwd = new URL("../", import.meta.url);
 const cmd = "./bin/cli.js";
+const TIMEOUT = 90000;
 
 describe("CLI", () => {
   // note: the snapshots in index.test.ts test the Node API; these test the CLI
   describe("snapshots", () => {
-    test("GitHub API", async () => {
-      const expected = fs.readFileSync(new URL("./examples/github-api.ts", cwd), "utf8").trim();
-      const { stdout } = await execa(cmd, ["./examples/github-api.yaml"], { cwd });
-      expect(stdout).toBe(expected);
-    }, 30000);
-    test("GitHub API (next)", async () => {
-      const expected = fs.readFileSync(new URL("./examples/github-api-next.ts", cwd), "utf8").trim();
-      const { stdout } = await execa(cmd, ["./examples/github-api-next.yaml"], { cwd });
-      expect(stdout).toBe(expected);
-    }, 30000);
-    test("Octokit GHES 3.6 Diff to API", async () => {
-      const expected = fs.readFileSync(new URL("./examples/octokit-ghes-3.6-diff-to-api.ts", cwd), "utf8").trim();
-      const { stdout } = await execa(cmd, ["./examples/octokit-ghes-3.6-diff-to-api.json"], { cwd });
-      expect(stdout).toBe(expected);
-    }, 30000);
-    test("Stripe API", async () => {
-      const expected = fs.readFileSync(new URL("./examples/stripe-api.ts", cwd), "utf8").trim();
-      const { stdout } = await execa(cmd, ["./examples/stripe-api.yaml"], { cwd });
-      expect(stdout).toBe(expected);
-    }, 30000);
-    test("DigitalOcean API (remote $refs)", async () => {
-      const expected = fs.readFileSync(new URL("./examples/digital-ocean-api.ts", cwd), "utf8").trim();
-      const { stdout } = await execa(cmd, ["./examples/digital-ocean-api/DigitalOcean-public.v2.yaml"], {
-        cwd,
-      });
-      expect(stdout).toBe(expected);
-    }, 60000);
-    test("stdin", async () => {
-      const expected = fs.readFileSync(new URL("./examples/stripe-api.ts", cwd), "utf8").trim();
-      const input = fs.readFileSync(new URL("./examples/stripe-api.yaml", cwd));
-      const { stdout } = await execa(cmd, { input });
-      expect(stdout).toBe(expected);
-    }, 30000);
+    test(
+      "GitHub API",
+      async () => {
+        const expected = fs.readFileSync(new URL("./examples/github-api.ts", cwd), "utf8").trim();
+        const { stdout } = await execa(cmd, ["./examples/github-api.yaml"], { cwd });
+        expect(stdout).toBe(expected);
+      },
+      TIMEOUT
+    );
+    test(
+      "GitHub API (next)",
+      async () => {
+        const expected = fs.readFileSync(new URL("./examples/github-api-next.ts", cwd), "utf8").trim();
+        const { stdout } = await execa(cmd, ["./examples/github-api-next.yaml"], { cwd });
+        expect(stdout).toBe(expected);
+      },
+      TIMEOUT
+    );
+    test(
+      "Octokit GHES 3.6 Diff to API",
+      async () => {
+        const expected = fs.readFileSync(new URL("./examples/octokit-ghes-3.6-diff-to-api.ts", cwd), "utf8").trim();
+        const { stdout } = await execa(cmd, ["./examples/octokit-ghes-3.6-diff-to-api.json"], { cwd });
+        expect(stdout).toBe(expected);
+      },
+      TIMEOUT
+    );
+    test(
+      "Stripe API",
+      async () => {
+        const expected = fs.readFileSync(new URL("./examples/stripe-api.ts", cwd), "utf8").trim();
+        const { stdout } = await execa(cmd, ["./examples/stripe-api.yaml"], { cwd });
+        expect(stdout).toBe(expected);
+      },
+      TIMEOUT
+    );
+    test(
+      "DigitalOcean API (remote $refs)",
+      async () => {
+        const expected = fs.readFileSync(new URL("./examples/digital-ocean-api.ts", cwd), "utf8").trim();
+        const { stdout } = await execa(cmd, ["./examples/digital-ocean-api/DigitalOcean-public.v2.yaml"], {
+          cwd,
+        });
+        expect(stdout).toBe(expected);
+      },
+      TIMEOUT
+    );
+    test(
+      "stdin",
+      async () => {
+        const expected = fs.readFileSync(new URL("./examples/stripe-api.ts", cwd), "utf8").trim();
+        const input = fs.readFileSync(new URL("./examples/stripe-api.yaml", cwd));
+        const { stdout } = await execa(cmd, { input });
+        expect(stdout).toBe(expected);
+      },
+      TIMEOUT
+    );
   });
 
   describe("flags", () => {


### PR DESCRIPTION
## Changes

Not due to any perf regressions; this is just necessary for the macOS runner in GitHub Actions to complete the DigitalOcean snapshot test. Fortunately, bumping up a test timeout doesn’t slow it down; it merely _allows_ it to be slow when needed.

## How to Review

N/A

## Checklist

N/A