### PR TITLE
Fix missing parameters

### DIFF
--- a/.changeset/fluffy-hounds-occur.md
+++ b/.changeset/fluffy-hounds-occur.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix missing params when they have same name, different location

--- a/.changeset/fluffy-hounds-occur.md
+++ b/.changeset/fluffy-hounds-occur.md
@@ -1,5 +1,0 @@
----
-"openapi-typescript": patch
----
-
-Fix missing params when they have same name, different location

--- a/packages/openapi-typescript/CHANGELOG.md
+++ b/packages/openapi-typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openapi-typescript
 
+## 6.7.4
+
+### Patch Changes
+
+- [#1509](https://github.com/drwpow/openapi-typescript/pull/1509) [`747611bcd0d056d5027841f985aed0aefcf6b63d`](https://github.com/drwpow/openapi-typescript/commit/747611bcd0d056d5027841f985aed0aefcf6b63d) Thanks [@drwpow](https://github.com/drwpow)! - Fix missing params when they have same name, different location
+
 ## 6.7.3
 
 ### Patch Changes

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-typescript",
   "description": "Convert OpenAPI 3.0 & 3.1 schemas to TypeScript",
-  "version": "6.7.3",
+  "version": "6.7.4",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"

--- a/packages/openapi-typescript/src/transform/parameter-object-array.ts
+++ b/packages/openapi-typescript/src/transform/parameter-object-array.ts
@@ -20,7 +20,7 @@ export default function transformParameterObjectArray(parameterObjectArray: (Par
     output.push(
       indent(
         `${key}: ${transformParameterObject(node, {
-          path: `${path}/${node.name}`,
+          path: `${path}/${node.in}/${node.name}`,
           ctx: { ...ctx, indentLv: ctx.indentLv + 1 },
         })};`,
         ctx.indentLv,

--- a/packages/openapi-typescript/src/transform/path-item-object.ts
+++ b/packages/openapi-typescript/src/transform/path-item-object.ts
@@ -28,7 +28,7 @@ export default function transformPathItemObject(pathItem: PathItemObject, { path
       // important: OperationObject parameters come last, and will override any conflicts with PathItem parameters
       for (const parameter of [...(pathItem.parameters ?? []), ...(operationObject.parameters ?? [])]) {
         // note: the actual key doesn’t matter here, as long as it can match between PathItem and OperationObject
-        keyedParameters["$ref" in parameter ? parameter.$ref : parameter.name] = parameter;
+        keyedParameters["$ref" in parameter ? parameter.$ref : `${parameter.in}/${parameter.name}`] = parameter;
       }
     }
 

--- a/packages/openapi-typescript/test/path-item-object.test.ts
+++ b/packages/openapi-typescript/test/path-item-object.test.ts
@@ -174,4 +174,65 @@ describe("Path Item Object", () => {
   get: components["schemas"]["GetUserOperation"]
 }`);
   });
+
+  it("operations with parameters with same name, different location", () => {
+    const operations: GlobalContext["operations"] = {};
+    const schema: PathItemObject = {
+      get: {
+        operationId: "getUserById",
+        summary: "Returns a user by ID.",
+        parameters: [
+          {
+            in: "path",
+            name: "user_id",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            in: "query",
+            name: "user_id",
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    };
+    const generated = transformPathItemObject(schema, { ...options, ctx: { ...options.ctx, operations } });
+    expect(generated).toBe(`{
+  /** Returns a user by ID. */
+  get: operations["getUserById"];
+}`);
+    expect(operations).toEqual({
+      getUserById: {
+        comment: "/** Returns a user by ID. */",
+        operationType: `{
+    parameters: {
+      query?: {
+        user_id?: string;
+      };
+      path: {
+        user_id: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": string;
+        };
+      };
+    };
+  }`,
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Changes

Fixes #1498, where sometimes parameters would be dropped if they had the same name, different locations.

## How to Review

- Tests should pass

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
