### PR TITLE
openapi-typescript-helpers@0.0.6

### DIFF
--- a/.changeset/nine-pigs-reply.md
+++ b/.changeset/nine-pigs-reply.md
@@ -1,5 +1,0 @@
----
-"openapi-typescript-helpers": patch
----
-
-Add RequestBodyJSON helper

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -63,7 +63,7 @@
     "version": "pnpm run prepare && pnpm run build"
   },
   "dependencies": {
-    "openapi-typescript-helpers": "^0.0.5"
+    "openapi-typescript-helpers": "^0.0.6"
   },
   "devDependencies": {
     "axios": "^1.6.0",

--- a/packages/openapi-typescript-helpers/CHANGELOG.md
+++ b/packages/openapi-typescript-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openapi-typescript-helpers
 
+## 0.0.6
+
+### Patch Changes
+
+- [#1458](https://github.com/drwpow/openapi-typescript/pull/1458) [`23517a2`](https://github.com/drwpow/openapi-typescript/commit/23517a2c2ab94d49085391130cd7d11f4da33cfb) Thanks [@drwpow](https://github.com/drwpow)! - Add RequestBodyJSON helper
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-typescript-helpers",
   "description": "TypeScript helpers for consuming openapi-typescript types",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
   packages/openapi-fetch:
     dependencies:
       openapi-typescript-helpers:
-        specifier: ^0.0.5
+        specifier: ^0.0.6
         version: link:../openapi-typescript-helpers
     devDependencies:
       axios:


### PR DESCRIPTION
## Changes

Publishes openapi-typescript-helpers@0.0.6 while 7.x is in beta

## How to Review

N/A

## Checklist

N/A