### PR TITLE
Stop trimming whitespace other than linebreaks in string values

### DIFF
--- a/.changeset/new-rats-yawn.md
+++ b/.changeset/new-rats-yawn.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Stop trimming whitespace other than linebreaks in string values

--- a/packages/openapi-typescript/src/utils.ts
+++ b/packages/openapi-typescript/src/utils.ts
@@ -273,7 +273,7 @@ export function tsUnionOf(...types: (string | number | boolean)[]): string {
 /** escape string value */
 export function escStr(input: any): string {
   if (typeof input !== "string") return JSON.stringify(input);
-  return `"${input.trim().replace(DOUBLE_QUOTE_RE, '\\"')}"`;
+  return `"${input.replace(LB_RE, "").replace(DOUBLE_QUOTE_RE, '\\"')}"`;
 }
 
 /** surround a JS object key with quotes, if needed */

--- a/packages/openapi-typescript/test/schema-object.test.ts
+++ b/packages/openapi-typescript/test/schema-object.test.ts
@@ -57,6 +57,12 @@ describe("Schema Object", () => {
   status?: "complete" | "incomplete";
 }`);
       });
+
+      test("enum (whitespace)", () => {
+        const schema: SchemaObject = { type: "string", enum: [" blue", "green ", " ", ""] };
+        const generated = transformSchemaObject(schema, options);
+        expect(generated).toBe('" blue" | "green " | " " | ""');
+      });
     });
 
     describe("number", () => {


### PR DESCRIPTION
## Changes

This PR attempts to fix #1224 while minimizing other impact.

## How to Review

The unit test gives a clear example of the scenario in which the behaviour is currently not as expected. The code change is required to make the unit test pass.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary) -> Not necessary
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript) -> No changes produced?
