### PR TITLE
Fix UTF-8 chars

### DIFF
--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -324,9 +324,10 @@ export function tsIsPrimitive(type: ts.TypeNode): boolean {
 /** Create a literal type */
 export function tsLiteral(value: unknown): ts.TypeNode {
   if (typeof value === "string") {
-    return ts.factory.createLiteralTypeNode(
-      ts.factory.createStringLiteral(value),
-    );
+    // workaround for UTF-8: https://github.com/microsoft/TypeScript/issues/36174
+    return ts.factory.createIdentifier(
+      JSON.stringify(value),
+    ) as unknown as ts.TypeNode;
   }
   if (typeof value === "number") {
     return ts.factory.createLiteralTypeNode(

--- a/packages/openapi-typescript/test/transform/schema-object/string.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/string.test.ts
@@ -46,6 +46,23 @@ describe("transformSchemaObject > string", () => {
       },
     ],
     [
+      "enum (UTF-8)",
+      {
+        given: { type: "string", enum: ["赤", "青", "緑"] },
+        want: `"赤" | "青" | "緑"`,
+        // options: DEFAULT_OPTIONS
+      },
+    ],
+    [
+      "enum (quotes)",
+      {
+        // prettier-ignore
+        // eslint-disable-next-line no-useless-escape
+        given: { type: "string", enum: ['"', "'", '\"', "`"] },
+        want: `"\\"" | "'" | "\\"" | "\`"`,
+      },
+    ],
+    [
       "nullable",
       {
         given: { type: ["string", "null"] },


### PR DESCRIPTION
## Changes

Fixes #1436. This is a known issue with the TypeScript compiler (https://github.com/microsoft/TypeScript/issues/36174). This hacks it by running it through JSON.stringify and basically telling TS “this is a reference don’t touch it.” Should probably be removed eventually, but for the short-term I can’t imagine there are any practical exploits.

## How to Review

- Tests should pass

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
