### PR TITLE
support $ref on deduplication of operator-object and path-item parameters

### DIFF
--- a/packages/openapi-typescript/src/transform/path-item-object.ts
+++ b/packages/openapi-typescript/src/transform/path-item-object.ts
@@ -80,17 +80,17 @@ export default function transformPathItemObject(
     }
 
     // fold top-level PathItem parameters into method-level, with the latter overriding the former
-    const keyedParameters: Record<string, ParameterObject | ReferenceObject> =
-      {};
+    const keyedParameters: Record<string, ParameterObject | ReferenceObject> = {};
     if (!("$ref" in operationObject)) {
       // important: OperationObject parameters come last, and will override any conflicts with PathItem parameters
       for (const parameter of [
         ...(pathItem.parameters ?? []),
         ...(operationObject.parameters ?? []),
       ]) {
-        // note: the actual key doesn’t matter here, as long as it can match between PathItem and OperationObject
-        keyedParameters["$ref" in parameter ? parameter.$ref : parameter.name] =
-          parameter;
+        const name = "$ref" in parameter ? options.ctx.resolve<ParameterObject>(parameter.$ref)?.name : parameter.name;
+        if (name) {
+          keyedParameters[name] = parameter;
+        }
       }
     }
 

--- a/packages/openapi-typescript/src/transform/path-item-object.ts
+++ b/packages/openapi-typescript/src/transform/path-item-object.ts
@@ -80,14 +80,18 @@ export default function transformPathItemObject(
     }
 
     // fold top-level PathItem parameters into method-level, with the latter overriding the former
-    const keyedParameters: Record<string, ParameterObject | ReferenceObject> = {};
+    const keyedParameters: Record<string, ParameterObject | ReferenceObject> =
+      {};
     if (!("$ref" in operationObject)) {
       // important: OperationObject parameters come last, and will override any conflicts with PathItem parameters
       for (const parameter of [
         ...(pathItem.parameters ?? []),
         ...(operationObject.parameters ?? []),
       ]) {
-        const name = "$ref" in parameter ? options.ctx.resolve<ParameterObject>(parameter.$ref)?.name : parameter.name;
+        const name =
+          "$ref" in parameter
+            ? options.ctx.resolve<ParameterObject>(parameter.$ref)?.name
+            : parameter.name;
         if (name) {
           keyedParameters[name] = parameter;
         }

--- a/packages/openapi-typescript/test/fixtures/_parameters-test-partial.yaml
+++ b/packages/openapi-typescript/test/fixtures/_parameters-test-partial.yaml
@@ -10,3 +10,9 @@ remote_ref_b:
   schema:
     type: string
   required: true
+remote_ref_override:
+  in: query
+  name: remote_ref_override
+  schema:
+    type: string
+  required: true

--- a/packages/openapi-typescript/test/fixtures/parameters-test.yaml
+++ b/packages/openapi-typescript/test/fixtures/parameters-test.yaml
@@ -25,10 +25,12 @@ paths:
           required: true
         - in: query
           name: local_ref_override
+          description: This overrides parameters with local $ref
           schema:
             type: string
         - in: query
           name: remote_ref_override
+          description: This overrides parameters with remote $ref
           schema:
             type: string
         - $ref: "#/components/parameters/local_ref_b"

--- a/packages/openapi-typescript/test/fixtures/parameters-test.yaml
+++ b/packages/openapi-typescript/test/fixtures/parameters-test.yaml
@@ -11,7 +11,9 @@ paths:
           type: string
         required: true
       - $ref: "#/components/parameters/local_ref_a"
+      - $ref: "#/components/parameters/local_ref_override"
       - $ref: "./_parameters-test-partial.yaml#/remote_ref_a"
+      - $ref: "./_parameters-test-partial.yaml#/remote_ref_override"
     get:
       description: OK
       parameters:
@@ -21,6 +23,14 @@ paths:
             type: number
           description: This overrides parameters
           required: true
+        - in: query
+          name: local_ref_override
+          schema:
+            type: string
+        - in: query
+          name: remote_ref_override
+          schema:
+            type: string
         - $ref: "#/components/parameters/local_ref_b"
         - $ref: "./_parameters-test-partial.yaml#/remote_ref_b"
 components:
@@ -34,6 +44,12 @@ components:
     local_ref_b:
       in: path
       name: local_ref_b
+      schema:
+        type: string
+      required: true
+    local_ref_override:
+      in: query
+      name: local_ref_override
       schema:
         type: string
       required: true

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -131,7 +131,10 @@ export type operations = Record<string, never>;`,
         want: `export interface paths {
     "/endpoint": {
         parameters: {
-            query?: never;
+            query: {
+                local_ref_override: components["parameters"]["local_ref_override"];
+                remote_ref_override: components["parameters"]["remote_ref_override"];
+            };
             header?: never;
             path: {
                 local_param_a: string;
@@ -143,7 +146,10 @@ export type operations = Record<string, never>;`,
         /** @description OK */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    local_ref_override?: string;
+                    remote_ref_override?: string;
+                };
                 header?: never;
                 path: {
                     /** @description This overrides parameters */
@@ -174,7 +180,9 @@ export interface components {
     parameters: {
         local_ref_a: string;
         local_ref_b: string;
+        local_ref_override: string;
         remote_ref_a: string;
+        remote_ref_override: string;
         remote_ref_b: string;
     };
     requestBodies: never;

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -147,7 +147,9 @@ export type operations = Record<string, never>;`,
         get: {
             parameters: {
                 query?: {
+                    /** @description This overrides parameters with local $ref */
                     local_ref_override?: string;
+                    /** @description This overrides parameters with remote $ref */
                     remote_ref_override?: string;
                 };
                 header?: never;


### PR DESCRIPTION
## Changes

openapi-typescript already support parameters deduplication but it doesn't care about `$ref`.
so if schema has `$ref` parameter with same key, it will be invalid typescript types.


## How to Review

I used `ctx.resolve` method but I don't know it's reasonable.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
