### PR TITLE
openapi-typescript@6.5.5

### DIFF
--- a/.changeset/four-ravens-shop.md
+++ b/.changeset/four-ravens-shop.md
@@ -1,6 +1,0 @@
----
-"openapi-typescript": patch
-"openapi-fetch": patch
----
-
-Restore original .d.ts module-resolution behavior

--- a/packages/openapi-fetch/CHANGELOG.md
+++ b/packages/openapi-fetch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openapi-fetch
 
+## 0.7.6
+
+### Patch Changes
+
+- [#1332](https://github.com/drwpow/openapi-typescript/pull/1332) [`8e8ebfd`](https://github.com/drwpow/openapi-typescript/commit/8e8ebfdcd84ff6a3d7b6f5d00695fc11366b436e) Thanks [@drwpow](https://github.com/drwpow)! - Restore original .d.ts module-resolution behavior
+
 ## 0.7.5
 
 ### Patch Changes

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-fetch",
   "description": "Fetch using your OpenAPI types. Weighs 2 kb and has virtually zero runtime. Works with React, Vue, Svelte, or vanilla JS.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"
@@ -65,7 +65,7 @@
     "del-cli": "^5.1.0",
     "esbuild": "^0.19.2",
     "nanostores": "^0.9.3",
-    "openapi-typescript": "^6.5.4",
+    "openapi-typescript": "^6.5.5",
     "openapi-typescript-codegen": "^0.25.0",
     "openapi-typescript-fetch": "^1.1.3",
     "superagent": "^8.1.2",

--- a/packages/openapi-typescript/CHANGELOG.md
+++ b/packages/openapi-typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openapi-typescript
 
+## 6.5.5
+
+### Patch Changes
+
+- [#1332](https://github.com/drwpow/openapi-typescript/pull/1332) [`8e8ebfd`](https://github.com/drwpow/openapi-typescript/commit/8e8ebfdcd84ff6a3d7b6f5d00695fc11366b436e) Thanks [@drwpow](https://github.com/drwpow)! - Restore original .d.ts module-resolution behavior
+
 ## 6.5.4
 
 ### Patch Changes

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-typescript",
   "description": "Generate runtime-free TypeScript types from Swagger OpenAPI specs",
-  "version": "6.5.4",
+  "version": "6.5.5",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
         specifier: ^0.9.3
         version: 0.9.3
       openapi-typescript:
-        specifier: ^6.5.4
+        specifier: ^6.5.5
         version: link:../openapi-typescript
       openapi-typescript-codegen:
         specifier: ^0.25.0


### PR DESCRIPTION
Release `openapi-typescript@6.5.5` and `openapi-fetch@0.7.6`.