### PR TITLE
docs: fixing various typos in the docs

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -41,7 +41,7 @@ description: Additional info about this project
 
 ### vs. swagger-codegen
 
-openapi-typescript was created specifically to be a lighterweight, easier-to-use alternative to swagger-codegen that doesn’t require the Java runtime or running an OpenAPI server. Nor does it generate heavyweight clientside code. In fact, all the code openapi-typescript generates is **runtime free static types** for maximum performance and minimum client weight.
+openapi-typescript was created specifically to be a lighter-weight, easier-to-use alternative to swagger-codegen that doesn’t require the Java runtime or running an OpenAPI server. Nor does it generate heavyweight client-side code. In fact, all the code openapi-typescript generates is **runtime free static types** for maximum performance and minimum client weight.
 
 ### vs. openapi-typescript-codegen
 
@@ -51,7 +51,7 @@ These 2 projects are unrelated. openapi-typescript-codegen is a Node.js alternat
 
 [tRPC](https://trpc.io/) is an opinionated typesafe framework for both server and client. It demands both your server and client be written in tRPC (which means Node.js for the backend).
 
-If you fit into this usecase, it’s a great experience! But for everyone else, openapi-typescript (and openapi-fetch) is a more flexible, lower-level solution that can work for any technology choice (or even be incrementally-adopted without any cost).
+If you fit into this use case, it’s a great experience! But for everyone else, openapi-typescript (and openapi-fetch) is a more flexible, lower-level solution that can work for any technology choice (or even be incrementally-adopted without any cost).
 
 ## Contributors
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -87,7 +87,7 @@ Different languages have different preferred syntax styles. To name a few:
 - `PascalCase`
 - `kebab-case`
 
-It’s tempting to want to rename API responses into `camelCase` that most JS styleguides encourage. However, **avoid renaming** because in addition to being a timesink, it introduces the following maintenance issues:
+It’s tempting to want to rename API responses into `camelCase` that most JS styleguides encourage. However, **avoid renaming** because in addition to being a time sink, it introduces the following maintenance issues:
 
 - ❌ generated types (like the ones produced by openapi-typescript) now have to be manually typed again
 - ❌ renaming has to happen at runtime, which means you’re slowing down your application for an invisible change

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ apis:
       output: ./openapi/openapi.ts
 ```
 
-Whenver you have a `redocly.yaml` file in your project with `apis`, you can omit the input/output parameters in the CLI:
+Whenever you have a `redocly.yaml` file in your project with `apis`, you can omit the input/output parameters in the CLI:
 
 ```bash
 npx openapi-typescript

--- a/packages/openapi-fetch/README.md
+++ b/packages/openapi-fetch/README.md
@@ -34,7 +34,7 @@ await PUT("/blogposts", {
 });
 ```
 
-`data` and `error` are typechecked and expose their shapes to Intellisence in VS Code (and any other IDE with TypeScript support). Likewise, the request `body` will also typecheck its fields, erring if any required params are missing, or if there’s a type mismatch.
+`data` and `error` are typechecked and expose their shapes to Intellisense in VS Code (and any other IDE with TypeScript support). Likewise, the request `body` will also typecheck its fields, erring if any required params are missing, or if there’s a type mismatch.
 
 `GET`, `PUT`, `POST`, etc. are only thin wrappers around the native [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (which you can [swap for any call](https://openapi-ts.pages.dev/openapi-fetch/api/#create-client)).
 

--- a/packages/openapi-typescript/CONTRIBUTING.md
+++ b/packages/openapi-typescript/CONTRIBUTING.md
@@ -40,7 +40,7 @@ This will compile the code as you change automatically.
 
 #### Tip: use ASTExplorer.net!
 
-Working with the TypeScript AST can be daunting. Luckly, there’s [astexplorer.net](https://astexplorer.net) which makes it much more accessible. Rather than trying to build an AST from scratch (which is near impossible), instead:
+Working with the TypeScript AST can be daunting. Luckily, there’s [astexplorer.net](https://astexplorer.net) which makes it much more accessible. Rather than trying to build an AST from scratch (which is near impossible), instead:
 
 1. Switch to the **typescript** parser in the top menu
 2. Type out code in the left-hand panel
@@ -66,7 +66,7 @@ To add a schema as a snapshot test, modify the [/scripts/download-schemas.ts](/s
 
 ### Generating types
 
-It may be surprising to hear, but generating TypeScript types from OpenAPI is opinionated. Even though TypeScript and OpenAPI are close relatives—both JavaScript/JSON-based—they are nonetheless 2 different languages and thus there is room for interpretation. Further, some parts of the OpenAPI specification can be ambiguous on how they’re used, and what the expected type outcomes may be (though this is generally for more advanced usecasees, such as specific implementations of `anyOf` as well as [discriminator](https://spec.openapis.org/oas/latest.html#discriminatorObject) and complex polymorphism).
+It may be surprising to hear, but generating TypeScript types from OpenAPI is opinionated. Even though TypeScript and OpenAPI are close relatives—both JavaScript/JSON-based—they are nonetheless 2 different languages and thus there is room for interpretation. Further, some parts of the OpenAPI specification can be ambiguous on how they’re used, and what the expected type outcomes may be (though this is generally for more advanced use cases, such as specific implementations of `anyOf` as well as [discriminator](https://spec.openapis.org/oas/latest.html#discriminatorObject) and complex polymorphism).
 
 All that said, this library should strive to generate _the most predictable_ TypeScript output for a given schema. And to achieve that, it always helps to open an [issue](https://github.com/drwpow/openapi-typescript/issues) or [discussion](https://github.com/drwpow/openapi-typescript/discussions) to gather feedback.
 


### PR DESCRIPTION
## Changes

Just some small typos I noticed while reading through the docs.
