### PR TITLE
Refactor CLI path handling, fixing several bugs

### DIFF
--- a/.changeset/gold-gorillas-kiss.md
+++ b/.changeset/gold-gorillas-kiss.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Refactor CLI path handling, fixing several bugs

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from "node:fs";
-import path from "path";
+import path from "node:path";
 import { URL } from "node:url";
 import glob from "fast-glob";
 import parser from "yargs-parser";
@@ -114,7 +114,10 @@ async function generateSchema(pathToSpec) {
     let outputFilePath = new URL(flags.output, CWD); // note: may be directory
     const isDir = fs.existsSync(outputFilePath) && fs.lstatSync(outputFilePath).isDirectory();
     if (isDir) {
-      const filename = pathToSpec.replace(EXT_RE, ".ts");
+      if (typeof flags.output === 'string' && !flags.output.endsWith('/')) {
+        outputFilePath = new URL(`${flags.output}/`, CWD)
+      }
+      const filename = path.basename(pathToSpec).replace(EXT_RE, ".ts");
       const originalOutputFilePath = outputFilePath;
       outputFilePath = new URL(filename, originalOutputFilePath);
       if (outputFilePath.protocol !== 'file:') {
@@ -189,7 +192,7 @@ async function main() {
     inputSpecPaths.map(async (specPath) => {
       if (flags.output !== "." && output === OUTPUT_FILE) {
         if (isGlob) {
-          fs.mkdirSync(new URL(path.dirname(specPath), outputDir), { recursive: true }); // recursively make parent dirs
+          fs.mkdirSync(outputFile, { recursive: true }); // recursively make parent dirs
         }
         else {
           fs.mkdirSync(outputDir, { recursive: true }); // recursively make parent dirs


### PR DESCRIPTION
## Changes

Fixes #1091

Uses of `URL` have been replaced by their `path` variants. This makes more sense because we're handling actual file paths here. This fixes several bugs, including the reporting one, but also for example exporting to absolute paths.

## How to Review
## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
