### PR TITLE
Bugfix for discriminators using allOf

### DIFF
--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -19323,7 +19323,7 @@ export interface operations {
          *      */
         requestBody?: {
             content: {
-                "application/json": Omit<components["schemas"]["floating_ip_action_unassign"], "type"> | Omit<components["schemas"]["floating_ip_action_assign"], "type">;
+                "application/json": components["schemas"]["floating_ip_action_unassign"] | components["schemas"]["floating_ip_action_assign"];
             };
         };
         responses: {
@@ -22367,7 +22367,7 @@ export interface operations {
          *      */
         requestBody?: {
             content: {
-                "application/json": Omit<components["schemas"]["reserved_ip_action_unassign"], "type"> | Omit<components["schemas"]["reserved_ip_action_assign"], "type">;
+                "application/json": components["schemas"]["reserved_ip_action_unassign"] | components["schemas"]["reserved_ip_action_assign"];
             };
         };
         responses: {

--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -9881,18 +9881,26 @@ export interface components {
              */
             type: "assign" | "unassign";
         };
-        floating_ip_action_assign: {
-            type: "assign";
-        } & (Omit<components["schemas"]["floatingIPsAction"], "type"> & {
+        floating_ip_action_assign: Omit<components["schemas"]["floatingIPsAction"], "type"> & {
             /**
              * @description The ID of the Droplet that the floating IP will be assigned to.
              * @example 758604968
              */
             droplet_id: number;
-        });
-        floating_ip_action_unassign: {
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "assign";
+        };
+        floating_ip_action_unassign: Omit<components["schemas"]["floatingIPsAction"], "type"> & Record<string, never> & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
             type: "unassign";
-        } & (Omit<components["schemas"]["floatingIPsAction"], "type"> & Record<string, never>);
+        };
         namespace_info: {
             /**
              * @description The namespace's API hostname. Each function in a namespace is provided an endpoint at the namespace's hostname.
@@ -11555,18 +11563,26 @@ export interface components {
              */
             type: "assign" | "unassign";
         };
-        reserved_ip_action_assign: {
-            type: "assign";
-        } & (Omit<components["schemas"]["reserved_ip_action_type"], "type"> & {
+        reserved_ip_action_assign: Omit<components["schemas"]["reserved_ip_action_type"], "type"> & {
             /**
              * @description The ID of the Droplet that the reserved IP will be assigned to.
              * @example 758604968
              */
             droplet_id: number;
-        });
-        reserved_ip_action_unassign: {
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "assign";
+        };
+        reserved_ip_action_unassign: Omit<components["schemas"]["reserved_ip_action_type"], "type"> & Record<string, never> & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
             type: "unassign";
-        } & (Omit<components["schemas"]["reserved_ip_action_type"], "type"> & Record<string, never>);
+        };
         snapshots: {
             /**
              * @description The unique identifier for the snapshot.

--- a/packages/openapi-typescript/src/lib/utils.ts
+++ b/packages/openapi-typescript/src/lib/utils.ts
@@ -326,7 +326,7 @@ export function scanDiscriminators(
   // (sometimes this mapping is implicit, so it can’t be done until we know
   // about every discriminator in the document)
   walk(schema, (obj, path) => {
-    for (const key of ["oneOf", "anyOf", "allOf"] as const) {
+    for (const key of ["allOf"] as const) {
       if (obj && Array.isArray(obj[key])) {
         for (const item of (obj as any)[key]) {
           if ("$ref" in item) {

--- a/packages/openapi-typescript/src/lib/utils.ts
+++ b/packages/openapi-typescript/src/lib/utils.ts
@@ -184,6 +184,7 @@ function createDiscriminatorEnum(
   };
 }
 
+/** Adds or replaces the discriminator enum with the passed `values` in a schema defined by `ref` */
 function patchDiscriminatorEnum(
   schema: SchemaObject,
   ref: string,

--- a/packages/openapi-typescript/test/discriminators.test.ts
+++ b/packages/openapi-typescript/test/discriminators.test.ts
@@ -43,6 +43,38 @@ describe("3.1 discriminators", () => {
                 },
                 allOf: [{ $ref: "#/components/schemas/Pet" }],
               },
+              LizardDog: {
+                allOf: [
+                  { $ref: "#/components/schemas/Dog" },
+                  { $ref: "#/components/schemas/Lizard" },
+                ],
+              },
+              AnimalSighting: {
+                oneOf: [
+                  {
+                    $ref: "#/components/schemas/Cat",
+                  },
+                  {
+                    $ref: "#/components/schemas/Dog",
+                  },
+                  {
+                    $ref: "#/components/schemas/Lizard",
+                  },
+                ],
+              },
+              Beast: {
+                anyOf: [
+                  {
+                    $ref: "#/components/schemas/Cat",
+                  },
+                  {
+                    $ref: "#/components/schemas/Dog",
+                  },
+                  {
+                    $ref: "#/components/schemas/Lizard",
+                  },
+                ],
+              },
             },
           },
         },
@@ -65,6 +97,11 @@ export interface components {
             petType: "Lizard";
             lovesRocks?: boolean;
         } & Omit<components["schemas"]["Pet"], "petType">;
+        LizardDog: {
+            petType: "LizardDog";
+        } & (Omit<components["schemas"]["Dog"], "petType"> & Omit<components["schemas"]["Lizard"], "petType">);
+        AnimalSighting: components["schemas"]["Cat"] | components["schemas"]["Dog"] | components["schemas"]["Lizard"];
+        Beast: components["schemas"]["Cat"] | components["schemas"]["Dog"] | components["schemas"]["Lizard"];
     };
     responses: never;
     parameters: never;

