### PR TITLE
fetch middware rework

### DIFF
--- a/docs/openapi-fetch/api.md
+++ b/docs/openapi-fetch/api.md
@@ -195,8 +195,8 @@ onRequest(req, options) {
 
 | Name      |        Type         | Description                                                                                                                                                                          |
 | :-------- | :-----------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `req`     | `MiddlewareRequest` | A standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) with `schemaPath` (OpenAPI pathname) and `params` ([params](/openapi-fetch/api#fetch-options) object) |
-| `options` |   `MergedOptions`   | Combination of [createClient](/openapi-fetch/api#create-client) options + [fetch overrides](/openapi-fetch/api#fetch-options)                                                        |
+| `req`     | `Request` | A standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) |
+| `options` |   `MergedOptions`   | Combination of [createClient](/openapi-fetch/api#create-client) options + [fetch overrides](/openapi-fetch/api#fetch-options)    with `schemaPath` (OpenAPI pathname) and `params` ([params](/openapi-fetch/api#fetch-options) object)                                                    |
 
 And it expects either:
 
@@ -215,7 +215,9 @@ onResponse(res, options) {
 | Name | Type | Description |
 | :-------- | :-----------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `req` | `MiddlewareRequest` | A standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). |
-| `options` | `MergedOptions` | Combination of [createClient](/openapi-fetch/api#create-client) options + [fetch overrides](/openapi-fetch/api#fetch-options) |
+| `options` | `MergedOptions` | Combination of [createClient](/openapi-fetch/api#create-client) options + [fetch overrides](/openapi-fetch/api#fetch-options) with `schemaPath` (OpenAPI pathname) and `params` ([params](/openapi-fetch/api#fetch-options) object)                                                    ||
+| `request`| `Request` |  A standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) that the response associated|
+
 
 And it expects either:
 
@@ -236,6 +238,22 @@ onRequest(req) {
 ```
 
 This will leave the request/response unmodified, and pass things off to the next middleware handler (if any). There’s no internal callback or observer library needed.
+
+### Resend
+
+If you want to resend some request in middleware, just use `send` with the `request` and `options` param.
+
+```ts
+async onResponse(response, options, request) {
+  if(response.status === 401) {
+    // do some other request...like refresh the token by refreshToken, then update it
+    refreshToken(); 
+    // then resend it.
+    return  await client.send(request.clone());
+  }
+  return response;
+},
+```
 
 ### Ejecting middleware
 

--- a/docs/openapi-fetch/api.md
+++ b/docs/openapi-fetch/api.md
@@ -214,10 +214,8 @@ onResponse(res, options) {
 `onResponse()` also takes 2 params:
 | Name | Type | Description |
 | :-------- | :-----------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `req` | `MiddlewareRequest` | A standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). |
+| `req` | `Request` | A standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). |
 | `options` | `MergedOptions` | Combination of [createClient](/openapi-fetch/api#create-client) options + [fetch overrides](/openapi-fetch/api#fetch-options) with `schemaPath` (OpenAPI pathname) and `params` ([params](/openapi-fetch/api#fetch-options) object)                                                    ||
-| `request`| `Request` |  A standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) that the response associated|
-
 
 And it expects either:
 
@@ -244,12 +242,12 @@ This will leave the request/response unmodified, and pass things off to the next
 If you want to resend some request in middleware, just use `send` with the `request` and `options` param.
 
 ```ts
-async onResponse(response, options, request) {
+async onResponse(response, options) {
   if(response.status === 401) {
     // do some other request...like refresh the token by refreshToken, then update it
     refreshToken(); 
     // then resend it.
-    return  await client.send(request.clone());
+    return  await client.send(new Request(options.requestUrl,options.requestOptions), options);
   }
   return response;
 },

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -155,6 +155,9 @@ export type MergedOptions<T = unknown> = {
     path?: Record<string, unknown>;
     cookie?: Record<string, unknown>;
   };
+  /** use to build a new request object. */
+  requestUrl: string;
+  requestOptions: RequestInit;
 };
 
 export function onRequest(
@@ -164,7 +167,6 @@ export function onRequest(
 export function onResponse(
   res: Response,
   options: MergedOptions,
-  request: Request,
 ): Response | undefined | Promise<Response | undefined>;
 
 export interface Middleware {

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -167,6 +167,7 @@ export function onRequest(
 export function onResponse(
   res: Response,
   options: MergedOptions,
+  request: Request,
 ): Response | undefined | Promise<Response | undefined>;
 
 export interface Middleware {

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -146,9 +146,6 @@ export type MergedOptions<T = unknown> = {
   querySerializer: QuerySerializer<T>;
   bodySerializer: BodySerializer<T>;
   fetch: typeof globalThis.fetch;
-};
-
-export interface MiddlewareRequest extends Request {
   /** The original OpenAPI schema path (including curly braces) */
   schemaPath: string;
   /** OpenAPI parameters as provided from openapi-fetch */
@@ -158,10 +155,10 @@ export interface MiddlewareRequest extends Request {
     path?: Record<string, unknown>;
     cookie?: Record<string, unknown>;
   };
-}
+};
 
 export function onRequest(
-  req: MiddlewareRequest,
+  req: Request,
   options: MergedOptions,
 ): Request | undefined | Promise<Request | undefined>;
 export function onResponse(
@@ -202,6 +199,8 @@ export default function createClient<Paths extends {}>(
   PATCH: ClientMethod<Paths, "patch">;
   /** Call a TRACE endpoint */
   TRACE: ClientMethod<Paths, "trace">;
+  /** the core send just with middleware */
+  send(request:Request, options?: MergedOptions): Promise<Response>;
   /** Register middleware */
   use(...middleware: Middleware[]): void;
   /** Unregister middleware */

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -105,7 +105,7 @@ export default function createClient(clientOptions) {
     for (let i = middlewares.length - 1; i >= 0; i--) {
       const m = middlewares[i];
       if (m && typeof m === "object" && typeof m.onResponse === "function") {
-        const result = await m.onResponse(response, mergedOptions);
+        const result = await m.onResponse(response, mergedOptions, request);
         if (result) {
           if (!(result instanceof Response)) {
             throw new Error(

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -69,10 +69,10 @@ export default function createClient(clientOptions) {
     if (requestInit.body instanceof FormData) {
       requestInit.headers.delete("Content-Type");
     }
-    const request = new Request(
-      createFinalURL(url, { baseUrl, params, querySerializer }),
-      requestInit,
-    );
+    
+    const finalUrl = createFinalURL(url, { baseUrl, params, querySerializer });
+    const finalOptions = requestInit;
+    const request = new Request(finalUrl, finalOptions);
     // middleware (request)
     const mergedOptions = {
       baseUrl,
@@ -82,6 +82,8 @@ export default function createClient(clientOptions) {
       bodySerializer,
       schemaPath: url,
       params,
+      requestUrl: finalUrl,
+      requestOptions: finalOptions
     };
     const response =  await coreSend(request, mergedOptions)
 
@@ -140,7 +142,7 @@ export default function createClient(clientOptions) {
     for (let i = middlewares.length - 1; i >= 0; i--) {
       const m = middlewares[i];
       if (m && typeof m === "object" && typeof m.onResponse === "function") {
-        const result = await m.onResponse(response, mergedOptions, request);
+        const result = await m.onResponse(response, mergedOptions);
         if (result) {
           if (!(result instanceof Response)) {
             throw new Error(

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -899,6 +899,37 @@ describe("client", () => {
         expect(data).toEqual({ success: true });
       });
 
+      it("can get the final url in merged options", async () => {
+        mockFetchOnce({ status: 200, body: JSON.stringify({ success: true }) });
+        const client = createClient<paths>({
+          baseUrl: "https://api.foo.bar/v1/",
+        });
+        let receivedUrl = '';
+        client.use({
+          onRequest(_, options) {
+            receivedUrl = options.requestUrl;
+            return undefined;
+          },
+        })
+        await client.GET("/blogposts/{id}", { params: { path: { id: "123" } } });
+        expect(receivedUrl).toBe("https://api.foo.bar/v1/blogposts/123");
+      });
+      it("can get the final request options in merged options", async () => {
+        mockFetchOnce({ status: 200, body: JSON.stringify({ success: true }) });
+        const client = createClient<paths>({
+          baseUrl: "https://api.foo.bar/v1/",
+        });
+        let receivedOptions: RequestInit = {};
+        client.use({
+          onRequest(_, options) {
+            receivedOptions = options.requestOptions;
+            return undefined;
+          },
+        })
+        await client.POST("/blogposts/{id}", { params: { path: { id: "123" } }, body: { title: "New Post"}});
+        expect(receivedOptions.method).toBe("POST");
+        expect(receivedOptions.body).toBe(JSON.stringify({ title: "New Post"}));
+      });
       it("can invoke send with middleware", async () => {
         mockFetchOnce({ status: 200, body: JSON.stringify({ success: true }) });
         const client = createClient<paths>({

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -935,12 +935,12 @@ describe("client", () => {
             requestUrls.push(request.url);
             return undefined;
           },
-          async onResponse(response, options, request) {
+          async onResponse(response, options) {
             if(response.status === 401) {
               // do some other request...
               // then resend it.
               firstTimeData = await response.clone().json();
-              return  await client.send(request.clone());
+              return  await client.send(new Request(options.requestUrl,options.requestOptions), options);
             }
             return response;
           },

--- a/packages/openapi-fetch/test/v7-beta.test.ts
+++ b/packages/openapi-fetch/test/v7-beta.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 // @ts-expect-error
 import createFetchMock from "vitest-fetch-mock";
 import createClient, {
+  MergedOptions,
   type Middleware,
-  type MiddlewareRequest,
   type QuerySerializerOptions,
 } from "../src/index.js";
 import type { paths } from "./fixtures/v7-beta.js";
@@ -865,15 +865,15 @@ describe("client", () => {
         };
 
         let receivedPath = "";
-        let receivedParams: MiddlewareRequest["params"] = {};
+        let receivedParams: MergedOptions["params"] = {};
 
         const client = createClient<paths>({
           baseUrl: "https://api.foo.bar/v1/",
         });
         client.use({
-          onRequest(req) {
-            receivedPath = req!.schemaPath;
-            receivedParams = req!.params;
+          onRequest(req,options) {
+            receivedPath = options!.schemaPath;
+            receivedParams = options!.params;
             return undefined;
           },
         });


### PR DESCRIPTION
## Changes

This PR rework middleware add feature:
* a new method `send`, that warp fetch with middleware, it accept the stand Request and return the stand Response.
* resend request in middleware by `send` with the stand request object.
* get pathSchame from merge options not request **BREAK CHANGE**
* add the final request url and options to mergeOptions, so that we can remake request easily, does't need to care about the body readable.

It also provider 5 tests for check above work or not.
It also update some docs for explain, but my English is sooo poor uhhhh


## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
