### PR TITLE
Prevent using request body before cloning it

### DIFF
--- a/packages/openapi-fetch/src/index.ts
+++ b/packages/openapi-fetch/src/index.ts
@@ -68,10 +68,12 @@ export default function createClient<Paths extends {}>(clientOptions: ClientOpti
 
     // parse response (falling back to .text() when necessary)
     if (response.ok) {
-      let data: any = response.body;
+      let data: any;
       if (parseAs !== "stream") {
         const cloned = response.clone();
         data = typeof cloned[parseAs] === "function" ? await cloned[parseAs]() : await cloned.text();
+      } else {
+        data = response.clone().body;
       }
       return { data, response: response as any };
     }

--- a/packages/openapi-fetch/src/index.ts
+++ b/packages/openapi-fetch/src/index.ts
@@ -68,11 +68,12 @@ export default function createClient<Paths extends {}>(clientOptions: ClientOpti
 
     // parse response (falling back to .text() when necessary)
     if (response.ok) {
-      let data: any;
+      let data: any; // we have to leave this empty here so that we don't consume the body
       if (parseAs !== "stream") {
         const cloned = response.clone();
         data = typeof cloned[parseAs] === "function" ? await cloned[parseAs]() : await cloned.text();
       } else {
+        // bun consumes the body when calling response.body, therefore we need to clone the response before accessing it
         data = response.clone().body;
       }
       return { data, response: response as any };


### PR DESCRIPTION
## Changes

This PR aims to fix a bug where the library would read the response's body before cloning it, which would result in the cloned response having an empty body after being cloned (at least in Bun).

## How to Review

This is a pretty minor fix, so I don't think there's any specific things to keep in mind when reviewing the changes.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
