### PR TITLE
openapi-fetch@0.7.5

### DIFF
--- a/.changeset/early-feet-report.md
+++ b/.changeset/early-feet-report.md
@@ -1,5 +1,0 @@
----
-"openapi-typescript-helpers": patch
----
-
-Fix type bug

--- a/packages/openapi-fetch/CHANGELOG.md
+++ b/packages/openapi-fetch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # openapi-fetch
 
+## 0.7.5
+
+### Patch Changes
+
+- Updated dependencies [[`e63a345`](https://github.com/drwpow/openapi-typescript/commit/e63a34561c8137c4cfdef858a2272be32960ca4f)]:
+  - openapi-typescript-helpers@0.0.2
+
 ## 0.7.4
 
 ### Patch Changes

--- a/packages/openapi-fetch/examples/nextjs/package.json
+++ b/packages/openapi-fetch/examples/nextjs/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "next": "13.4.19",
-    "openapi-fetch": "file:../..",
+    "openapi-fetch": "workspace:^",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/packages/openapi-fetch/examples/react-query/package.json
+++ b/packages/openapi-fetch/examples/react-query/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.33.0",
-    "openapi-fetch": "file:../..",
+    "openapi-fetch": "workspace:^",
     "openapi-typescript": "workspace:^",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/openapi-fetch/examples/sveltekit/package.json
+++ b/packages/openapi-fetch/examples/sveltekit/package.json
@@ -9,7 +9,7 @@
     "prepare": "openapi-typescript src/lib/api/v1.json -o src/lib/api/v1.d.ts"
   },
   "dependencies": {
-    "openapi-fetch": "file:../..",
+    "openapi-fetch": "workspace:^",
     "openapi-typescript": "workspace:^"
   },
   "devDependencies": {

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-fetch",
   "description": "Fetch using your OpenAPI types. Weighs 2 kb and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"
@@ -58,7 +58,7 @@
     "version": "pnpm run prepare && pnpm run build"
   },
   "dependencies": {
-    "openapi-typescript-helpers": "^0.0.1"
+    "openapi-typescript-helpers": "^0.0.2"
   },
   "devDependencies": {
     "axios": "^1.4.0",

--- a/packages/openapi-typescript-helpers/CHANGELOG.md
+++ b/packages/openapi-typescript-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openapi-typescript-helpers
 
+## 0.0.2
+
+### Patch Changes
+
+- [#1326](https://github.com/drwpow/openapi-typescript/pull/1326) [`e63a345`](https://github.com/drwpow/openapi-typescript/commit/e63a34561c8137c4cfdef858a2272be32960ca4f) Thanks [@drwpow](https://github.com/drwpow)! - Fix type bug
+
 ## 0.0.0
 
 Initial release

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-typescript-helpers",
   "description": "TypeScript helpers for consuming openapi-typescript types",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
   packages/openapi-fetch:
     dependencies:
       openapi-typescript-helpers:
-        specifier: ^0.0.1
+        specifier: ^0.0.2
         version: link:../openapi-typescript-helpers
     devDependencies:
       axios:
@@ -155,8 +155,8 @@ importers:
         specifier: 13.4.19
         version: 13.4.19(react-dom@18.2.0)(react@18.2.0)
       openapi-fetch:
-        specifier: file:../..
-        version: file:packages/openapi-fetch
+        specifier: workspace:^
+        version: link:../..
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -186,8 +186,8 @@ importers:
         specifier: ^4.33.0
         version: 4.33.0(react-dom@18.2.0)(react@18.2.0)
       openapi-fetch:
-        specifier: file:../..
-        version: file:packages/openapi-fetch
+        specifier: workspace:^
+        version: link:../..
       openapi-typescript:
         specifier: workspace:^
         version: link:../../../openapi-typescript
@@ -211,8 +211,8 @@ importers:
   packages/openapi-fetch/examples/sveltekit:
     dependencies:
       openapi-fetch:
-        specifier: file:../..
-        version: file:packages/openapi-fetch
+        specifier: workspace:^
+        version: link:../..
       openapi-typescript:
         specifier: workspace:^
         version: link:../../../openapi-typescript
@@ -5836,10 +5836,6 @@ packages:
     engines: {node: '>= 12.0.0', npm: '>= 7.0.0'}
     dev: true
 
-  /openapi-typescript-helpers@0.0.1:
-    resolution: {integrity: sha512-WDmxej0eHSZtLgCuyPEn2NXRV7tcvUnBBNP/0c/U66mOlxs6Yn0/dHuWlkVKdHGNahSUwG57A1tyutHWRpWqFg==}
-    dev: false
-
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -8185,11 +8181,4 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
-    dev: false
-
-  file:packages/openapi-fetch:
-    resolution: {directory: packages/openapi-fetch, type: directory}
-    name: openapi-fetch
-    dependencies:
-      openapi-typescript-helpers: 0.0.1
     dev: false


### PR DESCRIPTION
## Changes

Fixes bug in `npx changeset version` caused by something weird with the `openapi-fetch/examples` folder. Probably a bug within Changesets, but either way should just be a quick manual fix.

This prepares `openapi-fetch@0.7.5` and `openapi-typescript-helpers@0.0.2` for release

## How to Review

N/A

## Checklist

N/A