### PR TITLE
Fix invalid typescript for an array of integers

### DIFF
--- a/.changeset/tender-timers-sniff.md
+++ b/.changeset/tender-timers-sniff.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix invalid typescript for an array of integers

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -123,6 +123,7 @@ export function defaultSchemaObjectTransform(schemaObject: SchemaObject | Refere
         itemType = `[${result.join(", ")}]`;
       } else if (schemaObject.items) {
         itemType = transformSchemaObject(schemaObject.items, { path, ctx: { ...ctx, indentLv } });
+        if (itemType === "integer") itemType = "number";
       }
       const min: number = typeof schemaObject.minItems === "number" && schemaObject.minItems >= 0 ? schemaObject.minItems : 0;
       const max: number | undefined = typeof schemaObject.maxItems === "number" && schemaObject.maxItems >= 0 && min <= schemaObject.maxItems ? schemaObject.maxItems : undefined;

--- a/packages/openapi-typescript/test/schema-object.test.ts
+++ b/packages/openapi-typescript/test/schema-object.test.ts
@@ -106,6 +106,12 @@ describe("Schema Object", () => {
         expect(generated).toBe("string[]");
       });
 
+      test("integer array", () => {
+        const schema: SchemaObject = { type: "array", items: "integer" as any };
+        const generated = transformSchemaObject(schema, options);
+        expect(generated).toBe("number[]");
+      });
+
       test("tuple array", () => {
         const schema: SchemaObject = { type: "array", items: [{ type: "string" }, { type: "number" }], minItems: 2, maxItems: 2 };
         const generated = transformSchemaObject(schema, options);


### PR DESCRIPTION
## Changes

Fixed invalid typescript generation when items of an array is string instead of SchemaObject.

```
"values": {
  "type": "array",
  "items": "integer",
}
```
which would result in:
```
values: integer[]
```

## How to Review

Not sure if the test is in a sensible location or if this PR should've been an issue instead.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
