### PR TITLE
Improve YAML vs JSON parsing

### DIFF
--- a/.changeset/brown-trainers-wink.md
+++ b/.changeset/brown-trainers-wink.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Improve YAML vs JSON parsing

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -41,6 +41,7 @@
   },
   "scripts": {
     "build": "run-s -s build:*",
+    "build:clean": "del dist",
     "build:esm": "tsc -p tsconfig.build.json",
     "build:cjs": "esbuild --bundle --platform=node --target=es2019 --outfile=dist/index.cjs --external:js-yaml --external:undici src/index.ts --footer:js=\"module.exports = module.exports.default;\"",
     "dev": "tsc -p tsconfig.build.json --watch",


### PR DESCRIPTION
## Changes

Fixes #1347. Simplifies YAML vs JSON parsing by simply checking if the file starts with `{`.

## How to Review

- All tests should pass

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
