### PR TITLE
Fix Redoc CLI warning

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,17 +27,17 @@ npx openapi-typescript https://petstore3.swagger.io/api/v3/openapi.yaml -o petst
 
 ### Multiple schemas
 
-To transform multiple schemas, create a `redocly.yaml` file in the root of your project with [APIs defined](https://redocly.com/docs/cli/configuration/). Under `apis`, give each schema a unique name and optionally a version (the name doesn’t matter, so long as it’s unique). Set the `root` value to your schema’s entry point—this will act as the main input. For the output, set it with `openapi-ts.output`:
+To transform multiple schemas, create a `redocly.yaml` file in the root of your project with [APIs defined](https://redocly.com/docs/cli/configuration/). Under `apis`, give each schema a unique name and optionally a version (the name doesn’t matter, so long as it’s unique). Set the `root` value to your schema’s entry point—this will act as the main input. For the output, set it with `x-openapi-ts.output`:
 
 ```yaml
 apis:
   core@v2:
     root: ./openapi/openapi.yaml
-    openapi-ts:
+    x-openapi-ts:
       output: ./openapi/openapi.ts
   external@v1:
     root: ./openapi/external.yaml
-    openapi-ts:
+    x-openapi-ts:
       output: ./openapi/openapi.ts
 ```
 

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -38,6 +38,7 @@ Options
 const OUTPUT_FILE = "FILE";
 const OUTPUT_STDOUT = "STDOUT";
 const CWD = new URL(`file://${process.cwd()}/`);
+const REDOC_CONFIG_KEY = "x-openapi-ts";
 
 const timeStart = performance.now();
 
@@ -168,18 +169,25 @@ async function main() {
             ? new URL(`file://${redoc.configFile}`)
             : new URL(redoc.configFile, `file://${process.cwd()}/`);
         }
-        if (!api["openapi-ts"]?.output) {
+        if (!api[REDOC_CONFIG_KEY]?.output) {
+          // TODO: remove in stable v7
+          if (api["openapi-ts"]) {
+            errorAndExit(
+              `Please rename "openapi-ts" to "x-openapi-ts" in your Redoc config.`,
+            );
+          }
+
           errorAndExit(
-            `API ${name} is missing an \`openapi-ts.output\` key. See https://openapi-ts.pages.dev/cli/#multiple-schemas.`,
+            `API ${name} is missing an \`${REDOC_CONFIG_KEY}.output\` key. See https://openapi-ts.pages.dev/cli/#multiple-schemas.`,
           );
         }
         const result = await generateSchema(new URL(api.root, configRoot), {
           redoc, // TODO: merge API overrides better?
         });
-        const outFile = new URL(api["openapi-ts"].output, configRoot);
+        const outFile = new URL(api[REDOC_CONFIG_KEY].output, configRoot);
         fs.mkdirSync(new URL(".", outFile), { recursive: true });
         fs.writeFileSync(outFile, result, "utf8");
-        done(name, api["openapi-ts"].output, performance.now() - timeStart);
+        done(name, api[REDOC_CONFIG_KEY].output, performance.now() - timeStart);
       }),
     );
   }

--- a/packages/openapi-typescript/test/fixtures/redocly-flag/redocly.yaml
+++ b/packages/openapi-typescript/test/fixtures/redocly-flag/redocly.yaml
@@ -4,13 +4,13 @@ extends:
 apis:
   a@v1:
     root: ./openapi/a.yaml
-    openapi-ts:
+    x-openapi-ts:
       output: ./output/a.ts
   b@v1:
     root: ./openapi/b.yaml
-    openapi-ts:
+    x-openapi-ts:
       output: ./output/b.ts
   c@v1:
     root: ./openapi/c.yaml
-    openapi-ts:
+    x-openapi-ts:
       output: ./output/c.ts

--- a/packages/openapi-typescript/test/fixtures/redocly/redocly.yaml
+++ b/packages/openapi-typescript/test/fixtures/redocly/redocly.yaml
@@ -4,13 +4,13 @@ extends:
 apis:
   a@v1:
     root: ./openapi/a.yaml
-    openapi-ts:
+    x-openapi-ts:
       output: ./output/a.ts
   b@v1:
     root: ./openapi/b.yaml
-    openapi-ts:
+    x-openapi-ts:
       output: ./output/b.ts
   c@v1:
     root: ./openapi/c.yaml
-    openapi-ts:
+    x-openapi-ts:
       output: ./output/c.ts


### PR DESCRIPTION
## Changes

Fixes #1463 by changing `openapi-ts` to `x-openapi-ts`. This is a breaking change, but there’s a helpful migration error for users of the beta version.

## How to Review

- Tests updated; tests should pass

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
