### PR TITLE
Fix 2XX, 4XX, 5XX responses

### DIFF
--- a/.changeset/stale-shoes-sell.md
+++ b/.changeset/stale-shoes-sell.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix 2XX, 4XX, 5XX responses

--- a/packages/openapi-fetch/src/index.test.ts
+++ b/packages/openapi-fetch/src/index.test.ts
@@ -516,6 +516,21 @@ describe("client", () => {
       // assert array type (and only array type) was inferred
       expect(data.length).toBe(0);
     });
+
+    it("handles literal 2XX and 4XX codes", async () => {
+      const client = createClient<paths>();
+      mockFetch({ status: 201, body: '{"status": "success"}' });
+      const { data, error } = await client.PUT("/media", { body: { media: "base64", name: "myImage" } });
+
+      if (data) {
+        // assert 2XX type inferred correctly
+        expect(data.status).toBe("success");
+      } else {
+        // assert 4XX type inferred correctly
+        // (this should be a dead code path but tests TS types)
+        expect(error.message).toBe("Error");
+      }
+    });
   });
 
   describe("POST()", () => {

--- a/packages/openapi-fetch/src/index.ts
+++ b/packages/openapi-fetch/src/index.ts
@@ -29,9 +29,9 @@ export interface OperationObject {
   responses: any;
 }
 export type HttpMethod = "get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace";
-export type OkStatus = 200 | 201 | 202 | 203 | 204 | 206 | 207;
+export type OkStatus = 200 | 201 | 202 | 203 | 204 | 206 | 207 | "2XX";
 // prettier-ignore
-export type ErrorStatus = 500 | 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 408 | 409 | 410 | 411 | 412 | 413 | 414 | 415 | 416 | 417 | 418 | 420 | 421 | 422 | 423 | 424 | 425 | 426 | 429 | 431 | 444 | 450 | 451 | 497 | 498 | 499 | "default";
+export type ErrorStatus = 500 | '5XX' | 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 408 | 409 | 410 | 411 | 412 | 413 | 414 | 415 | 416 | 417 | 418 | 420 | 421 | 422 | 423 | 424 | 425 | 426 | 429 | 431 | 444 | 450 | 451 | 497 | 498 | 499 | '4XX' | "default";
 
 // util
 /** Get a union of paths which have method */

--- a/packages/openapi-fetch/test/v1.d.ts
+++ b/packages/openapi-fetch/test/v1.d.ts
@@ -112,6 +112,29 @@ export interface paths {
   "/header-params": {
     get: operations["getHeaderParams"];
   };
+  "/media": {
+    put: {
+      requestBody: {
+        content: {
+          "application/json": {
+            /** Format: blob */
+            media: string;
+            name: string;
+          };
+        };
+      };
+      responses: {
+        "2XX": {
+          content: {
+            "application/json": {
+              status: string;
+            };
+          };
+        };
+        "4XX": components["responses"]["Error"];
+      };
+    };
+  };
   "/self": {
     get: {
       responses: {

--- a/packages/openapi-fetch/test/v1.yaml
+++ b/packages/openapi-fetch/test/v1.yaml
@@ -123,6 +123,36 @@ paths:
                   - status
         500:
           $ref: '#/components/responses/Error'
+  /media:
+    put:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                media:
+                  type: string
+                  format: blob
+                name:
+                  type: string
+              required:
+                - media
+                - name
+      responses:
+        2XX:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                required:
+                  - status
+        4XX:
+          $ref: '#/components/responses/Error'
   /self:
     get:
       responses:

--- a/packages/openapi-typescript/test/operation-object.test.ts
+++ b/packages/openapi-typescript/test/operation-object.test.ts
@@ -1,0 +1,72 @@
+import type { GlobalContext, OperationObject } from "../src/types.js";
+import transformOperationObject from "../src/transform/operation-object.js";
+
+const ctx: GlobalContext = {
+  additionalProperties: false,
+  alphabetize: false,
+  defaultNonNullable: false,
+  discriminators: {},
+  emptyObjectsUnknown: false,
+  immutableTypes: false,
+  indentLv: 0,
+  operations: {},
+  parameters: {},
+  pathParamsAsTypes: false,
+  postTransform: undefined,
+  silent: true,
+  supportArrayLength: false,
+  transform: undefined,
+  excludeDeprecated: false,
+};
+
+describe("Operation Object", () => {
+  it("allows 2XX codes", () => {
+    const schema: OperationObject = {
+      responses: {
+        "2XX": {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: { type: "string" },
+            },
+          },
+        },
+        "4XX": {
+          description: "OK",
+          content: {
+            "application/json": { schema: { $ref: 'components["schemas"]["Error"]' } },
+          },
+        },
+        "5XX": {
+          description: "OK",
+          content: {
+            "application/json": { schema: { $ref: 'components["schemas"]["Error"]' } },
+          },
+        },
+      },
+    };
+    const generated = transformOperationObject(schema, { ctx, path: "#/paths/~get-item" });
+    expect(generated).toBe(`{
+  responses: {
+    /** @description OK */
+    "2XX": {
+      content: {
+        "application/json": string;
+      };
+    };
+    /** @description OK */
+    "4XX": {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+    /** @description OK */
+    "5XX": {
+      content: {
+        "application/json": components["schemas"]["Error"];
+      };
+    };
+  };
+}`);
+  });
+});


### PR DESCRIPTION
## Changes

Adds support for `2XX`, `4XX`, and `5XX` responses in schema, which is [supported by the spec](https://spec.openapis.org/oas/v3.1.0#x4-8-16-2-patterned-fields).

Funny enough, I have never used this or seen this; just happened to skim over that definition and saw it was allowed. In `openapi-typescript` we just skip right over this and don’t need to handle it. But `openapi-fetch` needed to add this for proper support.

## How to Review

Tests should pass.

## Checklist

- [x] Unit tests updated
- [ ] README updated
- [ ] `examples/` directory updated (only applicable for openapi-typescript)
