### PR TITLE
Fix error fallback for invalid JSON

### DIFF
--- a/.changeset/quiet-seals-speak.md
+++ b/.changeset/quiet-seals-speak.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix JSON consuming body

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -135,12 +135,12 @@ export default function createClient(clientOptions) {
       return { data: await response[parseAs](), response };
     }
 
-    // handle errors (always parse as .json() or .text())
-    let error = {};
+    // handle errors
+    let error = await response.text();
     try {
-      error = await response.json();
+      error = JSON.parse(error); // attempt to parse as JSON
     } catch {
-      error = await response.text();
+      // noop
     }
     return { error, response };
   }

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1141,6 +1141,15 @@ describe("client", () => {
         expect(error.message).toBe("Error");
       }
     });
+
+    it("gracefully handles invalid JSON for errors", async () => {
+      const client = createClient<paths>();
+      mockFetchOnce({ status: 401, body: "Unauthorized" });
+      const { data, error } = await client.GET("/blogposts");
+
+      expect(data).toBeUndefined();
+      expect(error).toBe("Unauthorized");
+    });
   });
 
   describe("POST()", () => {

--- a/packages/openapi-fetch/test/v7-beta.test.ts
+++ b/packages/openapi-fetch/test/v7-beta.test.ts
@@ -1136,6 +1136,15 @@ describe("client", () => {
         expect(error.message).toBe("Error");
       }
     });
+
+    it("gracefully handles invalid JSON for errors", async () => {
+      const client = createClient<paths>();
+      mockFetchOnce({ status: 401, body: "Unauthorized" });
+      const { data, error } = await client.GET("/blogposts");
+
+      expect(data).toBeUndefined();
+      expect(error).toBe("Unauthorized");
+    });
   });
 
   describe("POST()", () => {


### PR DESCRIPTION
## Changes

Fixes #1544 

## How to Review

Tests should pass

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
