### PR TITLE
fix(openapi-typescript): build cjs support astToString export

### DIFF
--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -43,7 +43,7 @@
     "build": "run-s -s build:*",
     "build:clean": "del dist",
     "build:esm": "tsc -p tsconfig.build.json",
-    "build:cjs": "esbuild --bundle --platform=node --target=es2019 --outfile=dist/index.cjs --external:@redocly/ajv --external:@redocly/openapi-core --external:typescript src/index.ts --footer:js=\"module.exports = module.exports.default;\"",
+    "build:cjs": "esbuild --bundle --platform=node --target=es2019 --outfile=dist/index.cjs --external:@redocly/ajv --external:@redocly/openapi-core --external:typescript src/index.ts",
     "dev": "tsc -p tsconfig.build.json --watch",
     "download:schemas": "vite-node ./scripts/download-schemas.ts",
     "format": "prettier --write \"src/**/*\"",

--- a/packages/openapi-typescript/test/cjs.test.js
+++ b/packages/openapi-typescript/test/cjs.test.js
@@ -2,28 +2,7 @@
 
 // important: MUST use require()!
 const { fileURLToPath } = require("node:url");
-const ts = require("typescript");
-const openapiTS = require("../dist/index.cjs");
-
-// copy from lib/ts.ts for CJS
-function astToString(ast, options) {
-  const sourceFile = ts.createSourceFile(
-    options?.fileName ?? "openapi-ts.ts",
-    options?.sourceText ?? "",
-    ts.ScriptTarget.ESNext,
-    false,
-    ts.ScriptKind.TS,
-  );
-  sourceFile.statements = ts.factory.createNodeArray(
-    Array.isArray(ast) ? ast : [ast],
-  );
-  const printer = ts.createPrinter({
-    newLine: ts.NewLineKind.LineFeed,
-    removeComments: false,
-    ...options?.formatOptions,
-  });
-  return printer.printFile(sourceFile);
-}
+const { astToString, default: openapiTS } = require('../dist/index.cjs');
 
 describe("CJS bundle", () => {
   it("basic", async () => {


### PR DESCRIPTION
## Changes

fix: #1482 

## How to Review

```
const openapiTS = require('openapi-typescript').default;
const { astToString } = require('openapi-typescript');
// output: [Function: astToString] [AsyncFunction: openapiTS]
console.log('output:',astToString, openapiTS);
```

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
