### PR TITLE
[openapi-fetch] Support parseAs type inference

### DIFF
--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -117,13 +117,12 @@ export default function createClient<Paths extends {}>(
     >
   >;
   /** Call a PUT endpoint */
-  PUT<P extends PathsWithMethod<Paths, "put">>(
+  PUT<
+    P extends PathsWithMethod<Paths, "put">,
+    O extends FetchOptions<FilterKeys<Paths[P], "put">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "put">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "put">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "put">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "put" extends infer T
@@ -132,17 +131,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a POST endpoint */
-  POST<P extends PathsWithMethod<Paths, "post">>(
+  POST<
+    P extends PathsWithMethod<Paths, "post">,
+    O extends FetchOptions<FilterKeys<Paths[P], "post">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "post">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "post">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "post">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "post" extends infer T
@@ -151,17 +150,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a DELETE endpoint */
-  DELETE<P extends PathsWithMethod<Paths, "delete">>(
+  DELETE<
+    P extends PathsWithMethod<Paths, "delete">,
+    O extends FetchOptions<FilterKeys<Paths[P], "delete">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "delete">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "delete">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "delete">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "delete" extends infer T
@@ -170,17 +169,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a OPTIONS endpoint */
-  OPTIONS<P extends PathsWithMethod<Paths, "options">>(
+  OPTIONS<
+    P extends PathsWithMethod<Paths, "options">,
+    O extends FetchOptions<FilterKeys<Paths[P], "options">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "options">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "options">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "options">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "options" extends infer T
@@ -189,17 +188,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a HEAD endpoint */
-  HEAD<P extends PathsWithMethod<Paths, "head">>(
+  HEAD<
+    P extends PathsWithMethod<Paths, "head">,
+    O extends FetchOptions<FilterKeys<Paths[P], "head">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "head">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "head">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "head">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "head" extends infer T
@@ -208,17 +207,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a PATCH endpoint */
-  PATCH<P extends PathsWithMethod<Paths, "patch">>(
+  PATCH<
+    P extends PathsWithMethod<Paths, "patch">,
+    O extends FetchOptions<FilterKeys<Paths[P], "patch">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "patch">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "patch">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "patch">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "patch" extends infer T
@@ -227,17 +226,17 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
   /** Call a TRACE endpoint */
-  TRACE<P extends PathsWithMethod<Paths, "trace">>(
+  TRACE<
+    P extends PathsWithMethod<Paths, "trace">,
+    O extends FetchOptions<FilterKeys<Paths[P], "trace">> = {},
+  >(
     url: P,
-    ...init: HasRequiredKeys<
-      FetchOptions<FilterKeys<Paths[P], "trace">>
-    > extends never
-      ? [(FetchOptions<FilterKeys<Paths[P], "trace">> | undefined)?]
-      : [FetchOptions<FilterKeys<Paths[P], "trace">>]
+    ...init: HasRequiredKeys<O> extends never ? [O?] : [O]
   ): Promise<
     FetchResponse<
       "trace" extends infer T
@@ -246,7 +245,8 @@ export default function createClient<Paths extends {}>(
             ? Paths[P][T]
             : unknown
           : never
-        : never
+        : never,
+      O
     >
   >;
 };

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -21,8 +21,8 @@ export default function createClient(clientOptions) {
 
   /**
    * Per-request fetch (keeps settings created in createClient()
-   * @param {string} url
-   * @param {import('./index.js').FetchOptions} fetchOptions
+   * @param {T} url
+   * @param {import('./index.js').FetchOptions<T>} fetchOptions
    */
   async function coreFetch(url, fetchOptions) {
     const {
@@ -50,6 +50,7 @@ export default function createClient(clientOptions) {
     );
 
     // fetch!
+    /** @type {RequestInit} */
     const requestInit = {
       redirect: "follow",
       ...baseOptions,

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -569,23 +569,28 @@ describe("client", () => {
       it("text", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "text" });
+        const { data }: { data?: string } = await client.GET("/anyMethod", {
+          parseAs: "text",
+        });
         expect(data).toBe("{}");
       });
 
       it("arrayBuffer", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", {
-          parseAs: "arrayBuffer",
-        });
+        const { data }: { data?: ArrayBuffer } = await client.GET(
+          "/anyMethod",
+          { parseAs: "arrayBuffer" },
+        );
         expect(data instanceof ArrayBuffer).toBe(true);
       });
 
       it("blob", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "blob" });
+        const { data }: { data?: Blob } = await client.GET("/anyMethod", {
+          parseAs: "blob",
+        });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((data as any).constructor.name).toBe("Blob");
       });
@@ -593,7 +598,10 @@ describe("client", () => {
       it("stream", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "stream" });
+        const { data }: { data?: ReadableStream | null } = await client.GET(
+          "/anyMethod",
+          { parseAs: "stream" },
+        );
         expect(data instanceof Buffer).toBe(true);
       });
     });

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -569,40 +569,49 @@ describe("client", () => {
       it("text", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: string } = await client.GET("/anyMethod", {
+        const { data, error } = await client.GET("/anyMethod", {
           parseAs: "text",
         });
-        expect(data).toBe("{}");
+        if (error) {
+          throw new Error(`parseAs text: error`);
+        }
+        expect(data.toLowerCase()).toBe("{}");
       });
 
       it("arrayBuffer", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: ArrayBuffer } = await client.GET(
-          "/anyMethod",
-          { parseAs: "arrayBuffer" },
-        );
-        expect(data instanceof ArrayBuffer).toBe(true);
+        const { data, error } = await client.GET("/anyMethod", {
+          parseAs: "arrayBuffer",
+        });
+        if (error) {
+          throw new Error(`parseAs arrayBuffer: error`);
+        }
+        expect(data.byteLength).toBe(true);
       });
 
       it("blob", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: Blob } = await client.GET("/anyMethod", {
+        const { data, error } = await client.GET("/anyMethod", {
           parseAs: "blob",
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((data as any).constructor.name).toBe("Blob");
+        if (error) {
+          throw new Error(`parseAs blob: error`);
+        }
+        expect((data as any).constructor.name).toBe("Blob"); // eslint-disable-line @typescript-eslint/no-explicit-any
       });
 
       it("stream", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: ReadableStream | null } = await client.GET(
-          "/anyMethod",
-          { parseAs: "stream" },
-        );
-        expect(data instanceof Buffer).toBe(true);
+        const { data } = await client.GET("/anyMethod", {
+          parseAs: "stream",
+        });
+        if (!data) {
+          throw new Error(`parseAs stream: error`);
+        }
+        expect(data.byteLength).toBe(8);
       });
     });
   });

