### PR TITLE
Fix: keep type information for nullable fields when possible

### DIFF
--- a/.changeset/loud-items-hope.md
+++ b/.changeset/loud-items-hope.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Keep type information for nullable fields when possible

--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -9085,7 +9085,7 @@ export interface external {
      * @description The Droplet that the floating IP has been assigned to. When you query a floating IP, if it is assigned to a Droplet, the entire Droplet object will be returned. If it is not assigned, the value will be null.
      * @example null
      */
-    droplet?: unknown;
+    droplet?: (Record<string, unknown> | null) | external["resources/droplets/models/droplet.yml"];
     /**
      * @description A boolean value indicating whether or not the floating IP has pending actions preventing new ones from being submitted.
      * @example true
@@ -13948,7 +13948,7 @@ export interface external {
      * @description The Droplet that the reserved IP has been assigned to. When you query a reserved IP, if it is assigned to a Droplet, the entire Droplet object will be returned. If it is not assigned, the value will be null.
      * @example null
      */
-    droplet?: unknown;
+    droplet?: (Record<string, unknown> | null) | external["resources/droplets/models/droplet.yml"];
     /**
      * @description A boolean value indicating whether or not the reserved IP has pending actions preventing new ones from being submitted.
      * @example true

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -267,7 +267,13 @@ export function defaultSchemaObjectTransform(schemaObject: SchemaObject | Refere
   }
 
   // nullable (3.0)
-  if (schemaObject.nullable) finalType = tsUnionOf(finalType || "unknown", "null");
+  if (schemaObject.nullable) {
+    if ("type" in schemaObject) {
+      finalType = tsUnionOf(finalType || "Record<string, unknown>", "null");
+    } else {
+      finalType = tsUnionOf(finalType || "unknown", "null");
+    }
+  }
 
   if (finalType) return finalType;
 

--- a/packages/openapi-typescript/test/schema-object.test.ts
+++ b/packages/openapi-typescript/test/schema-object.test.ts
@@ -379,6 +379,11 @@ describe("Schema Object", () => {
       const generated = transformSchemaObject({ nullable: true }, options);
       expect(generated).toBe(`unknown`);
     });
+
+    test("nullable object", () => {
+      const generated = transformSchemaObject({ nullable: true, type: "object" }, options);
+      expect(generated).toBe(`Record<string, unknown> | null`);
+    });
   });
 
   describe("schema composition", () => {


### PR DESCRIPTION
## Changes

The PR https://github.com/drwpow/openapi-typescript/pull/1468 was too aggressive in its use of `unknown` for nullable fields. It makes sense to use `unknown` when there is no `type` defined in the schema. But in cases where there is type information available, we should not discard it. 

The changes in the snapshots show that richer types are preserved when possible. I wrote a [comment](https://github.com/drwpow/openapi-typescript/pull/1468#issuecomment-1838526799) on the original PR relating to this, but it's possible it got missed. 

Essentially, we use the "old" behavior where we have some type info available in the schema, and the "new" behavior otherwise. The original bug report https://github.com/drwpow/openapi-typescript/issues/1407 says (emphasis mine):

> I found that when a field **has no type information**, but `nullable: true`, the resulting Typescript is Record<string, unknown> | null.

This PR ensures the "has no type information" part is respected.

## How to Review

The snapshots and tests should give enough context to evaluate the PR, and hopefully my justification makes sense.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
