### PR TITLE
[feat]: parseAs options reports correct data type

### DIFF
--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -38,16 +38,15 @@ export type QuerySerializer<T> = (
 
 export type BodySerializer<T> = (body: OperationRequestBodyContent<T>) => any;
 
-export type ParseAs = "json" | "text" | "blob" | "arrayBuffer" | "stream";
-export type ParseAsResponse<T, K extends ParseAs> = K extends "text"
-  ? Awaited<ReturnType<Response["text"]>>
-  : K extends "blob"
-  ? Awaited<ReturnType<Response["blob"]>>
-  : K extends "arrayBuffer"
-  ? Awaited<ReturnType<Response["arrayBuffer"]>>
-  : K extends "stream"
-  ? Response["body"]
-  : T;
+type BodyType<T = unknown> = {
+  json: T;
+  text: Awaited<ReturnType<Response["text"]>>;
+  blob: Awaited<ReturnType<Response["blob"]>>;
+  arrayBuffer: Awaited<ReturnType<Response["arrayBuffer"]>>;
+  stream: Response["body"];
+};
+export type ParseAs = keyof BodyType;
+export type ParseAsResponse<T, K> = K extends ParseAs ? BodyType<T>[K] : T;
 
 export interface DefaultParamsOption {
   params?: {
@@ -112,12 +111,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<
-    FetchResponse<
-      Paths[P]["get"],
-      I[0]["parseAs"] extends ParseAs ? I[O]["parseAs"] : "json"
-    >
-  >;
+  ): Promise<FetchResponse<Paths[P]["get"], I[0]["parseAs"]>>;
   /** Call a PUT endpoint */
   PUT<
     P extends PathsWithMethod<Paths, "put">,
@@ -125,12 +119,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<
-    FetchResponse<
-      Paths[P]["put"],
-      I[0]["parseAs"] extends ParseAs ? I[O]["parseAs"] : "json"
-    >
-  >;
+  ): Promise<FetchResponse<Paths[P]["put"], I[0]["parseAs"]>>;
   /** Call a POST endpoint */
   POST<
     P extends PathsWithMethod<Paths, "post">,
@@ -138,12 +127,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<
-    FetchResponse<
-      Paths[P]["post"],
-      I[0]["parseAs"] extends ParseAs ? I[O]["parseAs"] : "json"
-    >
-  >;
+  ): Promise<FetchResponse<Paths[P]["post"], I[0]["parseAs"]>>;
   /** Call a DELETE endpoint */
   DELETE<
     P extends PathsWithMethod<Paths, "delete">,
@@ -151,12 +135,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<
-    FetchResponse<
-      Paths[P]["delete"],
-      I[0]["parseAs"] extends ParseAs ? I[O]["parseAs"] : "json"
-    >
-  >;
+  ): Promise<FetchResponse<Paths[P]["delete"], I[0]["parseAs"]>>;
   /** Call a OPTIONS endpoint */
   OPTIONS<
     P extends PathsWithMethod<Paths, "options">,
@@ -164,12 +143,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<
-    FetchResponse<
-      Paths[P]["options"],
-      I[0]["parseAs"] extends ParseAs ? I[O]["parseAs"] : "json"
-    >
-  >;
+  ): Promise<FetchResponse<Paths[P]["options"], I[0]["parseAs"]>>;
   /** Call a HEAD endpoint */
   HEAD<
     P extends PathsWithMethod<Paths, "head">,
@@ -177,12 +151,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<
-    FetchResponse<
-      Paths[P]["head"],
-      I[0]["parseAs"] extends ParseAs ? I[O]["parseAs"] : "json"
-    >
-  >;
+  ): Promise<FetchResponse<Paths[P]["head"], I[0]["parseAs"]>>;
   /** Call a PATCH endpoint */
   PATCH<
     P extends PathsWithMethod<Paths, "patch">,
@@ -190,12 +159,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<
-    FetchResponse<
-      Paths[P]["patch"],
-      I[0]["parseAs"] extends ParseAs ? I[O]["parseAs"] : "json"
-    >
-  >;
+  ): Promise<FetchResponse<Paths[P]["patch"], I[0]["parseAs"]>>;
   /** Call a TRACE endpoint */
   TRACE<
     P extends PathsWithMethod<Paths, "trace">,
@@ -203,12 +167,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<
-    FetchResponse<
-      Paths[P]["trace"],
-      I[0]["parseAs"] extends ParseAs ? I[O]["parseAs"] : "json"
-    >
-  >;
+  ): Promise<FetchResponse<Paths[P]["trace"], I[0]["parseAs"]>>;
 };
 
 /** Serialize query params to string */

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -46,7 +46,7 @@ export type ParseAsResponse<T, K extends ParseAs> = K extends "text"
   : K extends "arrayBuffer"
   ? Awaited<ReturnType<Response["arrayBuffer"]>>
   : K extends "stream"
