### PR TITLE
Add Bun tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,13 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: latest
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
       - run: pnpm i
       - run: pnpm test
+      # ! Important: `bun test` != `bun run test`. We want the latter.
+      - run: bun run test
   test-macos:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
## Changes

CI only: run the test suite with Bun to ensure it’s working as expected (it’s only executing Vitest with Bun rather than Node, but will still flag any glaring issues)

## Che