### PR TITLE
Add questionToken option to transform

### DIFF
--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -467,6 +467,11 @@ export type SchemaObject = {
   | {}
 );
 
+export interface TransformObject {
+  schema: ts.TypeNode;
+  questionToken: boolean;
+}
+
 export interface StringSubtype {
   type: "string" | ["string", "null"];
   enum?: (string | ReferenceObject)[];
@@ -646,7 +651,7 @@ export interface OpenAPITSOptions {
   transform?: (
     schemaObject: SchemaObject,
     options: TransformNodeOptions,
-  ) => ts.TypeNode | undefined;
+  ) => ts.TypeNode | TransformObject | undefined;
   /** Modify TypeScript types built from Schema Objects */
   postTransform?: (
     type: ts.TypeNode,


### PR DESCRIPTION
## Changes

This adds the possibility of appending a questionToken to a property using the transform function. Fixes #1411 

## How to Review
I am not 100% confident I covered all use cases of the transform function. Keep in mind that with the limited knowledge of this library, I might have missed some things.

## Checklist

- [X] Unit tests updated
- [X] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
