### PR TITLE
fix: --exclude-deprecated flag is not applied to query and path

### DIFF
--- a/packages/openapi-typescript/src/transform/parameters-array.ts
+++ b/packages/openapi-typescript/src/transform/parameters-array.ts
@@ -48,7 +48,8 @@ export function transformParametersArray(
     }
     if (options.ctx.excludeDeprecated) {
       operationParameters = operationParameters.filter(
-        ({ resolved }) => !resolved?.deprecated && !resolved?.schema?.deprecated,
+        ({ resolved }) =>
+          !resolved?.deprecated && !resolved?.schema?.deprecated,
       );
     }
     for (const { original, resolved } of operationParameters) {

--- a/packages/openapi-typescript/src/transform/parameters-array.ts
+++ b/packages/openapi-typescript/src/transform/parameters-array.ts
@@ -33,7 +33,7 @@ export function transformParametersArray(
     "cookie",
   ] as ParameterObject["in"][]) {
     const paramLocType: ts.TypeElement[] = [];
-    const operationParameters = parametersArray.map((param) => ({
+    let operationParameters = parametersArray.map((param) => ({
       original: param,
       resolved:
         "$ref" in param
@@ -44,6 +44,11 @@ export function transformParametersArray(
     if (options.ctx.alphabetize) {
       operationParameters.sort((a, b) =>
         (a.resolved?.name ?? "").localeCompare(b.resolved?.name ?? ""),
+      );
+    }
+    if (options.ctx.excludeDeprecated) {
+      operationParameters = operationParameters.filter(
+        ({ resolved }) => !resolved?.deprecated && !resolved?.schema?.deprecated,
       );
     }
     for (const { original, resolved } of operationParameters) {

--- a/packages/openapi-typescript/test/transform/operation-object.test.ts
+++ b/packages/openapi-typescript/test/transform/operation-object.test.ts
@@ -217,6 +217,53 @@ responses: {
 };`,
       },
     ],
+    [
+      "parameters, responses > test excludeDeprecated option",
+      {
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_CTX, excludeDeprecated: true },
+        },
+        given: {
+          parameters: [
+            { in: "path", name: "user_id", schema: { type: "string" } },
+            { in: "path", name: "user_id_deprecated", schema: { type: "string", deprecated: true } },
+            { in: "query", name: "search", schema: { type: "string" } },
+            { in: "query", name: "search_deprecated", schema: { type: "string", deprecated: true } },
+          ],
+          responses: {
+            "200": {
+              description: "OK",
+              content: { "application/json": { schema: { type: "object", properties: { hello: { type: "string" }, hello_deprecated: { type: "string", deprecated: true } } } } },
+            },
+          },
+        },
+        want: `parameters: {
+    query?: {
+        search?: string;
+    };
+    header?: never;
+    path: {
+        user_id: string;
+    };
+    cookie?: never;
+};
+requestBody?: never;
+responses: {
+    /** @description OK */
+    200: {
+        headers: {
+            [name: string]: unknown;
+        };
+        content: {
+            "application/json": {
+                hello?: string;
+            };
+        };
+    };
+};`,
+      },
+    ],
   ];
 
   for (const [

--- a/packages/openapi-typescript/test/transform/operation-object.test.ts
+++ b/packages/openapi-typescript/test/transform/operation-object.test.ts
@@ -234,7 +234,10 @@ responses: {
           responses: {
             "200": {
               description: "OK",
-              content: { "application/json": { schema: { type: "object", properties: { hello: { type: "string" }, hello_deprecated: { type: "string", deprecated: true } } } } },
+              content: { "application/json": { schema: { type: "object", properties: { 
+                hello: { type: "string" },
+                hello_deprecated: { type: "string", deprecated: true } 
+              }}}},
             },
           },
         },


### PR DESCRIPTION
## Changes

fixes #1532 

## How to Review

added test demonstrating the fix

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
