### PR TITLE
fix advanced doc link

### DIFF
--- a/packages/openapi-typescript/README.md
+++ b/packages/openapi-typescript/README.md
@@ -25,7 +25,7 @@ npm i -D openapi-typescript
 
 > ✨ **Tip**
 >
-> Enabling [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) in `tsconfig.json` can go along way to improve type safety ([read more](/docs/src/content/docs/advanced.md#enable-nouncheckedindexedaccess-in-your-tsconfigjson))
+> Enabling [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) in `tsconfig.json` can go along way to improve type safety ([read more](../docs/src/content/docs/advanced.md#enable-nouncheckedindexedaccess-in-your-tsconfigjson))
 
 ## Basic usage
 


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._
This PR change is related to fix advanced.md link for **openapi-typescript** package.


## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_
Just check the path of advanced.md which is required to link  for **openapi-typescript** package.

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
