### PR TITLE
Fix openapi-fetch size

### DIFF
--- a/docs/src/content/docs/openapi-fetch/examples.md
+++ b/docs/src/content/docs/openapi-fetch/examples.md
@@ -70,7 +70,7 @@ client.GET("/some-authenticated-url", {
 
 ## Caching
 
-openapi-fetch doesn’t provide any caching utilities (it’s 1 kb, remember?). But this library is so lightweight, caching can be added easily.
+openapi-fetch doesn’t provide any caching utilities. But this library is so lightweight, caching can be added easily.
 
 ### Built-in Fetch caching
 

--- a/docs/src/content/docs/openapi-fetch/index.md
+++ b/docs/src/content/docs/openapi-fetch/index.md
@@ -5,7 +5,7 @@ description: Get Started with openapi-fetch
 
 <img src="/assets/openapi-fetch.svg" alt="openapi-fetch" width="216" height="40" />
 
-openapi-fetch applies your OpenAPI types to the native fetch API via TypeScript. Weighs in at **2 kb** and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.
+openapi-fetch applies your OpenAPI types to the native fetch API via TypeScript. Weighs **2 kb** and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.
 
 | Library                        | Size (min) |
 | :----------------------------- | ---------: |
@@ -13,7 +13,7 @@ openapi-fetch applies your OpenAPI types to the native fetch API via TypeScript.
 | **openapi-typescript-fetch**   |     `4 kB` |
 | **openapi-typescript-codegen** |   `345 kB` |
 
-The syntax is inspired by popular libraries like react-query or Apollo client, but without all the bells and whistles and in a 1 kb package.
+The syntax is inspired by popular libraries like react-query or Apollo client, but without all the bells and whistles and in a 2 kb package.
 
 ```ts
 import createClient from "openapi-fetch";

--- a/packages/openapi-fetch/README.md
+++ b/packages/openapi-fetch/README.md
@@ -1,6 +1,6 @@
 <img src="../../docs/public/assets/openapi-fetch.svg" alt="openapi-fetch" width="216" height="40" />
 
-openapi-fetch applies your OpenAPI types to the native fetch API via TypeScript. Weighs in at **2 kb** and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.
+openapi-fetch applies your OpenAPI types to the native fetch API via TypeScript. Weighs **2 kb** and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.
 
 | Library                        | Size (min) |
 | :----------------------------- | ---------: |
@@ -8,7 +8,7 @@ openapi-fetch applies your OpenAPI types to the native fetch API via TypeScript.
 | **openapi-typescript-fetch**   |     `4 kB` |
 | **openapi-typescript-codegen** |   `345 kB` |
 
-The syntax is inspired by popular libraries like react-query or Apollo client, but without all the bells and whistles and in a 1 kb package.
+The syntax is inspired by popular libraries like react-query or Apollo client, but without all the bells and whistles and in a 2 kb package.
 
 ```ts
 import createClient from "openapi-fetch";

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-fetch",
-  "description": "Fetch using your OpenAPI types. Weighs in at 1 kb and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.",
+  "description": "Fetch using your OpenAPI types. Weighs 2 kb and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.",
   "version": "0.7.0",
   "author": {
     "name": "Drew Powers",


### PR DESCRIPTION
## Changes

The sad day has come `openapi-fetch` has reached 2 kb 😱. Rest assured we will work diligently to remove all the added bloat in the future. But until then, fix the inconsistent size reporting.

Docs-only change.