### PR TITLE
Add openapi-typescript-helpers package

### DIFF
--- a/.changeset/tiny-waves-help.md
+++ b/.changeset/tiny-waves-help.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Use openapi-typescript-helpers package for types

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "build:openapi-fetch": "cd packages/openapi-fetch && pnpm run build",
     "lint": "run-p -s lint:*",
     "lint:openapi-typescript": "cd packages/openapi-typescript && pnpm run lint",
+    "lint:openapi-typescript-helpers": "cd packages/openapi-typescript-helpers && pnpm run lint",
     "lint:openapi-fetch": "cd packages/openapi-fetch && pnpm run lint",
     "test": "run-p -s test:*",
     "test:openapi-typescript": "cd packages/openapi-typescript && pnpm test",
+    "test:openapi-typescript-helpers": "cd packages/openapi-typescript-helpers && pnpm test",
     "test:openapi-fetch": "cd packages/openapi-fetch && pnpm test",
     "version": "pnpm run build && changeset version && pnpm i"
   },

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -58,7 +58,7 @@
     "version": "pnpm run prepare && pnpm run build"
   },
   "dependencies": {
-    "openapi-typescript-helpers": "^0.0.0"
+    "openapi-typescript-helpers": "^0.0.1"
   },
   "devDependencies": {
     "axios": "^1.4.0",

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -57,6 +57,9 @@
     "prepublish": "pnpm run prepare && pnpm run build",
     "version": "pnpm run prepare && pnpm run build"
   },
+  "dependencies": {
+    "openapi-typescript-helpers": "^0.0.0"
+  },
   "devDependencies": {
     "axios": "^1.4.0",
     "del-cli": "^5.0.0",

--- a/packages/openapi-typescript-helpers/CHANGELOG.md
+++ b/packages/openapi-typescript-helpers/CHANGELOG.md
@@ -1,0 +1,5 @@
+# openapi-typescript-helpers
+
+## 0.0.0
+
+Initial release

--- a/packages/openapi-typescript-helpers/LICENSE
+++ b/packages/openapi-typescript-helpers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Drew Powers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/openapi-typescript-helpers/README.md
+++ b/packages/openapi-typescript-helpers/README.md
@@ -1,0 +1,5 @@
+# openapi-typescript-helpers
+
+Helper utilities that power `openapi-fetch` but are generically-available for any project.
+
+This package isn’t as well-documented as the others, so it’s a bit “use at your own discretion.”

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types */
+
+// HTTP types
+
+export type HttpMethod = "get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace";
+/** 2XX statuses */
+export type OkStatus = 200 | 201 | 202 | 203 | 204 | 206 | 207 | "2XX";
+// prettier-ignore
+/** 4XX and 5XX statuses */
+export type ErrorStatus = 500 | '5XX' | 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 408 | 409 | 410 | 411 | 412 | 413 | 414 | 415 | 416 | 417 | 418 | 420 | 421 | 422 | 423 | 424 | 425 | 426 | 429 | 431 | 444 | 450 | 451 | 497 | 498 | 499 | '4XX' | "default";
+
+// OpenAPI type helpers
+
+/** Given an OpenAPI **Paths Object**, find all paths that have the given method */
+export type PathsWithMethod<Paths extends Record<string, PathItemObject>, PathnameMethod extends HttpMethod> = {
+  [Pathname in keyof Paths]: Paths[Pathname] extends { [K in PathnameMethod]: any } ? Pathname : never;
+}[keyof Paths];
+/** Internal helper used in PathsWithMethod */
+export type PathItemObject = { [M in HttpMethod]: OperationObject } & { parameters?: any };
+/** Return `responses` for an Operation Object */
+export type ResponseObjectMap<T> = T extends { responses: any } ? T["responses"] : unknown;
+/** Return `content` for a Response Object */
+export type ResponseContent<T> = T extends { content: any } ? T["content"] : unknown;
+/** Return `requestBody` for an Operation Object */
+export type OperationRequestBody<T> = T extends { requestBody?: any } ? T["requestBody"] : never;
+/** Internal helper used in OperationRequestBodyContent */
+export type OperationRequestBodyMediaContent<T> = undefined extends OperationRequestBody<T> ? FilterKeys<NonNullable<OperationRequestBody<T>>, "content"> | undefined : FilterKeys<OperationRequestBody<T>, "content">;
+/** Return first `content` from a Request Object Mapping, allowing any media type */
+export type OperationRequestBodyContent<T> = FilterKeys<OperationRequestBodyMediaContent<T>, MediaType> extends never
+  ? FilterKeys<NonNullable<OperationRequestBodyMediaContent<T>>, MediaType> | undefined
+  : FilterKeys<OperationRequestBodyMediaContent<T>, MediaType>;
+/** Return first 2XX response from a Response Object Map */
+export type SuccessResponse<T> = FilterKeys<FilterKeys<T, OkStatus>, "content">;
+/** Return first 5XX or 4XX response (in that order) from a Response Object Map */
+export type ErrorResponse<T> = FilterKeys<FilterKeys<T, ErrorStatus>, "content">;
+
+// Generic TS utils
+
+/** Find first match of multiple keys */
+export type FilterKeys<Obj, Matchers> = { [K in keyof Obj]: K extends Matchers ? Obj[K] : never }[keyof Obj];
+/** Return any `[string]/[string]` media type (important because openapi-fetch allows any content response, not just JSON-like) */
+export type MediaType = `${string}/${string}`;

--- a/packages/openapi-typescript-helpers/index.js
+++ b/packages/openapi-typescript-helpers/index.js
@@ -1,0 +1,4 @@
+/**
+ * Stub file to allow importing from the root of the package.
+ */
+export default null;

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "openapi-typescript-helpers",
+  "description": "TypeScript helpers for consuming openapi-typescript types",
+  "version": "0.0.0",
+  "author": {
+    "name": "Drew Powers",
+    "email": "drew@pow.rs"
+  },
+  "license": "MIT",
+  "scripts": {
+    "lint": "pnpm run lint:js",
+    "lint:js": "eslint \"*.{js,ts}\"",
+    "lint:prettier": "prettier --check \"{src,test}/**/*\"",
+    "test": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "default": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./*": "./*"
+  },
+  "devDependencies": {
+    "typescript": "^5.1.6"
+  }
+}

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -1,24 +1,36 @@
 {
   "name": "openapi-typescript-helpers",
   "description": "TypeScript helpers for consuming openapi-typescript types",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"
   },
   "license": "MIT",
-  "scripts": {
-    "lint": "pnpm run lint:js",
-    "lint:js": "eslint \"*.{js,ts}\"",
-    "lint:prettier": "prettier --check \"{src,test}/**/*\"",
-    "test": "tsc --noEmit"
-  },
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
       "default": "./index.js",
       "types": "./index.d.ts"
     },
     "./*": "./*"
