### PR TITLE
fix: correctly transform untyped nullable field

### DIFF
--- a/.changeset/large-ways-cheat.md
+++ b/.changeset/large-ways-cheat.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Correctly transform untyped nullable fields to `unknown`

--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -9085,7 +9085,7 @@ export interface external {
      * @description The Droplet that the floating IP has been assigned to. When you query a floating IP, if it is assigned to a Droplet, the entire Droplet object will be returned. If it is not assigned, the value will be null.
      * @example null
      */
-    droplet?: (Record<string, unknown> | null) | external["resources/droplets/models/droplet.yml"];
+    droplet?: unknown;
     /**
      * @description A boolean value indicating whether or not the floating IP has pending actions preventing new ones from being submitted.
      * @example true
@@ -13948,7 +13948,7 @@ export interface external {
      * @description The Droplet that the reserved IP has been assigned to. When you query a reserved IP, if it is assigned to a Droplet, the entire Droplet object will be returned. If it is not assigned, the value will be null.
      * @example null
      */
-    droplet?: (Record<string, unknown> | null) | external["resources/droplets/models/droplet.yml"];
+    droplet?: unknown;
     /**
      * @description A boolean value indicating whether or not the reserved IP has pending actions preventing new ones from being submitted.
      * @example true

--- a/packages/openapi-typescript/examples/octokit-ghes-3.6-diff-to-api.ts
+++ b/packages/openapi-typescript/examples/octokit-ghes-3.6-diff-to-api.ts
@@ -1227,7 +1227,7 @@ export interface components {
       permission?: string;
       members_url?: string;
       repositories_url?: string;
-      parent?: Record<string, unknown> | null;
+      parent?: unknown;
     };
     /**
      * Ldap Private User

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -267,7 +267,7 @@ export function defaultSchemaObjectTransform(schemaObject: SchemaObject | Refere
   }
 
   // nullable (3.0)
-  if (schemaObject.nullable) finalType = tsUnionOf(finalType || "Record<string, unknown>", "null");
+  if (schemaObject.nullable) finalType = tsUnionOf(finalType || "unknown", "null");
 
   if (finalType) return finalType;
 

--- a/packages/openapi-typescript/test/schema-object.test.ts
+++ b/packages/openapi-typescript/test/schema-object.test.ts
@@ -374,6 +374,11 @@ describe("Schema Object", () => {
       const generated = transformSchemaObject({}, options);
       expect(generated).toBe(`unknown`);
     });
+
+    test("unknown nullable", () => {
+      const generated = transformSchemaObject({ nullable: true }, options);
+      expect(generated).toBe(`unknown`);
+    });
   });
 
   describe("schema composition", () => {


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

Fixes #1407

Correctly transform untyped nullable field to `unknown` instead of `Record<string, unknown> | null`

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

First PR, so are there any test cases I'm missing? Anything I should add? Anything I should keep in mind going forward?

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
