### PR TITLE
Allow unsetting default headers

### DIFF
--- a/.changeset/gentle-socks-wink.md
+++ b/.changeset/gentle-socks-wink.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Make headers typing friendlier

--- a/.changeset/weak-games-exercise.md
+++ b/.changeset/weak-games-exercise.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Allow unsetting headers

--- a/packages/openapi-fetch/src/index.test.ts
+++ b/packages/openapi-fetch/src/index.test.ts
@@ -337,6 +337,16 @@ describe("client", () => {
       );
     });
 
+    it("allows unsetting headers", async () => {
+      const client = createClient<paths>({ headers: { "Content-Type": null } });
+      mockFetchOnce({ status: 200, body: JSON.stringify({ email: "user@user.com" }) });
+      await client.GET("/self", { params: {} });
+
+      // assert default headers were passed
+      const options = fetchMocker.mock.calls[0][1];
+      expect(options?.headers).toEqual(new Headers());
+    });
+
     it("accepts a custom fetch function", async () => {
       const data = { works: true };
       const customFetch = {


### PR DESCRIPTION
## Changes

Fixes #1298. Allows you to pass in `null` to headers to unset them (applicable to default headers either in the library or set with `createClient()`.

## How to Review

- Tests added; tests should pass

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
