### PR TITLE
Fix broken URL in openapi-typescript/README

### DIFF
--- a/packages/openapi-typescript/README.md
+++ b/packages/openapi-typescript/README.md
@@ -25,7 +25,7 @@ npm i -D openapi-typescript
 
 > ✨ **Tip**
 >
-> Enabling [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) in `tsconfig.json` can go along way to improve type safety ([read more](/advanced#enable-nouncheckedindexaccess-in-your-tsconfigjson))
+> Enabling [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) in `tsconfig.json` can go along way to improve type safety ([read more](/docs/src/content/docs/advanced.md#enable-nouncheckedindexedaccess-in-your-tsconfigjson))
 
 ## Basic usage
 


### PR DESCRIPTION
## Changes

Fixed broken link to advanced.md in README

## How to Review

-

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
