### PR TITLE
Add SuccessResponseJSON, ErrorResponseJSON helpers

### DIFF
--- a/.changeset/twelve-gifts-sort.md
+++ b/.changeset/twelve-gifts-sort.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript-helpers": patch
+---
+
+Add SuccessResponseJSON, ErrorResponseJSON helpers

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -67,11 +67,16 @@ export type OperationRequestBodyContent<T> = FilterKeys<
       | undefined
   : FilterKeys<OperationRequestBodyMediaContent<T>, MediaType>;
 /** Return first 2XX response from a Response Object Map */
-export type SuccessResponse<T> = FilterKeys<FilterKeys<T, OkStatus>, "content">;
+export type SuccessResponse<T> = ResponseContent<FilterKeys<T, OkStatus>>;
 /** Return first 5XX or 4XX response (in that order) from a Response Object Map */
-export type ErrorResponse<T> = FilterKeys<
-  FilterKeys<T, ErrorStatus>,
-  "content"
+export type ErrorResponse<T> = ResponseContent<FilterKeys<T, ErrorStatus>>;
+/** Return first JSON-like 2XX response from a path + HTTP method */
+export type SuccessResponseJSON<PathMethod> = JSONLike<
+  SuccessResponse<ResponseObjectMap<PathMethod>>
+>;
+/** Return first JSON-like 5XX or 4XX response from a path + HTTP method */
+export type ErrorResponseJSON<PathMethod> = JSONLike<
+  ErrorResponse<ResponseObjectMap<PathMethod>>
 >;
 
 // Generic TS utils
@@ -82,6 +87,8 @@ export type FilterKeys<Obj, Matchers> = {
 }[keyof Obj];
 /** Return any `[string]/[string]` media type (important because openapi-fetch allows any content response, not just JSON-like) */
 export type MediaType = `${string}/${string}`;
+/** Return any media type containing "json" (works for "application/json", "application/vnd.api+json", "application/vnd.oai.openapi+json") */
+export type JSONLike<T> = FilterKeys<T, `${string}/json`>;
 /** Filter objects that have required keys */
 export type FindRequiredKeys<T, K extends keyof T> = K extends unknown
   ? undefined extends T[K]


### PR DESCRIPTION
## Changes

Adds `SuccessResponseJSON` and `ErrorResponseJSON` helpers for easier usage. Before/after:

```diff
- type Response =
-   | SuccessResponse<FilterKeys<ResponseObjectMap<paths["/my/endpoint"]["get"]>, "application/json">>
-   | ErrorResponse<FilterKeys<ResponseObjectMap<paths["/my/endpoint"]["get"]>, "application/json">>;
+ type Response =
+   | SuccessResponseJSON<paths["/my/endpoint"]["get"]>
+   | ErrorResponseJSON<paths["/my/endpoint"]["get"]>;
```

Note this won’t be used in `openapi-fetch` for ✨ _reasons_ ✨. But is a useful utility.

_Note—will probably keep `Success*` and `Error*` separated for the forseeable future because they’re trivial to combine in a union, and you frequently will want to have these in different codepaths anyway._

## How to Review

N/A

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
