### PR TITLE
Fix missing type bug

### DIFF
--- a/.changeset/early-feet-report.md
+++ b/.changeset/early-feet-report.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript-helpers": patch
+---
+
+Fix type bug

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -15,6 +15,13 @@ export type ErrorStatus = 500 | '5XX' | 400 | 401 | 402 | 403 | 404 | 405 | 406 
 export type PathsWithMethod<Paths extends Record<string, PathItemObject>, PathnameMethod extends HttpMethod> = {
   [Pathname in keyof Paths]: Paths[Pathname] extends { [K in PathnameMethod]: any } ? Pathname : never;
 }[keyof Paths];
+/** DO NOT USE! Only used only for OperationObject type inference */
+export interface OperationObject {
+  parameters: any;
+  params?: { query?: Record<string, unknown> };
+  requestBody: any; // note: "any" will get overridden in inference
+  responses: any;
+}
 /** Internal helper used in PathsWithMethod */
 export type PathItemObject = { [M in HttpMethod]: OperationObject } & { parameters?: any };
 /** Return `responses` for an Operation Object */

--- a/packages/openapi-typescript-helpers/tsconfig.json
+++ b/packages/openapi-typescript-helpers/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "skipLibCheck": false
   },
   "include": ["."]
 }


### PR DESCRIPTION
## Changes

Fixes #1322. Caused by #1300, there was a type error that wasn’t being typechecked properly.

## How to Review

- Tests should pass

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
