### PR TITLE
fix(openapi-typescript):transformSchemaObject support two-dimensional…

### DIFF
--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -302,8 +302,13 @@ function transformSchemaObjectCore(
       }
       // standard array type
       else if (schemaObject.items) {
-        if("type" in schemaObject.items && schemaObject.items.type === 'array'){
-          itemType = ts.factory.createArrayTypeNode(transformSchemaObject(schemaObject.items, options));
+        if (
+          "type" in schemaObject.items &&
+          schemaObject.items.type === "array"
+        ) {
+          itemType = ts.factory.createArrayTypeNode(
+            transformSchemaObject(schemaObject.items, options),
+          );
         } else {
           itemType = transformSchemaObject(schemaObject.items, options);
         }

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -302,7 +302,11 @@ function transformSchemaObjectCore(
       }
       // standard array type
       else if (schemaObject.items) {
-        itemType = transformSchemaObject(schemaObject.items, options);
+        if("type" in schemaObject.items && schemaObject.items.type === 'array'){
+          itemType = ts.factory.createArrayTypeNode(transformSchemaObject(schemaObject.items, options));
+        } else {
+          itemType = transformSchemaObject(schemaObject.items, options);
+        }
       }
 
       const min: number =
@@ -350,9 +354,9 @@ function transformSchemaObjectCore(
         }
       }
 
-      return ts.isTupleTypeNode(itemType)
+      return ts.isTupleTypeNode(itemType) || ts.isArrayTypeNode(itemType)
         ? itemType
-        : ts.factory.createArrayTypeNode(itemType); // wrap itemType in array type, but only if not a tuple already
+        : ts.factory.createArrayTypeNode(itemType); // wrap itemType in array type, but only if not a tuple or array already
     }
 
     // polymorphic, or 3.1 nullable

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -337,6 +337,42 @@ describe("transformSchemaObject > object", () => {
         },
       },
     ],
+    [
+      "options > two-dimensional array",
+      {
+        given: {
+          type: "object",
+          properties: {
+            array: {
+              "type": "array",
+              "items": {
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "type": "array",
+                "maxItems": 2,
+                "minItems": 2
+              }
+            },
+          },
+        },
+        want: `{
+    array?: [
+        string,
+        boolean
+    ][];
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx },
+        },
+      },
+    ],
   ];
 
   for (const [

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -344,20 +344,20 @@ describe("transformSchemaObject > object", () => {
           type: "object",
           properties: {
             array: {
-              "type": "array",
-              "items": {
-                "items": [
+              type: "array",
+              items: {
+                items: [
                   {
-                    "type": "string"
+                    type: "string",
                   },
                   {
-                    "type": "boolean"
-                  }
+                    type: "boolean",
+                  },
                 ],
-                "type": "array",
-                "maxItems": 2,
-                "minItems": 2
-              }
+                type: "array",
+                maxItems: 2,
+                minItems: 2,
+              },
             },
           },
         },


### PR DESCRIPTION
… array

## Changes

fix:  #1483 
transformSchemaObject support two-dimensional array

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
