### PR TITLE
support boolean json schema

### DIFF
--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -20,6 +20,10 @@ export default function transformSchemaObject(schemaObject: SchemaObject | Refer
 export function defaultSchemaObjectTransform(schemaObject: SchemaObject | ReferenceObject, { path, ctx }: TransformSchemaObjectOptions): string {
   let { indentLv } = ctx;
 
+  // boolean schemas
+  if (typeof schemaObject === "boolean") {
+    return schemaObject ? "unknown" : "never";
+  }
   // const fallback (primitives) return passed value
   if (!schemaObject || typeof schemaObject !== "object") return schemaObject;
   // const fallback (array) return tuple

--- a/packages/openapi-typescript/test/schema-object.test.ts
+++ b/packages/openapi-typescript/test/schema-object.test.ts
@@ -23,6 +23,14 @@ const options: TransformSchemaObjectOptions = {
 };
 
 describe("Schema Object", () => {
+  describe("boolean schema", () => {
+    it("true", () => {
+      expect(transformSchemaObject(true as any, options)).toBe("unknown");
+    });
+    it("false", () => {
+      expect(transformSchemaObject(false as any, options)).toBe("never");
+    });
+  });
   describe("data types", () => {
     describe("string", () => {
       test("basic", () => {


### PR DESCRIPTION
## Changes

fixes #1227 

I wasn't able to update the `SchemaObject` type, adding `boolean | ` to it broke other stuff with long & cryptic errors, including
```
                Type 'ReferenceObject | OperationObject | undefined' is not assignable to type 'OperationObject | ReferenceObject | undefined'.
```

## Checklist

- [X] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (only applicable for openapi-typescript)
