### PR TITLE
Discriminator Mapping Support for oneOf composition

### DIFF
--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -9565,11 +9565,10 @@ export interface components {
         /** @description Specifies the action that will be taken on the Droplet. */
         droplet_action: {
             /**
-             * @description The type of action to initiate for the Droplet.
-             * @example reboot
+             * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "enable_backups" | "disable_backups" | "reboot" | "power_cycle" | "shutdown" | "power_off" | "power_on" | "restore" | "password_reset" | "resize" | "rebuild" | "rename" | "change_kernel" | "enable_ipv6" | "snapshot";
+            type: "enable_ipv6";
         };
         droplet_action_restore: components["schemas"]["droplet_action"] & {
             /**
@@ -9617,6 +9616,12 @@ export interface components {
              * @example Nifty New Snapshot
              */
             name?: string;
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "snapshot";
         };
         firewall_rule_base: {
             /**

--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -9565,10 +9565,10 @@ export interface components {
         /** @description Specifies the action that will be taken on the Droplet. */
         droplet_action: {
             /**
-             * @description discriminator enum property added by openapi-typescript
+             * @description The type of action to initiate for the Droplet. (enum property replaced by openapi-typescript)
              * @enum {string}
              */
-            type: "enable_ipv6";
+            type: "enable_backups" | "disable_backups" | "power_cycle" | "shutdown" | "power_off" | "power_on" | "enable_ipv6";
         };
         droplet_action_restore: components["schemas"]["droplet_action"] & {
             /**

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -71,7 +71,7 @@ export default async function openapiTS(
     additionalProperties: options.additionalProperties ?? false,
     alphabetize: options.alphabetize ?? false,
     defaultNonNullable: options.defaultNonNullable ?? true,
-    discriminators: scanDiscriminators(schema),
+    discriminators: scanDiscriminators(schema, options),
     emptyObjectsUnknown: options.emptyObjectsUnknown ?? false,
     enum: options.enum ?? false,
     excludeDeprecated: options.excludeDeprecated ?? false,

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -67,17 +67,11 @@ export default async function openapiTS(
     silent: options.silent ?? false,
   });
 
-  const { discriminators, discriminatorRefsHandled } = scanDiscriminators(
-    schema,
-    options,
-  );
-
   const ctx: GlobalContext = {
     additionalProperties: options.additionalProperties ?? false,
     alphabetize: options.alphabetize ?? false,
     defaultNonNullable: options.defaultNonNullable ?? true,
-    discriminators,
-    discriminatorRefsHandled,
+    discriminators: scanDiscriminators(schema, options),
     emptyObjectsUnknown: options.emptyObjectsUnknown ?? false,
     enum: options.enum ?? false,
     excludeDeprecated: options.excludeDeprecated ?? false,

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -67,11 +67,17 @@ export default async function openapiTS(
     silent: options.silent ?? false,
   });
 
+  const { discriminators, discriminatorRefsHandled } = scanDiscriminators(
+    schema,
+    options,
+  );
+
   const ctx: GlobalContext = {
     additionalProperties: options.additionalProperties ?? false,
     alphabetize: options.alphabetize ?? false,
     defaultNonNullable: options.defaultNonNullable ?? true,
-    discriminators: scanDiscriminators(schema, options),
+    discriminators,
+    discriminatorRefsHandled,
     emptyObjectsUnknown: options.emptyObjectsUnknown ?? false,
     enum: options.enum ?? false,
     excludeDeprecated: options.excludeDeprecated ?? false,

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -157,16 +157,19 @@ export function transformSchemaObjectWithComposition(
           typeof resolved === "object" &&
           "properties" in resolved
         ) {
-          // don’t try and make keys required if the $ref doesn’t have them
-          const validRequired = (required ?? []).filter(
-            (key) => !!resolved.properties![key],
-          );
-          if (validRequired.length) {
-            itemType = tsWithRequired(
-              itemType,
-              validRequired,
-              options.ctx.injectFooter,
+          // don’t try and make keys required if we have already handled the item (discriminator property was already added as required)
+          // or the $ref doesn’t have them
+          if (!options.ctx.discriminatorRefsHandled.includes(item.$ref)) {
+            const validRequired = (required ?? []).filter(
+              (key) => !!resolved.properties![key],
             );
+            if (validRequired.length) {
+              itemType = tsWithRequired(
+                itemType,
+                validRequired,
+                options.ctx.injectFooter,
+              );
+            }
           }
         }
       }

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -458,6 +458,7 @@ function transformSchemaObjectCore(
             continue;
           }
         }
+
         let optional =
           schemaObject.required?.includes(k) ||
           ("default" in v &&

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -159,7 +159,7 @@ export function transformSchemaObjectWithComposition(
         ) {
           // don’t try and make keys required if we have already handled the item (discriminator property was already added as required)
           // or the $ref doesn’t have them
-          if (!options.ctx.discriminatorRefsHandled.includes(item.$ref)) {
+          if (!options.ctx.discriminators.refsHandled.includes(item.$ref)) {
             const validRequired = (required ?? []).filter(
               (key) => !!resolved.properties![key],
             );
@@ -185,7 +185,7 @@ export function transformSchemaObjectWithComposition(
         );
       }
       const discriminator =
-        ("$ref" in item && options.ctx.discriminators[item.$ref]) ||
+        ("$ref" in item && options.ctx.discriminators.objects[item.$ref]) ||
         (item as any).discriminator; // eslint-disable-line @typescript-eslint/no-explicit-any
       if (discriminator) {
         output.push(tsOmit(itemType, [discriminator.propertyName]));
@@ -417,7 +417,8 @@ function transformSchemaObjectCore(
     // ctx.discriminators. But stop objects from referencing their own
     // discriminator meant for children (!schemaObject.discriminator)
     const discriminator =
-      !schemaObject.discriminator && options.ctx.discriminators[options.path!];
+      !schemaObject.discriminator &&
+      options.ctx.discriminators.objects[options.path!];
     if (discriminator) {
       coreObjectType.unshift(
         createDiscriminatorProperty(discriminator, {

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -458,7 +458,6 @@ function transformSchemaObjectCore(
             continue;
           }
         }
-
         let optional =
           schemaObject.required?.includes(k) ||
           ("default" in v &&

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -687,6 +687,7 @@ export interface GlobalContext {
   alphabetize: boolean;
   defaultNonNullable: boolean;
   discriminators: Record<string, DiscriminatorObject>;
+  discriminatorRefsHandled: string[];
   emptyObjectsUnknown: boolean;
   enum: boolean;
   excludeDeprecated: boolean;

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -686,8 +686,10 @@ export interface GlobalContext {
   additionalProperties: boolean;
   alphabetize: boolean;
   defaultNonNullable: boolean;
-  discriminators: Record<string, DiscriminatorObject>;
-  discriminatorRefsHandled: string[];
+  discriminators: {
+    objects: Record<string, DiscriminatorObject>;
+    refsHandled: string[];
+  };
   emptyObjectsUnknown: boolean;
   enum: boolean;
   excludeDeprecated: boolean;

--- a/packages/openapi-typescript/test/discriminators.test.ts
+++ b/packages/openapi-typescript/test/discriminators.test.ts
@@ -265,6 +265,312 @@ export type operations = Record<string, never>;`,
         // options: DEFAULT_OPTIONS,
       },
     ],
+    [
+      "oneOf > mapping support > replace discriminator enum",
+      {
+        given: {
+          openapi: "3.1.0",
+          info: {
+            title: "test",
+            version: 1,
+          },
+          paths: {
+            "/endpoint": {
+              get: {
+                responses: {
+                  "200": {
+                    description: "OK",
+                    content: {
+                      "application/json": {
+                        schema: {
+                          oneOf: [
+                            {
+                              $ref: "#/components/schemas/simpleObject",
+                            },
+                            {
+                              $ref: "#/components/schemas/complexObject",
+                            },
+                          ],
+                          discriminator: {
+                            propertyName: "type",
+                            mapping: {
+                              simple: "#/components/schemas/simpleObject",
+                              complex: "#/components/schemas/complexObject",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: {
+              simpleObject: {
+                type: "object",
+                required: ["type"],
+                properties: {
+                  type: {
+                    $ref: "#/components/schemas/type",
+                  },
+                  simple: {
+                    type: "boolean",
+                  },
+                },
+              },
+              complexObject: {
+                type: "object",
+                required: ["type"],
+                properties: {
+                  type: {
+                    $ref: "#/components/schemas/type",
+                  },
+                  complex: {
+                    type: "boolean",
+                  },
+                },
+              },
+              type: {
+                type: "string",
+                enum: ["simple", "complex"],
+              },
+            },
+          },
+        },
+        want: `export interface paths {
+    "/endpoint": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["simpleObject"] | components["schemas"]["complexObject"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        simpleObject: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "simple";
+            simple?: boolean;
+        };
+        complexObject: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "complex";
+            complex?: boolean;
+        };
+        /** @enum {string} */
+        type: "simple" | "complex";
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+      },
+    ],
+    [
+      "oneOf > mapping support > append enum in allOf",
+      {
+        given: {
+          openapi: "3.1.0",
+          info: {
+            title: "test",
+            version: 1,
+          },
+          paths: {
+            "/endpoint": {
+              get: {
+                responses: {
+                  "200": {
+                    description: "OK",
+                    content: {
+                      "application/json": {
+                        schema: {
+                          oneOf: [
+                            {
+                              $ref: "#/components/schemas/simpleObject",
+                            },
+                            {
+                              $ref: "#/components/schemas/complexObject",
+                            },
+                          ],
+                          discriminator: {
+                            propertyName: "type",
+                            mapping: {
+                              simple: "#/components/schemas/simpleObject",
+                              complex: "#/components/schemas/complexObject",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: {
+              baseObject: {
+                type: "object",
+                required: ["type"],
+                properties: {
+                  type: {
+                    $ref: "#/components/schemas/type",
+                  },
+                },
+              },
+              simpleObject: {
+                allOf: [
+                  {
+                    $ref: "#/components/schemas/baseObject",
+                  },
+                  {
+                    type: "object",
+                    properties: {
+                      simple: {
+                        type: "boolean",
+                      },
+                    },
+                  },
+                ],
+              },
+              complexObject: {
+                allOf: [
+                  {
+                    $ref: "#/components/schemas/baseObject",
+                  },
+                  {
+                    type: "object",
+                    properties: {
+                      complex: {
+                        type: "boolean",
+                      },
+                    },
+                  },
+                ],
+              },
+              type: {
+                type: "string",
+                enum: ["simple", "complex"],
+              },
+            },
+          },
+        },
+        want: `export interface paths {
+    "/endpoint": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["simpleObject"] | components["schemas"]["complexObject"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        baseObject: {
+            type: components["schemas"]["type"];
+        };
+        simpleObject: components["schemas"]["baseObject"] & {
+            simple?: boolean;
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type?: "simple";
+        };
+        complexObject: components["schemas"]["baseObject"] & {
+            complex?: boolean;
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type?: "complex";
+        };
+        /** @enum {string} */
+        type: "simple" | "complex";
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+      },
+    ],
   ];
 
   for (const [testName, { given, want, options, ci }] of tests) {

--- a/packages/openapi-typescript/test/discriminators.test.ts
+++ b/packages/openapi-typescript/test/discriminators.test.ts
@@ -454,6 +454,8 @@ export type operations = Record<string, never>;`,
                             mapping: {
                               simple: "#/components/schemas/simpleObject",
                               complex: "#/components/schemas/complexObject",
+                              // special case for different enum value but using the same schema as 'complex'
+                              tooComplex: "#/components/schemas/complexObject",
                             },
                           },
                         },
@@ -507,7 +509,7 @@ export type operations = Record<string, never>;`,
               },
               type: {
                 type: "string",
-                enum: ["simple", "complex"],
+                enum: ["simple", "complex", "tooComplex"],
               },
             },
           },
@@ -571,10 +573,10 @@ export interface components {
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type: "complex";
+            type: "complex" | "tooComplex";
         };
         /** @enum {string} */
-        type: "simple" | "complex";
+        type: "simple" | "complex" | "tooComplex";
     };
     responses: never;
     parameters: never;

--- a/packages/openapi-typescript/test/discriminators.test.ts
+++ b/packages/openapi-typescript/test/discriminators.test.ts
@@ -195,7 +195,7 @@ export type operations = Record<string, never>;`,
       },
     ],
     [
-      "oneOf",
+      "oneOf > implicit mapping",
       {
         given: {
           openapi: "3.1",
@@ -246,12 +246,27 @@ export interface components {
         Pet: components["schemas"]["Cat"] | components["schemas"]["Dog"] | components["schemas"]["Lizard"];
         Cat: {
             name?: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            petType: "Cat";
         };
         Dog: {
             bark?: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            petType: "dog";
         };
         Lizard: {
             lovesRocks?: boolean;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            petType: "Lizard";
         };
     };
     responses: never;
@@ -266,7 +281,7 @@ export type operations = Record<string, never>;`,
       },
     ],
     [
-      "oneOf > mapping support > replace discriminator enum",
+      "oneOf > explicit mapping > replace discriminator enum",
       {
         given: {
           openapi: "3.1.0",
@@ -409,7 +424,7 @@ export type operations = Record<string, never>;`,
       },
     ],
     [
-      "oneOf > mapping support > append enum in allOf",
+      "oneOf > explicit mapping > append enum in allOf",
       {
         given: {
           openapi: "3.1.0",
@@ -547,7 +562,7 @@ export interface components {
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type?: "simple";
+            type: "simple";
         };
         complexObject: components["schemas"]["baseObject"] & {
             complex?: boolean;
@@ -556,7 +571,7 @@ export interface components {
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            type?: "complex";
+            type: "complex";
         };
         /** @enum {string} */
         type: "simple" | "complex";

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -11,6 +11,7 @@ export const DEFAULT_CTX: GlobalContext = {
   arrayLength: false,
   defaultNonNullable: true,
   discriminators: {},
+  discriminatorRefsHandled: [],
   emptyObjectsUnknown: false,
   enum: false,
   excludeDeprecated: false,

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -10,8 +10,10 @@ export const DEFAULT_CTX: GlobalContext = {
   alphabetize: false,
   arrayLength: false,
   defaultNonNullable: true,
-  discriminators: {},
-  discriminatorRefsHandled: [],
+  discriminators: {
+    objects: {},
+    refsHandled: [],
+  },
   emptyObjectsUnknown: false,
   enum: false,
   excludeDeprecated: false,

--- a/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
@@ -219,18 +219,21 @@ describe("composition", () => {
           ctx: {
             ...DEFAULT_OPTIONS.ctx,
             discriminators: {
-              [DEFAULT_OPTIONS.path]: {
-                propertyName: "operation",
-                mapping: {
-                  test: DEFAULT_OPTIONS.path,
+              objects: {
+                [DEFAULT_OPTIONS.path]: {
+                  propertyName: "operation",
+                  mapping: {
+                    test: DEFAULT_OPTIONS.path,
+                  },
+                },
+                "#/components/schemas/parent": {
+                  propertyName: "operation",
+                  mapping: {
+                    test: DEFAULT_OPTIONS.path,
+                  },
                 },
               },
-              "#/components/schemas/parent": {
-                propertyName: "operation",
-                mapping: {
-                  test: DEFAULT_OPTIONS.path,
-                },
-              },
+              refsHandled: [],
             },
             resolve($ref) {
               switch ($ref) {
@@ -274,15 +277,18 @@ describe("composition", () => {
           ctx: {
             ...DEFAULT_OPTIONS.ctx,
             discriminators: {
-              "#/components/schemas/Pet": {
-                propertyName: "petType",
+              objects: {
+                "#/components/schemas/Pet": {
+                  propertyName: "petType",
+                },
+                "#/components/schemas/Cat": {
+                  propertyName: "petType",
+                },
+                "#/components/schemas/Dog": {
+                  propertyName: "petType",
+                },
               },
-              "#/components/schemas/Cat": {
-                propertyName: "petType",
-              },
-              "#/components/schemas/Dog": {
-                propertyName: "petType",
-              },
+              refsHandled: [],
             },
             resolve($ref) {
               switch ($ref) {
@@ -315,12 +321,15 @@ describe("composition", () => {
           ctx: {
             ...DEFAULT_OPTIONS.ctx,
             discriminators: {
-              [DEFAULT_OPTIONS.path]: {
-                propertyName: "operation",
+              objects: {
+                [DEFAULT_OPTIONS.path]: {
+                  propertyName: "operation",
+                },
+                "#/components/schemas/parent": {
+                  propertyName: "operation",
+                },
               },
-              "#/components/schemas/parent": {
-                propertyName: "operation",
-              },
+              refsHandled: [],
             },
             resolve($ref) {
               switch ($ref) {
@@ -356,18 +365,21 @@ describe("composition", () => {
           ctx: {
             ...DEFAULT_OPTIONS.ctx,
             discriminators: {
-              "#/components/schemas/schema-object": {
-                propertyName: "@type",
-                mapping: {
-                  test: DEFAULT_OPTIONS.path,
+              objects: {
+                "#/components/schemas/schema-object": {
+                  propertyName: "@type",
+                  mapping: {
+                    test: DEFAULT_OPTIONS.path,
+                  },
+                },
+                "#/components/schemas/parent": {
+                  propertyName: "@type",
+                  mapping: {
+                    test: DEFAULT_OPTIONS.path,
+                  },
                 },
               },
-              "#/components/schemas/parent": {
-                propertyName: "@type",
-                mapping: {
-                  test: DEFAULT_OPTIONS.path,
-                },
-              },
+              refsHandled: [],
             },
             resolve($ref) {
               switch ($ref) {
@@ -408,12 +420,15 @@ describe("composition", () => {
           ctx: {
             ...DEFAULT_OPTIONS.ctx,
             discriminators: {
-              "#/components/schemas/Pet": {
-                propertyName: "_petType",
+              objects: {
+                "#/components/schemas/Pet": {
+                  propertyName: "_petType",
+                },
+                "#/components/schemas/Dog": {
+                  propertyName: "_petType",
+                },
               },
-              "#/components/schemas/Dog": {
-                propertyName: "_petType",
-              },
+              refsHandled: [],
             },
             resolve($ref) {
               switch ($ref) {


### PR DESCRIPTION
## Changes

This PR tries to solve the ignored discriminator mappings for oneOf compositions. More details here: https://github.com/drwpow/openapi-typescript/issues/1572

I am unsure if changing the schemaObject is something we really want to do. But this is very fast and even solves the allOf compositions for discriminated objects with inheritance.

Added 2 tests as well for the new cases.

## How to Review

All other discriminator tests are now failing. I checked a few cases and saw actual improvements to the generated types for example in the DigitalOcean types. This needs to be discussed of course.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