+  },
+  "homepage": "https://openapi-ts.pages.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/drwpow/openapi-typescript",
+    "directory": "packages/openapi-fetch"
+  },
+  "bugs": {
+    "url": "https://github.com/drwpow/openapi-typescript/issues"
+  },
+  "scripts": {
+    "lint": "pnpm run lint:js",
+    "lint:js": "eslint \"*.{js,ts}\"",
+    "lint:prettier": "prettier --check \"{src,test}/**/*\"",
+    "test": "tsc --noEmit"
   },
   "devDependencies": {
     "typescript": "^5.1.6"

--- a/packages/openapi-typescript-helpers/tsconfig.json
+++ b/packages/openapi-typescript-helpers/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["."]
+}

--- a/packages/openapi-typescript/tsconfig.json
+++ b/packages/openapi-typescript/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "sourceRoot": ".",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["vitest/globals"]
   },
   "include": ["scripts", "src", "test", "*.ts"],
   "exclude": ["examples", "node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
   packages/openapi-fetch:
     dependencies:
       openapi-typescript-helpers:
-        specifier: ^0.0.0
+        specifier: ^0.0.1
         version: link:../openapi-typescript-helpers
     devDependencies:
       axios:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,10 @@ importers:
         version: 5.1.6
 
   packages/openapi-fetch:
+    dependencies:
+      openapi-typescript-helpers:
+        specifier: ^0.0.0
+        version: link:../openapi-typescript-helpers
     devDependencies:
       axios:
         specifier: ^1.4.0
@@ -187,6 +191,12 @@ importers:
       vitest:
         specifier: ^0.34.1
         version: 0.34.1(supports-color@9.4.0)
+
+  packages/openapi-typescript-helpers:
+    devDependencies:
+      typescript:
+        specifier: ^5.1.6
+        version: 5.1.6
 
 packages:
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "sourceMap": true,
     "strict": true,
     "target": "ESNext",
-    "types": ["vitest/globals"],
     "useDefineForClassFields": true
   }
 }


### PR DESCRIPTION
## Changes

Adds `openapi-typescript-helpers` package, as suggested in https://github.com/drwpow/openapi-typescript/discussions/1259. Still a bit of a WIP, but will be nice just being able to have types for anything that comes up. That way we have it


![0a045621-286c-4dd4-9f76-f76e3ae5b24e_text](https://github.com/drwpow/openapi-typescript/assets/1369770/5c21d557-caa3-4b09-9406-b0e9c091ae7f)


## How to Review

- Tests should pass (`openapi-fetch` especially)

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
