### PR TITLE
Separate outputs for CommonJS and ESM when building openapi-typescrip…

### DIFF
--- a/.changeset/hot-terms-vanish.md
+++ b/.changeset/hot-terms-vanish.md
@@ -1,0 +1,6 @@
+---
+"openapi-fetch": patch
+"openapi-typescript-helpers": patch
+---
+
+Fixed build of openapi-typescript-helpers for CommonJS environments

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "scripts": {
     "build": "run-p -s build:*",
     "build:openapi-typescript": "cd packages/openapi-typescript && pnpm run build",
-    "build:openapi-typescript-helpers": "cd packages/openapi-typescript-helpers && pnpm run build",
-    "build:openapi-fetch": "cd packages/openapi-fetch && pnpm run build",
+    "build:openapi-fetch": "cd packages/openapi-typescript-helpers && pnpm run build && cd ../openapi-fetch && pnpm run build",
     "lint": "run-p -s lint:*",
     "lint:openapi-typescript": "cd packages/openapi-typescript && pnpm run lint",
     "lint:openapi-typescript-helpers": "cd packages/openapi-typescript-helpers && pnpm run lint",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "run-p -s build:*",
     "build:openapi-typescript": "cd packages/openapi-typescript && pnpm run build",
+    "build:openapi-typescript-helpers": "cd packages/openapi-typescript-helpers && pnpm run build",
     "build:openapi-fetch": "cd packages/openapi-fetch && pnpm run build",
     "lint": "run-p -s lint:*",
     "lint:openapi-typescript": "cd packages/openapi-typescript && pnpm run lint",

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -12,8 +12,14 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
-      "default": "./index.js",
-      "types": "./index.d.ts"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     },
     "./*": "./*"
   },
@@ -27,6 +33,10 @@
     "url": "https://github.com/drwpow/openapi-typescript/issues"
   },
   "scripts": {
+    "build": "pnpm run build:clean && pnpm run build:js && pnpm run build:cjs",
+    "build:clean": "del dist",
+    "build:js": "mkdir -p dist && cp index.js index.d.ts dist",
+    "build:cjs": "mkdir -p dist/cjs && cp index.js dist/cjs/index.js && cp index.d.ts dist/cjs/index.d.cts",
     "lint": "pnpm run lint:js",
     "lint:js": "eslint \"*.{js,ts}\"",
     "lint:prettier": "prettier --check \"{src,test}/**/*\"",


### PR DESCRIPTION
…t-helpers

## Changes

Fixes https://github.com/drwpow/openapi-typescript/issues/1478

Creates separate output directories for CommonJS and ESM for the output of `openapi-typescript-helpers`.

## How to Review

1. Run `pnpm build`
2. Check that both `packages/openapi-typescript-helpers/dist/` and `packages/openapi-typescript-helpers/dist/cjs/` contain an `index.ts` and an `index.d.ts` file.

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
