### PR TITLE
Fix externalizing external refs

### DIFF
--- a/.changeset/swift-badgers-notice.md
+++ b/.changeset/swift-badgers-notice.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix externalizing external refs

--- a/packages/openapi-typescript/src/load.ts
+++ b/packages/openapi-typescript/src/load.ts
@@ -264,7 +264,7 @@ export default async function load(schema: URL | Subschema | Readable, options: 
 
         // local $ref: convert into TS path
         if (ref.filename === ".") {
-          if (subschemaID === ".") {
+          if (subschemaID === "." || ref.path[0] === "external") {
             node.$ref = makeTSIndex(ref.path);
           } else {
             node.$ref = makeTSIndex(["external", subschemaID, ...ref.path]);

--- a/packages/openapi-typescript/test/fixtures/anchor-with-ref-test-2.yaml
+++ b/packages/openapi-typescript/test/fixtures/anchor-with-ref-test-2.yaml
@@ -1,0 +1,14 @@
+openapi: "3.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /:
+    get:
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    obj:
+      $ref: './anchor-with-ref-test.yaml#/components/schemas/anchorTest'

--- a/packages/openapi-typescript/test/fixtures/anchor-with-ref-test.yaml
+++ b/packages/openapi-typescript/test/fixtures/anchor-with-ref-test.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /:
+    get:
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    test:
+      type: object
+      properties: &testProperties
+        metadata:
+          $ref: '#/components/schemas/metadata'
+      additionalProperties: false
+    anchorTest:
+      type: object
+      additionalProperties: false
+      properties: *testProperties
+    metadata:
+      type: object
+      additionalProperties: true

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -393,6 +393,71 @@ export interface external {
 export type operations = Record<string, never>;
 `);
     });
+
+    test("anchor $refs", async () => {
+      const generated = await openapiTS(new URL("./fixtures/anchor-with-ref-test-2.yaml", import.meta.url));
+      expect(generated).toBe(`${BOILERPLATE}
+export interface paths {
+  "/": {
+    get: {
+      responses: {
+        /** @description OK */
+        200: never;
+      };
+    };
+  };
+}
+
+export type webhooks = Record<string, never>;
+
+export interface components {
+  schemas: {
+    obj: external["anchor-with-ref-test.yaml"]["components"]["schemas"]["anchorTest"];
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
+}
+
+export interface external {
+  "anchor-with-ref-test.yaml": {
+    paths: {
+      "/": {
+        get: {
+          responses: {
+            /** @description OK */
+            200: never;
+          };
+        };
+      };
+    };
+    webhooks: Record<string, never>;
+    components: {
+      schemas: {
+        test: {
+          metadata?: external["anchor-with-ref-test.yaml"]["components"]["schemas"]["metadata"];
+        };
+        anchorTest: {
+          metadata?: external["anchor-with-ref-test.yaml"]["components"]["schemas"]["metadata"];
+        };
+        metadata: {
+          [key: string]: unknown;
+        };
+      };
+      responses: never;
+      parameters: never;
+      requestBodies: never;
+      headers: never;
+      pathItems: never;
+    };
+  };
+}
+
+export type operations = Record<string, never>;
+`);
+    })
   });
 
   describe("3.1", () => {


### PR DESCRIPTION
## Changes

Fixes #1276 

## How to Review

I'm unsure if this is a complete fix. It fixes my case, but there might be others that I overlooked.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
