### PR TITLE
docs: correct typo in "Multiple schemas" example and add tip for bund…

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,8 +38,14 @@ apis:
   external@v1:
     root: ./openapi/external.yaml
     x-openapi-ts:
-      output: ./openapi/openapi.ts
+      output: ./openapi/external.ts
 ```
+
+::: tip
+
+This will preserve schemas 1:1 input:output. To bundle multiple schemas into one, use Redocly’s [bundle command](https://redocly.com/docs/resources/multi-file-definitions/#bundle)
+
+:::
 
 Whenever you have a `redocly.yaml` file in your project with `apis`, you can omit the input/output parameters in the CLI:
 


### PR DESCRIPTION
…ling schemas

## Changes

_What does this PR change? Link to any related issue(s)._
As discussed in https://github.com/drwpow/openapi-typescript/issues/1497; the docs as-written give the impression that multiple schemas can be merged into a single file, as opposed to preserving 1:1 input:output.  Fixed the typo, and added the suggested tip linking to Redoly's bundling documentation.

![openapi-typescript_docs-update](https://github.com/drwpow/openapi-typescript/assets/565463/52e720dd-c411-417c-a28d-50e90e06c4fb)

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] ~~Unit tests updated~~ N/A
- [x] `docs/` updated (if necessary)
- [ ] ~~`pnpm run update:examples` run (only applicable for openapi-typescript)~~ N/A
