### PR TITLE
fixes links in READMEs and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-fetch.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-fetch.md
@@ -20,4 +20,4 @@ _(in case it’s not obvious)_
 
 **Checklist**
 
-- [ ] I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-fetch/blob/main/CONTRIBUTING.md))
+- [ ] I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/bug-report-ts.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-ts.md
@@ -31,4 +31,4 @@ _(in case it’s not obvious)_
 **Checklist**
 
 - [ ] My OpenAPI schema passes the [Redocly validator](https://redocly.com/docs/cli/commands/lint/) (`npx @redocly/cli@latest lint`)
-- [ ] I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/CONTRIBUTING.md))
+- [ ] I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/feature-request-fetch.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-fetch.md
@@ -16,4 +16,4 @@ _Write out the proposed syntax change. Please reference any prior art or similar
 
 **Checklist**
 
-- [ ] I’m willing to open a PR for this (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-fetch/blob/main/CONTRIBUTING.md))
+- [ ] I’m willing to open a PR for this (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/feature-request-ts.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-ts.md
@@ -16,4 +16,4 @@ _Outline the change to the library. If this is for the CLI, propose a flag name 
 
 **Checklist**
 
-- [ ] I’m willing to open a PR for this (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/CONTRIBUTING.md))
+- [ ] I’m willing to open a PR for this (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/packages/openapi-fetch/README.md
+++ b/packages/openapi-fetch/README.md
@@ -36,7 +36,7 @@ await PUT("/blogposts", {
 
 `data` and `error` are typechecked and expose their shapes to Intellisence in VS Code (and any other IDE with TypeScript support). Likewise, the request `body` will also typecheck its fields, erring if any required params are missing, or if there’s a type mismatch.
 
-`GET`, `PUT`, `POST`, etc. are only thin wrappers around the native [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (which you can [swap for any call](/openapi-fetch/api#create-client)).
+`GET`, `PUT`, `POST`, etc. are only thin wrappers around the native [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (which you can [swap for any call](https://openapi-ts.pages.dev/openapi-fetch/api/#create-client)).
 
 Notice there are no generics, and no manual typing. Your endpoint’s request and response were inferred automatically. This is a huge improvement in the type safety of your endpoints because **every manual assertion could lead to a bug**! This eliminates all of the following:
 

--- a/packages/openapi-typescript/README.md
+++ b/packages/openapi-typescript/README.md
@@ -85,4 +85,4 @@ _Thanks, [@psmyrdek](https://github.com/psmyrdek)!_
 
 ## 📓 Docs
 
-[View Docs](https://openapi-ts.pages.dev/)
+[View Docs](https://openapi-ts.pages.dev/introduction/)


### PR DESCRIPTION
## Changes

Fixes documentation links as mentioned in #1358 

## How to Review

1. Double check that I didn't put the `openapi-fetch` links in the `openapi-typescript` templates
2. Notify of any additional links that are dead. I tried clicking through most of them, but I easily could have missed them.

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