--- a/packages/openapi-typescript/test/discriminators.test.ts
+++ b/packages/openapi-typescript/test/discriminators.test.ts
@@ -20,6 +20,7 @@ describe("3.1 discriminators", () => {
                   propertyName: "petType",
                   mapping: {
                     dog: "#/components/schemas/Dog",
+                    poodle: "#/components/schemas/Dog",
                   },
                 },
               },
@@ -88,11 +89,15 @@ export interface components {
         Cat: {
             petType: "Cat";
         } & Omit<components["schemas"]["Pet"], "petType">;
-        Dog: {
-            petType: "dog";
-        } & (Omit<components["schemas"]["Pet"], "petType"> & {
+        Dog: Omit<components["schemas"]["Pet"], "petType"> & {
             bark?: string;
-        });
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            petType: "dog" | "poodle";
+        };
         Lizard: {
             petType: "Lizard";
             lovesRocks?: boolean;

--- a/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
@@ -300,6 +300,59 @@ describe("composition", () => {
       },
     ],
     [
+      // this is actually invalid syntax for oneOfs, but we support it anyways for better compatibility with bad schemas
+      "discriminator > oneOf inside object",
+      {
+        given: {
+          type: "object",
+          required: ["name"],
+          properties: {
+            name: { type: "string" },
+          },
+          oneOf: [
+            { $ref: "#/components/schemas/Cat" },
+            { $ref: "#/components/schemas/Dog" },
+          ],
+        },
+        want: `{
+    name: string;
+} & (components["schemas"]["Cat"] | components["schemas"]["Dog"])`,
+        options: {
+          path: "#/components/schemas/Pet",
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            discriminators: {
+              objects: {
+                "#/components/schemas/Pet": {
+                  propertyName: "petType",
+                },
+                "#/components/schemas/Cat": {
+                  propertyName: "petType",
+                },
+                "#/components/schemas/Dog": {
+                  propertyName: "petType",
+                },
+              },
+              refsHandled: [],
+            },
+            resolve($ref) {
+              switch ($ref) {
+                case "#/components/schemas/Pet": {
+                  return {
+                    propertyName: "petType",
+                    oneOf: ["#/components/schemas/Cat"],
+                  };
+                }
+                default: {
+                  return undefined as any;
+                }
+              }
+            },
+          },
+        },
+      },
+    ],
+    [
       "discriminator > oneOf + null + implicit mapping",
       {
         given: {

--- a/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
@@ -258,20 +258,12 @@ describe("composition", () => {
       "discriminator > oneOf",
       {
         given: {
-          type: "object",
-          required: ["name"],
-          properties: {
-            name: { type: "string" },
-          },
           oneOf: [
             { $ref: "#/components/schemas/Cat" },
             { $ref: "#/components/schemas/Dog" },
           ],
         },
-        want: `{
-    petType: "Pet";
-    name: string;
-} & (Omit<components["schemas"]["Cat"], "petType"> | Omit<components["schemas"]["Dog"], "petType">)`,
+        want: `components["schemas"]["Cat"] | components["schemas"]["Dog"]`,
         options: {
           path: "#/components/schemas/Pet",
           ctx: {
@@ -313,9 +305,7 @@ describe("composition", () => {
         given: {
           oneOf: [{ $ref: "#/components/schemas/parent" }, { type: "null" }],
         },
-        want: `{
-    operation: "schema-object";
-} & (Omit<components["schemas"]["parent"], "operation"> | null)`,
+        want: `components["schemas"]["parent"] | null`,
         options: {
           ...DEFAULT_OPTIONS,
           ctx: {


### PR DESCRIPTION
## Changes

I noticed that the current implementation for discriminators inherited from a base class is not working when the final objects are used in anyOf or oneOf. These combinations will omit the discriminator property from the final object and result in an invalid type:

```json
{
  "oneOf": [
    { "$ref": "#/components/schemas/Cat" },
    { "$ref": "#/components/schemas/Dog" },
  ]
}
```

```typescript
type AnimalSighting = Omit<components["schemas"]["Cat"], "petType"> | Omit<components["schemas"]["Dog"], "petType">;

const sighting: AnimalSighting = {
  petType: 'Cat'; // <= without petType we can't use the discriminator in Typescript
}
```

The [OpenAPI specification on discriminators](https://spec.openapis.org/oas/v3.1.0#discriminator-object) states the following:

> In both the oneOf and anyOf use cases, all possible schemas MUST be listed explicitly. To avoid redundancy, the discriminator MAY be added to a parent schema definition, and all schemas comprising the parent schema in an allOf construct may be used as an alternate schema.

This is very confusing in my opinion. My interpretation is as follows: A discriminator from one of the base classes will not be automatically inherited unless it uses allOf. This makes sense looking at the result above, that never results in something useful (I can think of) in my opinion.

The anyOf case is currently not handled, but I can have a look as well. anyOf + discriminator is a rare combination, but I think it can be handled exactly like we handle oneOf.

Bonus: I improved Windows compatibility and error handling for updating the examples.

## How to Review

The appropriate unit tests were adapted to test the changes. The DigitalOcean schema shows, that responses with discriminators now produce valid types.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