--- a/packages/openapi-fetch/test/v7-beta.test.ts
+++ b/packages/openapi-fetch/test/v7-beta.test.ts
@@ -578,23 +578,30 @@ describe("client", () => {
       it("text", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "text" });
+        const { data }: { data?: string } = await client.GET("/anyMethod", {
+          parseAs: "text",
+        });
         expect(data).toBe("{}");
       });
 
       it("arrayBuffer", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", {
-          parseAs: "arrayBuffer",
-        });
+        const { data }: { data?: ArrayBuffer } = await client.GET(
+          "/anyMethod",
+          {
+            parseAs: "arrayBuffer",
+          },
+        );
         expect(data instanceof ArrayBuffer).toBe(true);
       });
 
       it("blob", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "blob" });
+        const { data }: { data?: Blob } = await client.GET("/anyMethod", {
+          parseAs: "blob",
+        });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((data as any).constructor.name).toBe("Blob");
       });
@@ -602,7 +609,10 @@ describe("client", () => {
       it("stream", async () => {
         const client = createClient<paths>();
         mockFetchOnce({ status: 200, body: "{}" });
-        const { data } = await client.GET("/anyMethod", { parseAs: "stream" });
+        const { data }: { data?: ReadableStream | null } = await client.GET(
+          "/anyMethod",
+          { parseAs: "stream" },
+        );
         expect(data instanceof Buffer).toBe(true);
       });
     });


### PR DESCRIPTION
## Changes

Adds parseAs inference; continues from #1428

## How to Review

- N/A

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