-  ? Awaited<ReturnType<Response["body"]>>
+  ? Response["body"]
   : T;
 
 export interface DefaultParamsOption {

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -117,13 +117,12 @@ export default function createClient<Paths extends {}>(
     >
   >;
   /** Call a PUT endpoint */
-  PUT<P extends PathsWithMethod<Paths, "put">>(
+  PUT<
+    P extends PathsWithMethod<Paths, "put">,
+    O extends FetchOptions<FilterKeys<Paths[P], "put">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "put">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "put">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "put">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "put" extends infer T
@@ -132,17 +131,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a POST endpoint */
-  POST<P extends PathsWithMethod<Paths, "post">>(
+  POST<
+    P extends PathsWithMethod<Paths, "post">,
+    O extends FetchOptions<FilterKeys<Paths[P], "post">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "post">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "post">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "post">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "post" extends infer T
@@ -151,17 +150,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a DELETE endpoint */
-  DELETE<P extends PathsWithMethod<Paths, "delete">>(
+  DELETE<
+    P extends PathsWithMethod<Paths, "delete">,
+    O extends FetchOptions<FilterKeys<Paths[P], "delete">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "delete">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "delete">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "delete">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "delete" extends infer T
@@ -170,17 +169,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a OPTIONS endpoint */
-  OPTIONS<P extends PathsWithMethod<Paths, "options">>(
+  OPTIONS<
+    P extends PathsWithMethod<Paths, "options">,
+    O extends FetchOptions<FilterKeys<Paths[P], "options">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "options">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "options">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "options">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "options" extends infer T
@@ -189,17 +188,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a HEAD endpoint */
-  HEAD<P extends PathsWithMethod<Paths, "head">>(
+  HEAD<
+    P extends PathsWithMethod<Paths, "head">,
+    O extends FetchOptions<FilterKeys<Paths[P], "head">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "head">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "head">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "head">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "head" extends infer T
@@ -208,17 +207,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a PATCH endpoint */
-  PATCH<P extends PathsWithMethod<Paths, "patch">>(
+  PATCH<
+    P extends PathsWithMethod<Paths, "patch">,
+    O extends FetchOptions<FilterKeys<Paths[P], "patch">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "patch">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "patch">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "patch">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "patch" extends infer T
@@ -227,17 +226,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a TRACE endpoint */
-  TRACE<P extends PathsWithMethod<Paths, "trace">>(
+  TRACE<
+    P extends PathsWithMethod<Paths, "trace">,
+    O extends FetchOptions<FilterKeys<Paths[P], "trace">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "trace">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "trace">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "trace">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "trace" extends infer T
@@ -246,7 +245,8 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
 };

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -46,7 +46,11 @@ type BodyType<T = unknown> = {
   stream: Response["body"];
 };
 export type ParseAs = keyof BodyType;
-export type ParseAsResponse<T, K> = K extends ParseAs ? BodyType<T>[K] : T;
+export type ParseAsResponse<T, O extends FetchOptions> = O extends {
+  parseAs: ParseAs;
+}
+  ? BodyType<T>[O["parseAs"]]
+  : T;
 
 export interface DefaultParamsOption {
   params?: {
@@ -78,11 +82,11 @@ export type MaybeOptionalInit<
   ? [(FetchOptions<FilterKeys<P, M>> | undefined)?]
   : [FetchOptions<FilterKeys<P, M>>];
 
-export type FetchResponse<T, R extends ParseAs = "json"> =
+export type FetchResponse<T, O extends FetchOptions> =
   | {
       data: ParseAsResponse<
         FilterKeys<SuccessResponse<ResponseObjectMap<T>>, MediaType>,
-        R
+        O
       >;
       error?: never;
       response: Response;
@@ -111,7 +115,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<FetchResponse<Paths[P]["get"], I[0]["parseAs"]>>;
+  ): Promise<FetchResponse<Paths[P]["get"], I[0]>>;
   /** Call a PUT endpoint */
   PUT<
     P extends PathsWithMethod<Paths, "put">,
@@ -119,7 +123,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<FetchResponse<Paths[P]["put"], I[0]["parseAs"]>>;
+  ): Promise<FetchResponse<Paths[P]["put"], I[0]>>;
   /** Call a POST endpoint */
   POST<
     P extends PathsWithMethod<Paths, "post">,
@@ -127,7 +131,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<FetchResponse<Paths[P]["post"], I[0]["parseAs"]>>;
+  ): Promise<FetchResponse<Paths[P]["post"], I[0]>>;
   /** Call a DELETE endpoint */
   DELETE<
     P extends PathsWithMethod<Paths, "delete">,
@@ -135,7 +139,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<FetchResponse<Paths[P]["delete"], I[0]["parseAs"]>>;
+  ): Promise<FetchResponse<Paths[P]["delete"], I[0]>>;
   /** Call a OPTIONS endpoint */
   OPTIONS<
     P extends PathsWithMethod<Paths, "options">,
@@ -143,7 +147,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<FetchResponse<Paths[P]["options"], I[0]["parseAs"]>>;
+  ): Promise<FetchResponse<Paths[P]["options"], I[0]>>;
   /** Call a HEAD endpoint */
   HEAD<
     P extends PathsWithMethod<Paths, "head">,
@@ -151,7 +155,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<FetchResponse<Paths[P]["head"], I[0]["parseAs"]>>;
+  ): Promise<FetchResponse<Paths[P]["head"], I[0]>>;
   /** Call a PATCH endpoint */
   PATCH<
     P extends PathsWithMethod<Paths, "patch">,
@@ -159,7 +163,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<FetchResponse<Paths[P]["patch"], I[0]["parseAs"]>>;
+  ): Promise<FetchResponse<Paths[P]["patch"], I[0]>>;
   /** Call a TRACE endpoint */
   TRACE<
     P extends PathsWithMethod<Paths, "trace">,
@@ -167,7 +171,7 @@ export default function createClient<Paths extends {}>(
   >(
     url: P,
     ...init: I
-  ): Promise<FetchResponse<Paths[P]["trace"], I[0]["parseAs"]>>;
+  ): Promise<FetchResponse<Paths[P]["trace"], I[0]>>;
 };
 
 /** Serialize query params to string */

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -21,8 +21,8 @@ export default function createClient(clientOptions) {
 
   /**
    * Per-request fetch (keeps settings created in createClient()
-   * @param {string} url
-   * @param {import('./index.js').FetchOptions} fetchOptions
+   * @param {T} url
+   * @param {import('./index.js').FetchOptions<T>} fetchOptions
    */
   async function coreFetch(url, fetchOptions) {
     const {
@@ -50,6 +50,7 @@ export default function createClient(clientOptions) {
     );
 
     // fetch!
+    /** @type {RequestInit} */
     const requestInit = {
       redirect: "follow",
       ...baseOptions,

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -569,23 +569,28 @@ describe("client", () => {
       it("text", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "text" });
+        const { data }: { data?: string } = await client.GET("/anyMethod", {
+          parseAs: "text",
+        });
         expect(data).toBe("{}");
       });
 
       it("arrayBuffer", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", {
-          parseAs: "arrayBuffer",
-        });
+        const { data }: { data?: ArrayBuffer } = await client.GET(
+          "/anyMethod",
+          { parseAs: "arrayBuffer" },
+        );
         expect(data instanceof ArrayBuffer).toBe(true);
       });
 
       it("blob", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "blob" });
+        const { data }: { data?: Blob } = await client.GET("/anyMethod", {
+          parseAs: "blob",
+        });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((data as any).constructor.name).toBe("Blob");
       });
