### PR TITLE
fix: replace # characters in operation IDs with a slash

### DIFF
--- a/.changeset/olive-dots-sing.md
+++ b/.changeset/olive-dots-sing.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Works around an issue where operation IDs containing the "#" character failed to generate teh correct type mappings

--- a/packages/openapi-typescript/src/transform/path-item-object.ts
+++ b/packages/openapi-typescript/src/transform/path-item-object.ts
@@ -105,7 +105,7 @@ export default function transformPathItemObject(
     // if operationId exists, move into an `operations` export and pass the reference in here
     else if (operationObject.operationId) {
       // workaround for issue caused by redocly ref parsing: https://github.com/drwpow/openapi-typescript/issues/1542
-      const operationId = operationObject.operationId.replace(/#/g, "/");
+      const operationId = operationObject.operationId.replace(HASH_RE, "/");
       operationType = oapiRef(createRef(["operations", operationId]));
       injectOperationObject(
         operationId,
@@ -132,3 +132,5 @@ export default function transformPathItemObject(
 
   return ts.factory.createTypeLiteralNode(type);
 }
+
+const HASH_RE = /#/g;

--- a/packages/openapi-typescript/src/transform/path-item-object.ts
+++ b/packages/openapi-typescript/src/transform/path-item-object.ts
@@ -104,11 +104,11 @@ export default function transformPathItemObject(
     }
     // if operationId exists, move into an `operations` export and pass the reference in here
     else if (operationObject.operationId) {
-      operationType = oapiRef(
-        createRef(["operations", operationObject.operationId]),
-      );
+      // workaround for issue caused by redocly ref parsing: https://github.com/drwpow/openapi-typescript/issues/1542
+      const operationId = operationObject.operationId.replace(/#/g, "/");
+      operationType = oapiRef(createRef(["operations", operationId]));
       injectOperationObject(
-        operationObject.operationId,
+        operationId,
         { ...operationObject, parameters: Object.values(keyedParameters) },
         { ...options, path: createRef([options.path!, method]) },
       );

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -488,6 +488,84 @@ export type operations = Record<string, never>;`,
         // options: DEFAULT_OPTIONS
       },
     ],
+
+    [
+      "operations > # character is parsed correctly",
+      {
+        given: {
+          openapi: "3.1",
+          info: { title: "Test", version: "1.0" },
+          paths: {
+            "/accounts": {
+              get: {
+                operationId: "Accounts#List",
+                responses: {
+                  200: {
+                    description: "OK",
+                    content: {
+                      "application/json": {
+                        schema: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        want: `export interface paths {
+    "/accounts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["Accounts/List"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    "Accounts/List": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+        };
+    };
+}`,
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
     [
       "JSONSchema > $defs are respected",
       {


### PR DESCRIPTION
## Changes

Fixes #1542

A [recent change](https://github.com/Redocly/redocly-cli/pull/1408) to redocly affected the way JSON pointers are parsed, causing operation IDs with the "#" character to generate the incorrect type mapping to operations referenced in the path item object. This works around the issue by replacing "#" characters in operation IDs with a "/" character.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
