### PR TITLE
Improve impossible body typing

### DIFF
--- a/.changeset/cold-pets-sit.md
+++ b/.changeset/cold-pets-sit.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix impossible body typing

--- a/packages/openapi-fetch/src/index.test.ts
+++ b/packages/openapi-fetch/src/index.test.ts
@@ -235,7 +235,7 @@ describe("client", () => {
 
         // expect error on missing `body`
         // @ts-expect-error
-        await client.GET("/blogposts", {});
+        await client.PUT("/blogposts", {});
 
         // expect error on missing fields
         // @ts-expect-error
@@ -401,9 +401,8 @@ describe("client", () => {
     it("returns empty object on 204", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 204, body: "" });
-      const { data, error, response } = await client.PUT("/tag/{name}", {
+      const { data, error, response } = await client.DELETE("/tag/{name}", {
         params: { path: { name: "New Tag" } },
-        body: { description: "This is a new tag" },
       });
 
       // assert correct data was returned

--- a/packages/openapi-fetch/src/index.ts
+++ b/packages/openapi-fetch/src/index.ts
@@ -51,7 +51,7 @@ export type Params<T> = T extends { parameters: any } ? { params: NonNullable<T[
 export type RequestBodyObj<T> = T extends { requestBody?: any } ? T["requestBody"] : never;
 export type RequestBodyContent<T> = undefined extends RequestBodyObj<T> ? FilterKeys<NonNullable<RequestBodyObj<T>>, "content"> | undefined : FilterKeys<RequestBodyObj<T>, "content">;
 export type RequestBodyMedia<T> = FilterKeys<RequestBodyContent<T>, MediaType> extends never ? FilterKeys<NonNullable<RequestBodyContent<T>>, MediaType> | undefined : FilterKeys<RequestBodyContent<T>, MediaType>;
-export type RequestBody<T> = undefined extends RequestBodyMedia<T> ? { body?: RequestBodyMedia<T> } : { body: RequestBodyMedia<T> };
+export type RequestBody<T> = RequestBodyMedia<T> extends never ? { body?: never } : undefined extends RequestBodyMedia<T> ? { body?: RequestBodyMedia<T> } : { body: RequestBodyMedia<T> };
 export type QuerySerializer<T> = (query: T extends { parameters: any } ? NonNullable<T["parameters"]["query"]> : Record<string, unknown>) => string;
 export type BodySerializer<T> = (body: RequestBodyMedia<T>) => any;
 export type RequestOptions<T> = Params<T> &

--- a/packages/openapi-fetch/test/v1.d.ts
+++ b/packages/openapi-fetch/test/v1.d.ts
@@ -176,6 +176,18 @@ export interface paths {
         500: components["responses"]["Error"];
       };
     };
+    delete: {
+      parameters: {
+        path: {
+          name: string;
+        };
+      };
+      responses: {
+        /** @description No Content */
+        204: never;
+        500: components["responses"]["Error"];
+      };
+    };
     parameters: {
       path: {
         name: string;

--- a/packages/openapi-fetch/test/v1.yaml
+++ b/packages/openapi-fetch/test/v1.yaml
@@ -190,6 +190,12 @@ paths:
           $ref: '#/components/responses/CreateTag'
         500:
           $ref: '#/components/responses/Error'
+    delete:
+      responses:
+        204:
+          description: No Content
+        500:
+          $ref: '#/components/responses/Error'
   /default-as-error:
     get:
       responses:


### PR DESCRIPTION
## Changes

Improves #1124 by adding better inference to “impossible” body types. But I think the real fix will come in #1280 which fixes the underlying typing for responses.

## How to Review

CI should pass.

## Checklist

N/A