@@ -593,7 +598,10 @@ describe("client", () => {
       it("stream", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "stream" });
+        const { data }: { data?: ReadableStream | null } = await client.GET(
+          "/anyMethod",
+          { parseAs: "stream" },
+        );
         expect(data instanceof Buffer).toBe(true);
       });
     });

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -569,9 +569,9 @@ describe("client", () => {
       it("text", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data, error } = await client.GET("/anyMethod", {
+        const { data, error } = (await client.GET("/anyMethod", {
           parseAs: "text",
-        });
+        })) satisfies { data?: string };
         if (error) {
           throw new Error(`parseAs text: error`);
         }
@@ -581,9 +581,9 @@ describe("client", () => {
       it("arrayBuffer", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data, error } = await client.GET("/anyMethod", {
+        const { data, error } = (await client.GET("/anyMethod", {
           parseAs: "arrayBuffer",
-        });
+        })) satisfies { data?: ArrayBuffer };
         if (error) {
           throw new Error(`parseAs arrayBuffer: error`);
         }
@@ -593,9 +593,9 @@ describe("client", () => {
       it("blob", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data, error } = await client.GET("/anyMethod", {
+        const { data, error } = (await client.GET("/anyMethod", {
           parseAs: "blob",
-        });
+        })) satisfies { data?: Blob };
         if (error) {
           throw new Error(`parseAs blob: error`);
         }
@@ -605,12 +605,13 @@ describe("client", () => {
       it("stream", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", {
+        const { data } = (await client.GET("/anyMethod", {
           parseAs: "stream",
-        });
+        })) satisfies { data?: ReadableStream<Uint8Array> | null };
         if (!data) {
           throw new Error(`parseAs stream: error`);
         }
+        // todo - not sure what test to put here - previously it just checked for instanceof Buffer
         expect(data.byteLength).toBe(8);
       });
     });

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -569,40 +569,49 @@ describe("client", () => {
       it("text", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: string } = await client.GET("/anyMethod", {
+        const { data, error } = await client.GET("/anyMethod", {
           parseAs: "text",
         });
-        expect(data).toBe("{}");
+        if (error) {
+          throw new Error(`parseAs text: error`);
+        }
+        expect(data.toLowerCase()).toBe("{}");
       });
 
       it("arrayBuffer", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: ArrayBuffer } = await client.GET(
-          "/anyMethod",
-          { parseAs: "arrayBuffer" },
-        );
-        expect(data instanceof ArrayBuffer).toBe(true);
+        const { data, error } = await client.GET("/anyMethod", {
+          parseAs: "arrayBuffer",
+        });
+        if (error) {
+          throw new Error(`parseAs arrayBuffer: error`);
+        }
+        expect(data.byteLength).toBe(true);
       });
 
       it("blob", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: Blob } = await client.GET("/anyMethod", {
+        const { data, error } = await client.GET("/anyMethod", {
           parseAs: "blob",
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((data as any).constructor.name).toBe("Blob");
+        if (error) {
+          throw new Error(`parseAs blob: error`);
+        }
+        expect((data as any).constructor.name).toBe("Blob"); // eslint-disable-line @typescript-eslint/no-explicit-any
       });
 
       it("stream", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: ReadableStream | null } = await client.GET(
-          "/anyMethod",
-          { parseAs: "stream" },
-        );
-        expect(data instanceof Buffer).toBe(true);
+        const { data } = await client.GET("/anyMethod", {
+          parseAs: "stream",
+        });
+        if (!data) {
+          throw new Error(`parseAs stream: error`);
+        }
+        expect(data.byteLength).toBe(8);
       });
     });
   });

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -599,7 +599,8 @@ describe("client", () => {
         if (error) {
           throw new Error(`parseAs blob: error`);
         }
-        expect((data as any).constructor.name).toBe("Blob"); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        expect(data.constructor.name).toBe("Blob");
       });
 
       it("stream", async () => {

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -587,7 +587,7 @@ describe("client", () => {
         if (error) {
           throw new Error(`parseAs arrayBuffer: error`);
         }
-        expect(data.byteLength).toBe(true);
+        expect(data.byteLength).toBe(2);
       });
 
       it("blob", async () => {
@@ -611,8 +611,13 @@ describe("client", () => {
         if (!data) {
           throw new Error(`parseAs stream: error`);
         }
-        // todo - not sure what test to put here - previously it just checked for instanceof Buffer
-        expect(data.byteLength).toBe(8);
+
+        expect(data instanceof Buffer).toBe(true);
+        if (!(data instanceof Buffer)) {
+          throw Error("Data should be an instance of Buffer in Node context");
+        }
+
+        expect(data.byteLength).toBe(2);
       });
     });
   });

