### PR TITLE
fix: adjusted RequestBodyOption to identify mandatory body param

### DIFF
--- a/packages/openapi-fetch/src/index.ts
+++ b/packages/openapi-fetch/src/index.ts
@@ -60,10 +60,16 @@ export type ParamsOption<T> = T extends { parameters: any }
 // : never;
 
 export type RequestBodyOption<T> = OperationRequestBodyContent<T> extends never
-  ? { body?: never }
-  : undefined extends OperationRequestBodyContent<T>
-  ? { body?: OperationRequestBodyContent<T> }
-  : { body: OperationRequestBodyContent<T> };
+  ? {
+      body?: never;
+    }
+  : HasRequiredKeys<OperationRequestBodyContent<T>> extends never
+  ? {
+      body?: OperationRequestBodyContent<T>;
+    }
+  : {
+      body: OperationRequestBodyContent<T>;
+    };
 
 export type FetchOptions<T> = RequestOptions<T> & Omit<RequestInit, "body">;
 

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -83,9 +83,4 @@ export type FilterKeys<Obj, Matchers> = {
 /** Return any `[string]/[string]` media type (important because openapi-fetch allows any content response, not just JSON-like) */
 export type MediaType = `${string}/${string}`;
 /** Filter objects that have required keys */
-export type FindRequiredKeys<T, K extends keyof T> = K extends unknown
-  ? undefined extends T[K]
-    ? never
-    : K
-  : K;
-export type HasRequiredKeys<T> = FindRequiredKeys<T, keyof T>;
+export type HasRequiredKeys<T> = { [K in keyof T]-?: {} extends Pick<T, K> ? never : T }[keyof T];


### PR DESCRIPTION
# Description
Currently the body of every request is optional, even if it has mandatory keys.

i.E.
```
import createClient from 'openapi-fetch';
import type { paths } from "my-sdk";

const client = createClient<paths>();

// Typescript should complain if there are required params in requestBody from paths("/user/create")
await client.POST("/user/create", {});
```
fixes #1384
# Checklist
 - [ ] Unit tests updated
 - [ ] docs/ updated (if necessary)
- [ ]  pnpm run update:examples run (only applicable for openapi-typescript)