### PR TITLE
Expand README, add docs contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,5 +9,5 @@ _How can a reviewer review your changes? What should be kept in mind for this re
 ## Checklist
 
 - [ ] Unit tests updated
-- [ ] README updated
-- [ ] `examples/` directory updated (only applicable for openapi-typescript)
+- [ ] `docs/` updated (if necessary)
+- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tools for consuming OpenAPI schemas in TypeScript.
 
-## Packages
+## 📦 Packages
 
 <a href="./packages/openapi-typescript"><img src="./docs/public/assets/openapi-ts.svg" alt="openapi-typescript" width="200" height="40" /><br />
 Generate TypeScript types from static OpenAPI schemas
@@ -11,3 +11,18 @@ Generate TypeScript types from static OpenAPI schemas
 <a href="./packages/openapi-fetch"><img src="./docs/public/assets/openapi-fetch.svg" alt="openapi-fetch" width="216" height="40" /><br />
 Ultra-fast fetching for TypeScript generated automatically from your OpenAPI schema.
 </a>
+
+## 🤝 Contributing
+
+Contributions are appreciated and welcome! See the appropriate guide for each package:
+
+- [Contributing to openapi-typescript](./packages/openapi-typescript/CONTRIBUTING.md)
+- [Contributing to openapi-fetch](./packages/openapi-fetch/CONTRIBUTING.md)
+- [Contributing to docs](./docs/CONTRIBUTING.md)
+
+## ♥️ Thanks
+
+- Thanks to [dozens of lovely, smart contributors](https://github.com/drwpow/openapi-typescript/graphs/contributors) that made this library possible
+- Thanks to [Astro](https://astro.build/) for the docs site
+- Thanks to [Cloudflare Pages](https://pages.cloudflare.com/) for docs site hosting
+- Thanks to [Algolia](https://www.algolia.com/) for the docs site search

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to openapi-typescript docs
+
+## Setup
+
+See the [README](./README.md) for basic setup.
+
+## Corrections / small edits
+
+Corrections are always welcome! Please go straight to [opening a PR](https://github.com/drwpow/openapi-typescript/pulls) for correcting typos or misinformation language. Small edits are also welcome, which include shortening verbose language or clarifying confusing wording.
+
+## Styling fixes
+
+Styling fixes are also welcome (contrast improvements, styling bugs, general frontend improvements). You can also go straight to [opening a PR](https://github.com/drwpow/openapi-typescript/pulls) for those.
+
+## Additions & Larger edits
+
+[Opening a new discussion](https://github.com/drwpow/openapi-typescript/discussions) would be appreciated for all of the following:
+
+- Adding a new section or page
+- Restructuring the docs
+- Major rewrites
+
+All of the above are welcome! But if you just opened a PR without discussing the plan ahead-of-time, it will probably be rejected. Be sure to save your own time by talking about big changes first!
+
+## Code of Conduct
+
+All docs edits are held accountable to the [Code of Conduct](../../CODE_OF_CONDUCT.md) outlined in this project. Language in the documentation must be inclusive, kind, and respectful.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# openapi-typescript Docs
+
+Docs site powered by [Astro](https://github.com/withastro/astro), a modern static site generator.
+
+Lives at [https://openapi-ts.pages.dev](https://openapi-ts.pages.dev).
+
+## Setup
+
+Setup requires the latest version of [Node.js](https://nodejs.org/en) and [pnpm](https://pnpm.io/). With both installed, run:
+
+```
+pnpm 1
+pnpm run dev
+```
+
+That will launch the docs site at `http://localhost:3000`.
+
+## Editing
+
+All content lives in the [content/](./src/content) directory, in `.md` files that should be familiar to edit to most.
+
+For the non-markdown bits, please see the [Astro Documentation](https://docs.astro.build/en/getting-started/).
+
+## Contributing
+
+Docs contributions are welcome! Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for additional assistance.


### PR DESCRIPTION
## Changes

- Adds guides / READMEs on contributing to documentation
- Expands READMEs to be a little more helpful.

## How to Review

Docs-only change.

## Checklist

- [ ] Unit tests updated
- [x] README updated
- [ ] `examples/` directory updated (only applicable for openapi-typescript)