--- a/packages/openapi-fetch/test/v7-beta.test.ts
+++ b/packages/openapi-fetch/test/v7-beta.test.ts
@@ -578,23 +578,30 @@ describe("client", () => {
       it("text", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "text" });
+        const { data }: { data?: string } = await client.GET("/anyMethod", {
+          parseAs: "text",
+        });
         expect(data).toBe("{}");
       });
 
       it("arrayBuffer", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", {
-          parseAs: "arrayBuffer",
-        });
+        const { data }: { data?: ArrayBuffer } = await client.GET(
+          "/anyMethod",
+          {
+            parseAs: "arrayBuffer",
+          },
+        );
         expect(data instanceof ArrayBuffer).toBe(true);
       });
 
       it("blob", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "blob" });
+        const { data }: { data?: Blob } = await client.GET("/anyMethod", {
+          parseAs: "blob",
+        });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((data as any).constructor.name).toBe("Blob");
       });
@@ -602,7 +609,10 @@ describe("client", () => {
       it("stream", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "stream" });
+        const { data }: { data?: ReadableStream | null } = await client.GET(
+          "/anyMethod",
+          { parseAs: "stream" },
+        );
         expect(data instanceof Buffer).toBe(true);
       });
     });

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -77,9 +77,7 @@ export type ErrorResponse<T> = FilterKeys<
 // Generic TS utils
 
 /** Find first match of multiple keys */
-export type FilterKeys<Obj, Matchers> = {
-  [K in keyof Obj]: K extends Matchers ? Obj[K] : never;
-}[keyof Obj];
+export type FilterKeys<Obj, Matchers> = Obj[keyof Obj & Matchers];
 /** Return any `[string]/[string]` media type (important because openapi-fetch allows any content response, not just JSON-like) */
 export type MediaType = `${string}/${string}`;
 /** Filter objects that have required keys */


### PR DESCRIPTION
## Changes

Closes #1370

## How to Review

Improves typing of fetch function by introducing a fetchOptions generic which can then be used to report correct return type.

## Checklist

- [x] Unit tests updated 
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
