### PR TITLE
Rename all methods to UPPERCASE

### DIFF
--- a/.changeset/witty-ears-change.md
+++ b/.changeset/witty-ears-change.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": minor
+---
+
+⚠️ Breaking: rename all methods to UPPERCASE (`GET()`, `POST()`, etc.)

--- a/docs/src/content/docs/openapi-fetch/api.md
+++ b/docs/src/content/docs/openapi-fetch/api.md
@@ -21,7 +21,7 @@ createClient<paths>(options);
 
 ## Fetch options
 
-The following options apply to all request methods (`.get()`, `.post()`, etc.)
+The following options apply to all request methods (`.GET()`, `.POST()`, etc.)
 
 ```ts
 client.get("/my-url", options);
@@ -43,7 +43,7 @@ client.get("/my-url", options);
 This library uses <a href="https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams" target="_blank" rel="noopener noreferrer">URLSearchParams</a> to <a href="https://swagger.io/docs/specification/serialization/" target="_blank" rel="noopener noreferrer">serialize query parameters</a>. For complex query param types (e.g. arrays) you’ll need to provide your own `querySerializer()` method that transforms query params into a URL-safe string:
 
 ```ts
-const { data, error } = await get("/search", {
+const { data, error } = await GET("/search", {
   params: {
     query: { tags: ["food", "california", "healthy"] },
   },
@@ -66,7 +66,7 @@ const { data, error } = await get("/search", {
 Similar to [querySerializer](#querySerializer), bodySerializer works for requestBody. You probably only need this when using `multipart/form-data`:
 
 ```ts
-const { data, error } = await put("/submit", {
+const { data, error } = await PUT("/submit", {
   body: {
     name: "",
     query: { version: 2 },

--- a/docs/src/content/docs/openapi-fetch/examples.md
+++ b/docs/src/content/docs/openapi-fetch/examples.md
@@ -30,9 +30,9 @@ export const client = computed(authToken, (currentToken) =>
 // src/some-other-file.ts
 import { client } from "./lib/api";
 
-const { get, post } = client.get();
+const { GET, POST } = client.get();
 
-get("/some-authenticated-url", {
+GET("/some-authenticated-url", {
   /* … */
 });
 ```
@@ -63,7 +63,7 @@ export default new Proxy(baseClient, {
 // src/some-other-file.ts
 import client from "./lib/api";
 
-client.get("/some-authenticated-url", {
+client.GET("/some-authenticated-url", {
   /* … */
 });
 ```
@@ -89,7 +89,7 @@ export default createClient({
 // src/some-other-file.ts
 import client from "./lib/api";
 
-client.get("/my/endpoint", {
+client.GET("/my/endpoint", {
   /* … */
 });
 ```
@@ -202,7 +202,7 @@ function useUser({ params, body, reactQuery }: UseQueryOptions<paths[typeof GET_
       // add any other hook dependencies here
     ],
     queryFn: async ({ signal }) => {
-      const { data, error } = await client.get(GET_USER, {
+      const { data, error } = await client.GET(GET_USER, {
         params,
         // body - isn’t used for GET, but needed for other request types
         signal, // allows React Query to cancel request

--- a/docs/src/content/docs/openapi-fetch/index.md
+++ b/docs/src/content/docs/openapi-fetch/index.md
@@ -19,10 +19,10 @@ The syntax is inspired by popular libraries like react-query or Apollo client, b
 import createClient from "openapi-fetch";
 import { paths } from "./v1"; // generated from openapi-typescript
 
-const { get, put } = createClient<paths>({ baseUrl: "https://myapi.dev/v1/" });
+const { GET, PUT } = createClient<paths>({ baseUrl: "https://myapi.dev/v1/" });
 
 // Type-checked request
-await put("/blogposts", {
+await PUT("/blogposts", {
   body: {
     title: "My New Post",
     // ❌ Property 'publish_date' is missing in type …
@@ -30,7 +30,7 @@ await put("/blogposts", {
 });
 
 // Type-checked response
-const { data, error } = await get("/blogposts/{post_id}", { params: { path: { post_id: "123" } } });
+const { data, error } = await GET("/blogposts/{post_id}", { params: { path: { post_id: "123" } } });
 console.log(data.title); // ❌ 'data' is possibly 'undefined'
 console.log(error.message); // ❌ 'error' is possibly 'undefined'
 console.log(data?.foo); // ❌ Property 'foo' does not exist on type …
@@ -90,16 +90,16 @@ Here’s how you’d fetch GET `/blogposts/{post_id}` and PUT `/blogposts`:
 import createClient from "openapi-fetch";
 import { paths } from "./v1";
 
-const { get, put } = createClient<paths>({ baseUrl: "https://myapi.dev/v1/" });
+const { GET, PUT } = createClient<paths>({ baseUrl: "https://myapi.dev/v1/" });
 
-const { data, error } = await get("/blogposts/{post_id}", {
+const { data, error } = await GET("/blogposts/{post_id}", {
   params: {
     path: { post_id: "my-post" },
     query: { version: 2 },
   },
 });
 
-const { data, error } = await put("/blogposts", {
+const { data, error } = await PUT("/blogposts", {
   body: {
     title: "New Post",
     body: "<p>New post body</p>",
@@ -110,7 +110,7 @@ const { data, error } = await put("/blogposts", {
 
 ### Pathname
 
-The pathname of `get()`, `put()`, `post()`, etc. **must match your schema literally.** Note in the example, the URL is `/blogposts/{post_id}`. This library will replace all `path` params for you (so they can be typechecked)
+The pathname of `GET()`, `PUT()`, `POST()`, etc. **must match your schema literally.** Note in the example, the URL is `/blogposts/{post_id}`. This library will replace all `path` params for you (so they can be typechecked)
 
 > ✨ **Tip**
 >
@@ -121,9 +121,9 @@ The pathname of `get()`, `put()`, `post()`, etc. **must match your schema litera
 
 ### Request
 
-The `get()` request shown needed the `params` object that groups <a href="https://spec.openapis.org/oas/latest.html#parameter-object" target="_blank" rel="noopener noreferrer">parameters by type</a> (`path` or `query`). If a required param is missing, or the wrong type, a type error will be thrown.
+The `GET()` request shown needed the `params` object that groups <a href="https://spec.openapis.org/oas/latest.html#parameter-object" target="_blank" rel="noopener noreferrer">parameters by type</a> (`path` or `query`). If a required param is missing, or the wrong type, a type error will be thrown.
 
-The `post()` request required a `body` object that provided all necessary <a href="https://spec.openapis.org/oas/latest.html#request-body-object" target="_blank" rel="noopener noreferrer">requestBody</a> data.
+The `POST()` request required a `body` object that provided all necessary <a href="https://spec.openapis.org/oas/latest.html#request-body-object" target="_blank" rel="noopener noreferrer">requestBody</a> data.
 
 ### Response
 

--- a/packages/openapi-fetch/README.md
+++ b/packages/openapi-fetch/README.md
@@ -14,10 +14,10 @@ The syntax is inspired by popular libraries like react-query or Apollo client, b
 import createClient from "openapi-fetch";
 import { paths } from "./v1"; // (generated from openapi-typescript)
 
-const { get, post } = createClient<paths>({ baseUrl: "https://myapi.dev/v1/" });
+const { GET, POST } = createClient<paths>({ baseUrl: "https://myapi.dev/v1/" });
 
 // Type-checked request
-await post("/create-post", {
+await POST("/create-post", {
   body: {
     title: "My New Post",
     // ❌ Property 'publish_date' is missing in type …
@@ -25,7 +25,7 @@ await post("/create-post", {
 });
 
 // Type-checked response
-const { data, error } = await get("/blogposts/my-blog-post");
+const { data, error } = await GET("/blogposts/my-blog-post");
 
 console.log(data.title); // ❌ 'data' is possibly 'undefined'
 console.log(error.message); // ❌ 'error' is possibly 'undefined'
@@ -86,16 +86,16 @@ Here’s how you’d fetch GET `/blogposts/{post_id}` and PUT `/blogposts`:
 import createClient from "openapi-fetch";
 import { paths } from "./v1";
 
-const { get, put } = createClient<paths>({ baseUrl: "https://myapi.dev/v1/" });
+const { GET, PUT } = createClient<paths>({ baseUrl: "https://myapi.dev/v1/" });
 
-const { data, error } = await get("/blogposts/{post_id}", {
+const { data, error } = await GET("/blogposts/{post_id}", {
   params: {
     path: { post_id: "my-post" },
     query: { version: 2 },
   },
 });
 
-const { data, error } = await put("/blogposts", {
+const { data, error } = await PUT("/blogposts", {
   body: {
     title: "New Post",
     body: "<p>New post body</p>",

--- a/packages/openapi-fetch/src/index.test.ts
+++ b/packages/openapi-fetch/src/index.test.ts
@@ -32,14 +32,14 @@ describe("client", () => {
   it("generates all proper functions", () => {
     const client = createClient<paths>();
 
-    expect(client).toHaveProperty("get");
-    expect(client).toHaveProperty("put");
-    expect(client).toHaveProperty("post");
-    expect(client).toHaveProperty("del");
-    expect(client).toHaveProperty("options");
-    expect(client).toHaveProperty("head");
-    expect(client).toHaveProperty("patch");
-    expect(client).toHaveProperty("trace");
+    expect(client).toHaveProperty("GET");
+    expect(client).toHaveProperty("PUT");
+    expect(client).toHaveProperty("POST");
+    expect(client).toHaveProperty("DELETE");
+    expect(client).toHaveProperty("OPTIONS");
+    expect(client).toHaveProperty("HEAD");
+    expect(client).toHaveProperty("PATCH");
+    expect(client).toHaveProperty("TRACE");
   });
 
   describe("TypeScript checks", () => {
@@ -48,7 +48,7 @@ describe("client", () => {
 
       // data
       mockFetchOnce({ status: 200, body: JSON.stringify(["one", "two", "three"]) });
-      const dataRes = await client.get("/string-array", {});
+      const dataRes = await client.GET("/string-array", {});
 
       // … is initially possibly undefined
       // @ts-expect-error
@@ -67,7 +67,7 @@ describe("client", () => {
 
       // error
       mockFetchOnce({ status: 500, body: JSON.stringify({ code: 500, message: "Something went wrong" }) });
-      const errorRes = await client.get("/string-array", {});
+      const errorRes = await client.GET("/string-array", {});
 
       // … is initially possibly undefined
       // @ts-expect-error
@@ -92,22 +92,22 @@ describe("client", () => {
 
         // expect error on missing 'params'
         // @ts-expect-error
-        await client.get("/blogposts/{post_id}", {});
+        await client.GET("/blogposts/{post_id}", {});
 
         // expect error on empty params
         // @ts-expect-error
-        await client.get("/blogposts/{post_id}", { params: {} });
+        await client.GET("/blogposts/{post_id}", { params: {} });
 
         // expect error on empty params.path
         // @ts-expect-error
-        await client.get("/blogposts/{post_id}", { params: { path: {} } });
+        await client.GET("/blogposts/{post_id}", { params: { path: {} } });
 
         // expect error on mismatched type (number v string)
         // @ts-expect-error
-        await client.get("/blogposts/{post_id}", { params: { path: { post_id: 1234 } } });
+        await client.GET("/blogposts/{post_id}", { params: { path: { post_id: 1234 } } });
 
         // (no error)
-        await client.get("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
+        await client.GET("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
 
         // expect param passed correctly
         const lastCall = fetchMocker.mock.calls[fetchMocker.mock.calls.length - 1];
@@ -120,18 +120,18 @@ describe("client", () => {
 
         // expet error on missing header
         // @ts-expect-error
-        await client.get("/header-params", {});
+        await client.GET("/header-params", {});
 
         // expect error on incorrect header
         // @ts-expect-error
-        await client.get("/header-params", { params: { header: { foo: "bar" } } });
+        await client.GET("/header-params", { params: { header: { foo: "bar" } } });
 
         // expect error on mismatched type
         // @ts-expect-error
-        await client.get("/header-params", { params: { header: { "x-required-header": true } } });
+        await client.GET("/header-params", { params: { header: { "x-required-header": true } } });
 
         // (no error)
-        await client.get("/header-params", { params: { header: { "x-required-header": "correct" } } });
+        await client.GET("/header-params", { params: { header: { "x-required-header": "correct" } } });
 
         // expect param passed correctly
         const lastCall = fetchMocker.mock.calls[fetchMocker.mock.calls.length - 1];
@@ -142,7 +142,7 @@ describe("client", () => {
         it("basic", async () => {
           const client = createClient<paths>();
           mockFetchOnce({ status: 200, body: "{}" });
-          await client.get("/blogposts/{post_id}", {
+          await client.GET("/blogposts/{post_id}", {
             params: {
               path: { post_id: "my-post" },
               query: { version: 2, format: "json" },
@@ -155,7 +155,7 @@ describe("client", () => {
         it("array params", async () => {
           const client = createClient<paths>();
           mockFetchOnce({ status: 200, body: "{}" });
-          await client.get("/blogposts", {
+          await client.GET("/blogposts", {
             params: {
               query: { tags: ["one", "two", "three"] },
             },
@@ -167,7 +167,7 @@ describe("client", () => {
         it("empty/null params", async () => {
           const client = createClient<paths>();
           mockFetchOnce({ status: 200, body: "{}" });
-          await client.get("/blogposts/{post_id}", {
+          await client.GET("/blogposts/{post_id}", {
             params: {
               path: { post_id: "my-post" },
               query: { version: undefined, format: null as any },
@@ -181,7 +181,7 @@ describe("client", () => {
           it("custom", async () => {
             const client = createClient<paths>();
             mockFetchOnce({ status: 200, body: "{}" });
-            await client.get("/blogposts/{post_id}", {
+            await client.GET("/blogposts/{post_id}", {
               params: {
                 path: { post_id: "my-post" },
                 query: { version: 2, format: "json" },
@@ -197,7 +197,7 @@ describe("client", () => {
               querySerializer: (q) => `alpha=${q.version}&beta=${q.format}`,
             });
             mockFetchOnce({ status: 200, body: "{}" });
-            await client.get("/blogposts/{post_id}", {
+            await client.GET("/blogposts/{post_id}", {
               params: {
                 path: { post_id: "my-post" },
                 query: { version: 2, format: "json" },
@@ -212,7 +212,7 @@ describe("client", () => {
               querySerializer: () => "query",
             });
             mockFetchOnce({ status: 200, body: "{}" });
-            await client.get("/blogposts/{post_id}", {
+            await client.GET("/blogposts/{post_id}", {
               params: {
                 path: { post_id: "my-post" },
                 query: { version: 2, format: "json" },
@@ -233,15 +233,15 @@ describe("client", () => {
 
         // expect error on missing `body`
         // @ts-expect-error
-        await client.get("/blogposts", {});
+        await client.GET("/blogposts", {});
 
         // expect error on missing fields
         // @ts-expect-error
-        await client.put("/blogposts", { body: { title: "Foo" } });
+        await client.PUT("/blogposts", { body: { title: "Foo" } });
 
         // expect present body to be good enough (all fields optional)
         // (no error)
-        await client.put("/blogposts", {
+        await client.PUT("/blogposts", {
           body: { title: "Foo", body: "Bar", publish_date: new Date("2023-04-01T12:00:00Z").getTime() },
         });
       });
@@ -252,10 +252,10 @@ describe("client", () => {
 
         // expect error on wrong body type
         // @ts-expect-error
-        await client.put("/blogposts-optional-inline", { body: { error: true } });
+        await client.PUT("/blogposts-optional-inline", { body: { error: true } });
 
         // (no error)
-        await client.put("/blogposts-optional-inline", {
+        await client.PUT("/blogposts-optional-inline", {
           body: {
             title: "",
             publish_date: 3,
@@ -269,14 +269,14 @@ describe("client", () => {
         const client = createClient<paths>();
 
         // assert missing `body` doesn’t raise a TS error
-        await client.put("/blogposts-optional", {});
+        await client.PUT("/blogposts-optional", {});
 
         // assert error on type mismatch
         // @ts-expect-error
-        await client.put("/blogposts-optional", { body: { error: true } });
+        await client.PUT("/blogposts-optional", { body: { error: true } });
 
         // (no error)
-        await client.put("/blogposts-optional", {
+        await client.PUT("/blogposts-optional", {
           body: {
             title: "",
             publish_date: 3,
@@ -291,13 +291,13 @@ describe("client", () => {
     it("respects baseUrl", async () => {
       let client = createClient<paths>({ baseUrl: "https://myapi.com/v1" });
       mockFetch({ status: 200, body: JSON.stringify({ message: "OK" }) });
-      await client.get("/self", {});
+      await client.GET("/self", {});
 
       // assert baseUrl and path mesh as expected
       expect(fetchMocker.mock.calls[0][0]).toBe("https://myapi.com/v1/self");
 
       client = createClient<paths>({ baseUrl: "https://myapi.com/v1/" });
-      await client.get("/self", {});
+      await client.GET("/self", {});
       // assert trailing '/' was removed
       expect(fetchMocker.mock.calls[1][0]).toBe("https://myapi.com/v1/self");
     });
@@ -307,7 +307,7 @@ describe("client", () => {
 
       const client = createClient<paths>({ headers });
       mockFetchOnce({ status: 200, body: JSON.stringify({ email: "user@user.com" }) });
-      await client.get("/self", {});
+      await client.GET("/self", {});
 
       // assert default headers were passed
       const options = fetchMocker.mock.calls[0][1];
@@ -322,7 +322,7 @@ describe("client", () => {
     it("allows override headers", async () => {
       const client = createClient<paths>({ headers: { "Cache-Control": "max-age=10000000" } });
       mockFetchOnce({ status: 200, body: JSON.stringify({ email: "user@user.com" }) });
-      await client.get("/self", { params: {}, headers: { "Cache-Control": "no-cache" } });
+      await client.GET("/self", { params: {}, headers: { "Cache-Control": "no-cache" } });
 
       // assert default headers were passed
       const options = fetchMocker.mock.calls[0][1];
@@ -346,7 +346,7 @@ describe("client", () => {
       const client = createClient<paths>({
         fetch: async () => Promise.resolve(customFetch as Response),
       });
-      expect((await client.get("/self", {})).data).toBe(data);
+      expect((await client.GET("/self", {})).data).toBe(data);
     });
   });
 
@@ -354,7 +354,7 @@ describe("client", () => {
     it("escapes URLs properly", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      await client.get("/blogposts/{post_id}", {
+      await client.GET("/blogposts/{post_id}", {
         params: {
           path: {
             post_id: "post?id = 🥴",
@@ -369,7 +369,7 @@ describe("client", () => {
     it("multipart/form-data", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      const { data } = await client.put("/contact", {
+      const { data } = await client.PUT("/contact", {
         body: {
           name: "John Doe",
           email: "test@email.email",
@@ -398,7 +398,7 @@ describe("client", () => {
     it("returns empty object on 204", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 204, body: "" });
-      const { data, error, response } = await client.put("/tag/{name}", {
+      const { data, error, response } = await client.PUT("/tag/{name}", {
         params: { path: { name: "New Tag" } },
         body: { description: "This is a new tag" },
       });
@@ -414,7 +414,7 @@ describe("client", () => {
     it("treats `default` as an error", async () => {
       const client = createClient<paths>({ headers: { "Cache-Control": "max-age=10000000" } });
       mockFetchOnce({ status: 500, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ code: 500, message: "An unexpected error occurred" }) });
-      const { error } = await client.get("/default-as-error", {});
+      const { error } = await client.GET("/default-as-error", {});
 
       // discard `data` object
       if (!error) throw new Error("treats `default` as an error: error response should be present");
@@ -427,38 +427,38 @@ describe("client", () => {
       it("text", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.get("/anyMethod", { parseAs: "text" });
+        const { data } = await client.GET("/anyMethod", { parseAs: "text" });
         expect(data).toBe("{}");
       });
 
       it("arrayBuffer", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.get("/anyMethod", { parseAs: "arrayBuffer" });
+        const { data } = await client.GET("/anyMethod", { parseAs: "arrayBuffer" });
         expect(data instanceof ArrayBuffer).toBe(true);
       });
 
       it("blob", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.get("/anyMethod", { parseAs: "blob" });
+        const { data } = await client.GET("/anyMethod", { parseAs: "blob" });
         expect((data as any).constructor.name).toBe("Blob");
       });
 
       it("stream", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.get("/anyMethod", { parseAs: "stream" });
+        const { data } = await client.GET("/anyMethod", { parseAs: "stream" });
         expect(data instanceof Buffer).toBe(true);
       });
     });
   });
 
-  describe("get()", () => {
+  describe("GET()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      await client.get("/anyMethod", {});
+      await client.GET("/anyMethod", {});
       expect(fetchMocker.mock.calls[0][1]?.method).toBe("GET");
     });
 
@@ -466,7 +466,7 @@ describe("client", () => {
       const mockData = { title: "My Post", body: "<p>This is a very good post</p>", publish_date: new Date("2023-03-01T12:00:00Z").getTime() };
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: JSON.stringify(mockData) });
-      const { data, error, response } = await client.get("/blogposts/{post_id}", {
+      const { data, error, response } = await client.GET("/blogposts/{post_id}", {
         params: { path: { post_id: "my-post" } },
       });
 
@@ -485,7 +485,7 @@ describe("client", () => {
       const mockError = { code: 404, message: "Post not found" };
       const client = createClient<paths>();
       mockFetchOnce({ status: 404, body: JSON.stringify(mockError) });
-      const { data, error, response } = await client.get("/blogposts/{post_id}", {
+      const { data, error, response } = await client.GET("/blogposts/{post_id}", {
         params: { path: { post_id: "my-post" } },
       });
 
@@ -507,7 +507,7 @@ describe("client", () => {
     it("handles array-type responses", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "[]" });
-      const { data } = await client.get("/blogposts", { params: {} });
+      const { data } = await client.GET("/blogposts", { params: {} });
       if (!data) throw new Error("data empty");
 
       // assert array type (and only array type) was inferred
@@ -515,11 +515,11 @@ describe("client", () => {
     });
   });
 
-  describe("post()", () => {
+  describe("POST()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      await client.post("/anyMethod", {});
+      await client.POST("/anyMethod", {});
       expect(fetchMocker.mock.calls[0][1]?.method).toBe("POST");
     });
 
@@ -527,7 +527,7 @@ describe("client", () => {
       const mockData = { status: "success" };
       const client = createClient<paths>();
       mockFetchOnce({ status: 201, body: JSON.stringify(mockData) });
-      const { data, error, response } = await client.put("/blogposts", {
+      const { data, error, response } = await client.PUT("/blogposts", {
         body: {
           title: "New Post",
           body: "<p>Best post yet</p>",
@@ -550,7 +550,7 @@ describe("client", () => {
       const mockData = { message: "My reply" };
       const client = createClient<paths>();
       mockFetchOnce({ status: 201, body: JSON.stringify(mockData) });
-      const { data, error, response } = await client.put("/comment", {
+      const { data, error, response } = await client.PUT("/comment", {
         params: {},
         body: {
           message: "My reply",
@@ -567,18 +567,18 @@ describe("client", () => {
     });
   });
 
-  describe("delete()", () => {
+  describe("DELETE()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      await client.del("/anyMethod", {});
+      await client.DELETE("/anyMethod", {});
       expect(fetchMocker.mock.calls[0][1]?.method).toBe("DELETE");
     });
 
     it("returns empty object on 204", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 204, body: "" });
-      const { data, error } = await client.del("/blogposts/{post_id}", {
+      const { data, error } = await client.DELETE("/blogposts/{post_id}", {
         params: {
           path: { post_id: "123" },
         },
@@ -594,7 +594,7 @@ describe("client", () => {
     it("returns empty object on Content-Length: 0", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ headers: { "Content-Length": "0" }, status: 200, body: "" });
-      const { data, error } = await client.del("/blogposts/{post_id}", {
+      const { data, error } = await client.DELETE("/blogposts/{post_id}", {
         params: {
           path: { post_id: "123" },
         },
@@ -608,38 +608,38 @@ describe("client", () => {
     });
   });
 
-  describe("options()", () => {
+  describe("OPTIONS()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      await client.options("/anyMethod", {});
+      await client.OPTIONS("/anyMethod", {});
       expect(fetchMocker.mock.calls[0][1]?.method).toBe("OPTIONS");
     });
   });
 
-  describe("head()", () => {
+  describe("HEAD()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      await client.head("/anyMethod", {});
+      await client.HEAD("/anyMethod", {});
       expect(fetchMocker.mock.calls[0][1]?.method).toBe("HEAD");
     });
   });
 
-  describe("patch()", () => {
+  describe("PATCH()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      await client.patch("/anyMethod", {});
+      await client.PATCH("/anyMethod", {});
       expect(fetchMocker.mock.calls[0][1]?.method).toBe("PATCH");
     });
   });
 
-  describe("trace()", () => {
+  describe("TRACE()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>();
       mockFetchOnce({ status: 200, body: "{}" });
-      await client.trace("/anyMethod", {});
+      await client.TRACE("/anyMethod", {});
       expect(fetchMocker.mock.calls[0][1]?.method).toBe("TRACE");
     });
   });
@@ -653,7 +653,7 @@ describe("examples", () => {
 
     // assert initial call is unauthenticated
     mockFetchOnce({ status: 200, body: "{}" });
-    await client.get().get("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
+    await client.get().GET("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
     expect(fetchMocker.mock.calls[0][1].headers.get("authorization")).toBeNull();
 
     // assert after setting token, client is authenticated
@@ -665,7 +665,7 @@ describe("examples", () => {
         resolve();
       }, 0)
     );
-    await client.get().get("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
+    await client.get().GET("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
     expect(fetchMocker.mock.calls[1][1].headers.get("authorization")).toBe(`Bearer ${tokenVal}`);
   });
 
@@ -682,7 +682,7 @@ describe("examples", () => {
 
     // assert initial call is unauthenticated
     mockFetchOnce({ status: 200, body: "{}" });
-    await client.get("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
+    await client.GET("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
     expect(fetchMocker.mock.calls[0][1].headers.get("authorization")).toBeNull();
 
     // assert after setting token, client is authenticated
@@ -694,7 +694,7 @@ describe("examples", () => {
         resolve();
       }, 0)
     );
-    await client.get("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
+    await client.GET("/blogposts/{post_id}", { params: { path: { post_id: "1234" } } });
     expect(fetchMocker.mock.calls[1][1].headers.get("authorization")).toBe(`Bearer ${tokenVal}`);
   });
 });

--- a/packages/openapi-fetch/src/index.ts
+++ b/packages/openapi-fetch/src/index.ts
@@ -115,35 +115,35 @@ export default function createClient<Paths extends {}>(clientOptions: ClientOpti
 
   return {
     /** Call a GET endpoint */
-    async get<P extends PathsWith<Paths, "get">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "get">>) {
+    async GET<P extends PathsWith<Paths, "get">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "get">>) {
       return coreFetch<P, "get">(url, { ...init, method: "GET" } as any);
     },
     /** Call a PUT endpoint */
-    async put<P extends PathsWith<Paths, "put">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "put">>) {
+    async PUT<P extends PathsWith<Paths, "put">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "put">>) {
       return coreFetch<P, "put">(url, { ...init, method: "PUT" } as any);
     },
     /** Call a POST endpoint */
-    async post<P extends PathsWith<Paths, "post">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "post">>) {
+    async POST<P extends PathsWith<Paths, "post">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "post">>) {
       return coreFetch<P, "post">(url, { ...init, method: "POST" } as any);
     },
     /** Call a DELETE endpoint */
-    async del<P extends PathsWith<Paths, "delete">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "delete">>) {
+    async DELETE<P extends PathsWith<Paths, "delete">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "delete">>) {
       return coreFetch<P, "delete">(url, { ...init, method: "DELETE" } as any);
     },
     /** Call a OPTIONS endpoint */
-    async options<P extends PathsWith<Paths, "options">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "options">>) {
+    async OPTIONS<P extends PathsWith<Paths, "options">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "options">>) {
       return coreFetch<P, "options">(url, { ...init, method: "OPTIONS" } as any);
     },
     /** Call a HEAD endpoint */
-    async head<P extends PathsWith<Paths, "head">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "head">>) {
+    async HEAD<P extends PathsWith<Paths, "head">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "head">>) {
       return coreFetch<P, "head">(url, { ...init, method: "HEAD" } as any);
     },
     /** Call a PATCH endpoint */
-    async patch<P extends PathsWith<Paths, "patch">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "patch">>) {
+    async PATCH<P extends PathsWith<Paths, "patch">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "patch">>) {
       return coreFetch<P, "patch">(url, { ...init, method: "PATCH" } as any);
     },
     /** Call a TRACE endpoint */
-    async trace<P extends PathsWith<Paths, "trace">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "trace">>) {
+    async TRACE<P extends PathsWith<Paths, "trace">>(url: P, init: FetchOptions<FilterKeys<Paths[P], "trace">>) {
       return coreFetch<P, "trace">(url, { ...init, method: "TRACE" } as any);
     },
   };


### PR DESCRIPTION
## Changes

Renames all methods to uppercase, following discussion of #1218.

Particularly pertinent is SvelteKit’s prior art of also using uppercase methods ([discussion](https://github.com/sveltejs/kit/discussions/5359)). It’s an exact overlap, and I think this discussion alone makes more than enough reason to make the change (plus, aligning with SvelteKit is never a bad thing 🙂).

## How to Review

Tests should pass.

## Checklist

- [x] Unit tests updated
- [x] README updated
- [ ] `examples/` directory updated (only applicable for openapi-typescript)
