### PR TITLE
Add Node 21 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 21.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Changes

CI-only change: Add Node 21.x to CI to test upcoming compatibility for when 22.x gets a stable release.

Will keep `macos` and `windows` locked to 20.x because those runners are expensive, and GitHub doesn’t queue those up too many (tried to expand the matrix to include these, but it just blocked the CI pipeline for a half hour)

## How to Review

- CI should pass (🤞)

## Checklist

N/A
