### PR TITLE
Fix querySerializer example

### DIFF
--- a/docs/openapi-fetch/api.md
+++ b/docs/openapi-fetch/api.md
@@ -49,15 +49,17 @@ const { data, error } = await GET("/search", {
     query: { tags: ["food", "california", "healthy"] },
   },
   querySerializer(q) {
-    let s = "";
+    let s = [];
     for (const [k, v] of Object.entries(q)) {
       if (Array.isArray(v)) {
-        s += `${k}[]=${v.join(",")}`;
+        for (const i of v) {
+          s.push(`${k}[]=${i}`);
+        }
       } else {
-        s += `${k}=${v}`;
+        s.push(`${k}=${v}`);
       }
     }
-    return s; // ?tags[]=food&tags[]=california&tags[]=healthy
+    return s.join("&"); // ?tags[]=food&tags[]=california&tags[]=healthy
   },
 });
 ```


### PR DESCRIPTION
## Changes

The example function for the `querySerializer` doesn't actually do what it says it does.
The comment next to the return statement suggests the output would be `?tags[]=food&tags[]=california&tags[]=healthy`, however the output of the current snippet is actually: `tags[]=food,california,healthy`.

Furthermore, the snippet also does not place any `&` characters between query parameters.

This PR fixes that, so that the output is actually `?tags[]=food&tags[]=california&tags[]=healthy` (strictly, the output is actually `tags[]=food&tags[]=california&tags[]=healthy` but I just assumed the `?` is to demonstrate how it would look like in an URL)

## How to Review

Try the new snippet.

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
