### PR TITLE
Fix TS errors

### DIFF
--- a/.changeset/unlucky-pumpkins-march.md
+++ b/.changeset/unlucky-pumpkins-march.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix type errors

--- a/packages/openapi-fetch/examples/nextjs/package.json
+++ b/packages/openapi-fetch/examples/nextjs/package.json
@@ -12,7 +12,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/node": "20.11.19",
+    "@types/node": "20.11.24",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",
     "openapi-typescript": "workspace:^",

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -74,7 +74,7 @@
     "openapi-typescript-fetch": "^1.1.3",
     "superagent": "^8.1.2",
     "typescript": "^5.3.3",
-    "vitest": "^1.2.2",
+    "vitest": "^1.3.1",
     "vitest-fetch-mock": "^0.2.2"
   }
 }

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -1,12 +1,13 @@
 import type {
   ErrorResponse,
-  SuccessResponse,
   FilterKeys,
+  HasRequiredKeys,
+  HttpMethod,
   MediaType,
+  OperationRequestBodyContent,
   PathsWithMethod,
   ResponseObjectMap,
-  OperationRequestBodyContent,
-  HasRequiredKeys,
+  SuccessResponse,
 } from "openapi-typescript-helpers";
 
 // Note: though "any" is considered bad practice in general, this library relies
@@ -80,7 +81,7 @@ type BodyType<T = unknown> = {
   stream: Response["body"];
 };
 export type ParseAs = keyof BodyType;
-export type ParseAsResponse<T, O extends FetchOptions> = O extends {
+export type ParseAsResponse<T, O> = O extends {
   parseAs: ParseAs;
 }
   ? BodyType<T>[O["parseAs"]]
@@ -110,13 +111,7 @@ export type RequestBodyOption<T> =
 export type FetchOptions<T> = RequestOptions<T> &
   Omit<RequestInit, "body" | "headers">;
 
-/** This type helper makes the 2nd function param required if params/requestBody are required; otherwise, optional */
-export type MaybeOptionalInit<P extends {}, M extends keyof P> =
-  HasRequiredKeys<FetchOptions<FilterKeys<P, M>>> extends never
-    ? [(FetchOptions<FilterKeys<P, M>> | undefined)?]
-    : [FetchOptions<FilterKeys<P, M>>];
-
-export type FetchResponse<T, O extends FetchOptions> =
+export type FetchResponse<T, O> =
   | {
       data: ParseAsResponse<
         FilterKeys<SuccessResponse<ResponseObjectMap<T>>, MediaType>,
@@ -174,7 +169,19 @@ export interface Middleware {
   onResponse?: typeof onResponse;
 }
 
-export type ClientMethod<Paths extends {}, M> = <
+/** This type helper makes the 2nd function param required if params/requestBody are required; otherwise, optional */
+export type MaybeOptionalInit<
+  P extends Record<HttpMethod, {}>,
+  M extends keyof P,
+> =
+  HasRequiredKeys<FetchOptions<FilterKeys<P, M>>> extends never
+    ? [(FetchOptions<FilterKeys<P, M>> | undefined)?]
+    : [FetchOptions<FilterKeys<P, M>>];
+
+export type ClientMethod<
+  Paths extends Record<string, Record<HttpMethod, {}>>,
+  M extends HttpMethod,
+> = <
   P extends PathsWithMethod<Paths, M>,
   I extends MaybeOptionalInit<Paths[P], M>,
 >(

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1,4 +1,3 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 // @ts-expect-error
 import createFetchMock from "vitest-fetch-mock";
 import createClient, {

--- a/packages/openapi-fetch/test/v7-beta.test.ts
+++ b/packages/openapi-fetch/test/v7-beta.test.ts
@@ -1,4 +1,3 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 // @ts-expect-error
 import createFetchMock from "vitest-fetch-mock";
 import createClient, {

--- a/packages/openapi-fetch/tsconfig.json
+++ b/packages/openapi-fetch/tsconfig.json
@@ -9,11 +9,11 @@
     "moduleResolution": "NodeNext",
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strict": true,
     "target": "ESNext",
     "types": ["vitest/globals"]
   },
   "include": ["src", "test"],
-  "exclude": ["node_modules"]
+  "exclude": ["examples", "node_modules"]
 }

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -58,14 +58,15 @@ export type OperationRequestBodyMediaContent<T> =
     ? FilterKeys<NonNullable<OperationRequestBody<T>>, "content"> | undefined
     : FilterKeys<OperationRequestBody<T>, "content">;
 /** Return first `content` from a Request Object Mapping, allowing any media type */
-export type OperationRequestBodyContent<T> = FilterKeys<
-  OperationRequestBodyMediaContent<T>,
-  MediaType
-> extends never
-  ?
-      | FilterKeys<NonNullable<OperationRequestBodyMediaContent<T>>, MediaType>
-      | undefined
-  : FilterKeys<OperationRequestBodyMediaContent<T>, MediaType>;
+export type OperationRequestBodyContent<T> =
+  FilterKeys<OperationRequestBodyMediaContent<T>, MediaType> extends never
+    ?
+        | FilterKeys<
+            NonNullable<OperationRequestBodyMediaContent<T>>,
+            MediaType
+          >
+        | undefined
+    : FilterKeys<OperationRequestBodyMediaContent<T>, MediaType>;
 /** Return first 2XX response from a Response Object Map */
 export type SuccessResponse<T> = ResponseContent<FilterKeys<T, OkStatus>>;
 /** Return first 5XX or 4XX response (in that order) from a Response Object Map */
@@ -97,4 +98,5 @@ export type FindRequiredKeys<T, K extends keyof T> = K extends unknown
     ? never
     : K
   : K;
+/** Does this object contain required keys? */
 export type HasRequiredKeys<T> = FindRequiredKeys<T, keyof T>;

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -62,7 +62,7 @@
     "typescript": "^5.x"
   },
   "dependencies": {
-    "@redocly/openapi-core": "^1.9.0",
+    "@redocly/openapi-core": "^1.10.3",
     "ansi-colors": "^4.1.3",
     "supports-color": "^9.4.0",
     "yargs-parser": "^21.1.1"
@@ -70,13 +70,13 @@
   "devDependencies": {
     "@types/degit": "^2.8.6",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.11.19",
+    "@types/node": "^20.11.24",
     "degit": "^2.8.4",
     "del-cli": "^5.1.0",
-    "esbuild": "^0.20.0",
+    "esbuild": "^0.20.1",
     "execa": "^7.2.0",
     "typescript": "^5.3.3",
-    "vite-node": "^1.2.2",
-    "vitest": "^1.2.2"
+    "vite-node": "^1.3.1",
+    "vitest": "^1.3.1"
   }
 }

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import openapiTS, { astToString } from "../src/index.js";
 import type { OpenAPI3, OpenAPITSOptions } from "../src/types.js";
 import type { TestCase } from "./test-helpers.js";
@@ -692,7 +693,7 @@ export type operations = Record<string, never>;`,
     );
   }
 
-  it("does not mutate original reference", async () => {
+  test("does not mutate original reference", async () => {
     const schema: OpenAPI3 = {
       openapi: "3.1",
       info: { title: "test", version: "1.0" },

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../../src/lib/ts.js";
 
 describe("addJSDocComment", () => {
-  it("single-line comment", () => {
+  test("single-line comment", () => {
     const property = ts.factory.createPropertySignature(
       undefined,
       "comment",
@@ -30,7 +30,7 @@ describe("addJSDocComment", () => {
 }`);
   });
 
-  it("multi-line comment", () => {
+  test("multi-line comment", () => {
     const property = ts.factory.createPropertySignature(
       undefined,
       "comment",
@@ -57,7 +57,7 @@ describe("addJSDocComment", () => {
 }`);
   });
 
-  it("escapes internal comments", () => {
+  test("escapes internal comments", () => {
     const property = ts.factory.createPropertySignature(
       undefined,
       "comment",
@@ -77,11 +77,11 @@ describe("addJSDocComment", () => {
 });
 
 describe("oapiRef", () => {
-  it("single part", () => {
+  test("single part", () => {
     expect(astToString(oapiRef("#/components")).trim()).toBe(`components`);
   });
 
-  it("multiple parts", () => {
+  test("multiple parts", () => {
     expect(astToString(oapiRef("#/components/schemas/User")).trim()).toBe(
       `components["schemas"]["User"]`,
     );
@@ -89,7 +89,7 @@ describe("oapiRef", () => {
 });
 
 describe("tsEnum", () => {
-  it("string members", () => {
+  test("string members", () => {
     expect(astToString(tsEnum("-my-color-", ["green", "red", "blue"])).trim())
       .toBe(`enum MyColor {
     green = "green",
@@ -98,7 +98,7 @@ describe("tsEnum", () => {
 }`);
   });
 
-  it("name from path", () => {
+  test("name from path", () => {
     expect(
       astToString(
         tsEnum("#/paths/url/get/parameters/query/status", [
@@ -112,7 +112,7 @@ describe("tsEnum", () => {
 }`);
   });
 
-  it("string members with numeric prefix", () => {
+  test("string members with numeric prefix", () => {
     expect(astToString(tsEnum("/my/enum/", ["0a", "1b", "2c"])).trim())
       .toBe(`enum MyEnum {
     Value0a = "0a",
@@ -121,7 +121,7 @@ describe("tsEnum", () => {
 }`);
   });
 
-  it("number members", () => {
+  test("number members", () => {
     expect(astToString(tsEnum(".Error.code.", [100, 101, 102])).trim())
       .toBe(`enum ErrorCode {
     Value100 = 100,
@@ -130,7 +130,7 @@ describe("tsEnum", () => {
 }`);
   });
 
-  it("number members with x-enum-descriptions", () => {
+  test("number members with x-enum-descriptions", () => {
     expect(
       astToString(
         tsEnum(
@@ -153,7 +153,7 @@ describe("tsEnum", () => {
 }`);
   });
 
-  it("x-enum-varnames", () => {
+  test("x-enum-varnames", () => {
     expect(
       astToString(
         tsEnum(
@@ -173,7 +173,7 @@ describe("tsEnum", () => {
 }`);
   });
 
-  it("x-enum-varnames with numeric prefix", () => {
+  test("x-enum-varnames with numeric prefix", () => {
     expect(
       astToString(
         tsEnum(
@@ -189,7 +189,7 @@ describe("tsEnum", () => {
 }`);
   });
 
-  it("partial x-enum-varnames and x-enum-descriptions", () => {
+  test("partial x-enum-varnames and x-enum-descriptions", () => {
     expect(
       astToString(
         tsEnum(
@@ -209,7 +209,7 @@ describe("tsEnum", () => {
 }`);
   });
 
-  it("x-enum-descriptions with x-enum-varnames", () => {
+  test("x-enum-descriptions with x-enum-varnames", () => {
     expect(
       astToString(
         tsEnum(
@@ -237,7 +237,7 @@ describe("tsEnum", () => {
 });
 
 describe("tsPropertyIndex", () => {
-  it("numbers -> number literals", () => {
+  test("numbers -> number literals", () => {
     expect(astToString(tsPropertyIndex(200)).trim()).toBe(`200`);
     expect(astToString(tsPropertyIndex(200.5)).trim()).toBe(`200.5`);
     expect(astToString(tsPropertyIndex(Infinity)).trim()).toBe(`Infinity`);
@@ -245,7 +245,7 @@ describe("tsPropertyIndex", () => {
     expect(astToString(tsPropertyIndex(10e3)).trim()).toBe(`10000`);
   });
 
-  it("valid strings -> identifiers", () => {
+  test("valid strings -> identifiers", () => {
     expect(astToString(tsPropertyIndex("identifier")).trim()).toBe(
       `identifier`,
     );
@@ -257,7 +257,7 @@ describe("tsPropertyIndex", () => {
     expect(astToString(tsPropertyIndex("10e3")).trim()).toBe(`"10e3"`);
   });
 
-  it("invalid strings -> string literals", () => {
+  test("invalid strings -> string literals", () => {
     expect(astToString(tsPropertyIndex("kebab-case")).trim()).toBe(
       `"kebab-case"`,
     );
@@ -273,27 +273,27 @@ describe("tsPropertyIndex", () => {
 });
 
 describe("tsIsPrimitive", () => {
-  it("null", () => {
+  test("null", () => {
     expect(tsIsPrimitive(NULL)).toBe(true);
   });
 
-  it("number", () => {
+  test("number", () => {
     expect(tsIsPrimitive(NUMBER)).toBe(true);
   });
 
-  it("string", () => {
+  test("string", () => {
     expect(tsIsPrimitive(STRING)).toBe(true);
   });
 
-  it("boolean", () => {
+  test("boolean", () => {
     expect(tsIsPrimitive(BOOLEAN)).toBe(true);
   });
 
-  it("array", () => {
+  test("array", () => {
     expect(tsIsPrimitive(ts.factory.createArrayTypeNode(STRING))).toBe(false);
   });
 
-  it("object", () => {
+  test("object", () => {
     expect(
       tsIsPrimitive(
         ts.factory.createTypeLiteralNode([
@@ -310,21 +310,21 @@ describe("tsIsPrimitive", () => {
 });
 
 describe("tsUnion", () => {
-  it("none", () => {
+  test("none", () => {
     expect(astToString(tsUnion([])).trim()).toBe(`never`);
   });
 
-  it("one", () => {
+  test("one", () => {
     expect(astToString(tsUnion([STRING])).trim()).toBe(`string`);
   });
 
-  it("multiple (primitive)", () => {
+  test("multiple (primitive)", () => {
     expect(
       astToString(tsUnion([STRING, STRING, NUMBER, NULL, NUMBER, NULL])).trim(),
     ).toBe(`string | number | null`);
   });
 
-  it("multiple (const)", () => {
+  test("multiple (const)", () => {
     expect(
       astToString(
         tsUnion([NULL, tsLiteral("red"), tsLiteral(42), tsLiteral(false)]),
@@ -332,7 +332,7 @@ describe("tsUnion", () => {
     ).toBe(`null | "red" | 42 | false`);
   });
 
-  it("multiple (object types)", () => {
+  test("multiple (object types)", () => {
     const obj = ts.factory.createTypeLiteralNode([
       ts.factory.createPropertySignature(undefined, "foo", undefined, STRING),
     ]);

--- a/packages/openapi-typescript/test/transform/operation-object.test.ts
+++ b/packages/openapi-typescript/test/transform/operation-object.test.ts
@@ -227,17 +227,32 @@ responses: {
         given: {
           parameters: [
             { in: "path", name: "user_id", schema: { type: "string" } },
-            { in: "path", name: "user_id_deprecated", schema: { type: "string", deprecated: true } },
+            {
+              in: "path",
+              name: "user_id_deprecated",
+              schema: { type: "string", deprecated: true },
+            },
             { in: "query", name: "search", schema: { type: "string" } },
-            { in: "query", name: "search_deprecated", schema: { type: "string", deprecated: true } },
+            {
+              in: "query",
+              name: "search_deprecated",
+              schema: { type: "string", deprecated: true },
+            },
           ],
           responses: {
             "200": {
               description: "OK",
-              content: { "application/json": { schema: { type: "object", properties: { 
-                hello: { type: "string" },
-                hello_deprecated: { type: "string", deprecated: true } 
-              }}}},
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      hello: { type: "string" },
+                      hello_deprecated: { type: "string", deprecated: true },
+                    },
+                  },
+                },
+              },
             },
           },
         },

--- a/packages/openapi-typescript/test/yaml.test.ts
+++ b/packages/openapi-typescript/test/yaml.test.ts
@@ -7,7 +7,7 @@ const cwd = os.platform() === "win32" ? fileURLToPath(root) : root; // execa bug
 const cmd = "./bin/cli.js";
 
 describe("YAML features", () => {
-  it("merge", async () => {
+  test("merge", async () => {
     const result = await execa(cmd, ["./test/fixtures/yaml-merge.yaml"], {
       cwd,
     });

--- a/packages/openapi-typescript/tsconfig.json
+++ b/packages/openapi-typescript/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
     "sourceRoot": ".",
     "outDir": "dist",
     "types": ["vitest/globals"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,11 +85,11 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vitest:
-        specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.19)(supports-color@9.4.0)
+        specifier: ^1.3.1
+        version: 1.3.1(@types/node@20.11.24)(supports-color@9.4.0)
       vitest-fetch-mock:
         specifier: ^0.2.2
-        version: 0.2.2(vitest@1.2.2)
+        version: 0.2.2(vitest@1.3.1)
 
   packages/openapi-fetch/examples/nextjs:
     dependencies:
@@ -107,8 +107,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@types/node':
-        specifier: 20.11.19
-        version: 20.11.19
+        specifier: 20.11.24
+        version: 20.11.24
       '@types/react':
         specifier: 18.2.20
         version: 18.2.20
@@ -154,7 +154,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.1.4
-        version: 5.1.4(@types/node@20.11.19)
+        version: 5.1.4
 
   packages/openapi-fetch/examples/sveltekit:
     dependencies:
@@ -188,13 +188,13 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.1.4
-        version: 5.1.4(@types/node@20.11.19)
+        version: 5.1.4
 
   packages/openapi-typescript:
     dependencies:
       '@redocly/openapi-core':
-        specifier: ^1.9.0
-        version: 1.9.0
+        specifier: ^1.10.3
+        version: 1.10.3
       ansi-colors:
         specifier: ^4.1.3
         version: 4.1.3
@@ -212,8 +212,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^20.11.19
-        version: 20.11.19
+        specifier: ^20.11.24
+        version: 20.11.24
       degit:
         specifier: ^2.8.4
         version: 2.8.4
@@ -221,8 +221,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       esbuild:
-        specifier: ^0.20.0
-        version: 0.20.0
+        specifier: ^0.20.1
+        version: 0.20.1
       execa:
         specifier: ^7.2.0
         version: 7.2.0
@@ -230,11 +230,11 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite-node:
-        specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.19)(supports-color@9.4.0)
+        specifier: ^1.3.1
+        version: 1.3.1(@types/node@20.11.24)(supports-color@9.4.0)
       vitest:
-        specifier: ^1.2.2
-        version: 1.2.2(@types/node@20.11.19)(supports-color@9.4.0)
+        specifier: ^1.3.1
+        version: 1.3.1(@types/node@20.11.24)(supports-color@9.4.0)
 
   packages/openapi-typescript-helpers:
     devDependencies:
@@ -719,6 +719,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.20.1:
+    resolution: {integrity: sha512-m55cpeupQ2DbuRGQMMZDzbv9J9PgVelPjlcmM5kxHnrBdBx6REaEd7LamYV7Dm8N7rCyR/XwU6rVP8ploKtIkA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.19.12:
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
@@ -730,6 +739,15 @@ packages:
 
   /@esbuild/android-arm64@0.20.0:
     resolution: {integrity: sha512-aVpnM4lURNkp0D3qPoAzSG92VXStYmoVPOgXveAUoQBWRSuQzt51yvSju29J6AHPmwY1BjH49uR29oyfH1ra8Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.20.1:
+    resolution: {integrity: sha512-hCnXNF0HM6AjowP+Zou0ZJMWWa1VkD77BXe959zERgGJBBxB+sV+J9f/rcjeg2c5bsukD/n17RKWXGFCO5dD5A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -755,6 +773,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.20.1:
+    resolution: {integrity: sha512-4j0+G27/2ZXGWR5okcJi7pQYhmkVgb4D7UKwxcqrjhvp5TKWx3cUjgB1CGj1mfdmJBQ9VnUGgUhign+FPF2Zgw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.19.12:
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
@@ -766,6 +793,15 @@ packages:
 
   /@esbuild/android-x64@0.20.0:
     resolution: {integrity: sha512-uK7wAnlRvjkCPzh8jJ+QejFyrP8ObKuR5cBIsQZ+qbMunwR8sbd8krmMbxTLSrDhiPZaJYKQAU5Y3iMDcZPhyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.20.1:
+    resolution: {integrity: sha512-MSfZMBoAsnhpS+2yMFYIQUPs8Z19ajwfuaSZx+tSl09xrHZCjbeXXMsUF/0oq7ojxYEpsSo4c0SfjxOYXRbpaA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -791,6 +827,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.20.1:
+    resolution: {integrity: sha512-Ylk6rzgMD8klUklGPzS414UQLa5NPXZD5tf8JmQU8GQrj6BrFA/Ic9tb2zRe1kOZyCbGl+e8VMbDRazCEBqPvA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.19.12:
     resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
@@ -802,6 +847,15 @@ packages:
 
   /@esbuild/darwin-x64@0.20.0:
     resolution: {integrity: sha512-bsgTPoyYDnPv8ER0HqnJggXK6RyFy4PH4rtsId0V7Efa90u2+EifxytE9pZnsDgExgkARy24WUQGv9irVbTvIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.20.1:
+    resolution: {integrity: sha512-pFIfj7U2w5sMp52wTY1XVOdoxw+GDwy9FsK3OFz4BpMAjvZVs0dT1VXs8aQm22nhwoIWUmIRaE+4xow8xfIDZA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -827,6 +881,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.20.1:
+    resolution: {integrity: sha512-UyW1WZvHDuM4xDz0jWun4qtQFauNdXjXOtIy7SYdf7pbxSWWVlqhnR/T2TpX6LX5NI62spt0a3ldIIEkPM6RHw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.19.12:
     resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
@@ -838,6 +901,15 @@ packages:
 
   /@esbuild/freebsd-x64@0.20.0:
     resolution: {integrity: sha512-uG8B0WSepMRsBNVXAQcHf9+Ko/Tr+XqmK7Ptel9HVmnykupXdS4J7ovSQUIi0tQGIndhbqWLaIL/qO/cWhXKyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.20.1:
+    resolution: {integrity: sha512-itPwCw5C+Jh/c624vcDd9kRCCZVpzpQn8dtwoYIt2TJF3S9xJLiRohnnNrKwREvcZYx0n8sCSbvGH349XkcQeg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -863,6 +935,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.20.1:
+    resolution: {integrity: sha512-cX8WdlF6Cnvw/DO9/X7XLH2J6CkBnz7Twjpk56cshk9sjYVcuh4sXQBy5bmTwzBjNVZze2yaV1vtcJS04LbN8w==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.19.12:
     resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
@@ -874,6 +955,15 @@ packages:
 
   /@esbuild/linux-arm@0.20.0:
     resolution: {integrity: sha512-2ezuhdiZw8vuHf1HKSf4TIk80naTbP9At7sOqZmdVwvvMyuoDiZB49YZKLsLOfKIr77+I40dWpHVeY5JHpIEIg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.20.1:
+    resolution: {integrity: sha512-LojC28v3+IhIbfQ+Vu4Ut5n3wKcgTu6POKIHN9Wpt0HnfgUGlBuyDDQR4jWZUZFyYLiz4RBBBmfU6sNfn6RhLw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -899,6 +989,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.20.1:
+    resolution: {integrity: sha512-4H/sQCy1mnnGkUt/xszaLlYJVTz3W9ep52xEefGtd6yXDQbz/5fZE5dFLUgsPdbUOQANcVUa5iO6g3nyy5BJiw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.19.12:
     resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
@@ -910,6 +1009,15 @@ packages:
 
   /@esbuild/linux-loong64@0.20.0:
     resolution: {integrity: sha512-lR2rr/128/6svngnVta6JN4gxSXle/yZEZL3o4XZ6esOqhyR4wsKyfu6qXAL04S4S5CgGfG+GYZnjFd4YiG3Aw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.20.1:
+    resolution: {integrity: sha512-c0jgtB+sRHCciVXlyjDcWb2FUuzlGVRwGXgI+3WqKOIuoo8AmZAddzeOHeYLtD+dmtHw3B4Xo9wAUdjlfW5yYA==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -935,6 +1043,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.20.1:
+    resolution: {integrity: sha512-TgFyCfIxSujyuqdZKDZ3yTwWiGv+KnlOeXXitCQ+trDODJ+ZtGOzLkSWngynP0HZnTsDyBbPy7GWVXWaEl6lhA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.19.12:
     resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
@@ -946,6 +1063,15 @@ packages:
 
   /@esbuild/linux-ppc64@0.20.0:
     resolution: {integrity: sha512-CoWSaaAXOZd+CjbUTdXIJE/t7Oz+4g90A3VBCHLbfuc5yUQU/nFDLOzQsN0cdxgXd97lYW/psIIBdjzQIwTBGw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.20.1:
+    resolution: {integrity: sha512-b+yuD1IUeL+Y93PmFZDZFIElwbmFfIKLKlYI8M6tRyzE6u7oEP7onGk0vZRh8wfVGC2dZoy0EqX1V8qok4qHaw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -971,6 +1097,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.20.1:
+    resolution: {integrity: sha512-wpDlpE0oRKZwX+GfomcALcouqjjV8MIX8DyTrxfyCfXxoKQSDm45CZr9fanJ4F6ckD4yDEPT98SrjvLwIqUCgg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.19.12:
     resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
     engines: {node: '>=12'}
@@ -982,6 +1117,15 @@ packages:
 
   /@esbuild/linux-s390x@0.20.0:
     resolution: {integrity: sha512-fgf9ubb53xSnOBqyvWEY6ukBNRl1mVX1srPNu06B6mNsNK20JfH6xV6jECzrQ69/VMiTLvHMicQR/PgTOgqJUQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.20.1:
+    resolution: {integrity: sha512-5BepC2Au80EohQ2dBpyTquqGCES7++p7G+7lXe1bAIvMdXm4YYcEfZtQrP4gaoZ96Wv1Ute61CEHFU7h4FMueQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -1007,6 +1151,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.20.1:
+    resolution: {integrity: sha512-5gRPk7pKuaIB+tmH+yKd2aQTRpqlf1E4f/mC+tawIm/CGJemZcHZpp2ic8oD83nKgUPMEd0fNanrnFljiruuyA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.19.12:
     resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
     engines: {node: '>=12'}
@@ -1018,6 +1171,15 @@ packages:
 
   /@esbuild/netbsd-x64@0.20.0:
     resolution: {integrity: sha512-lCT675rTN1v8Fo+RGrE5KjSnfY0x9Og4RN7t7lVrN3vMSjy34/+3na0q7RIfWDAj0e0rCh0OL+P88lu3Rt21MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.20.1:
+    resolution: {integrity: sha512-4fL68JdrLV2nVW2AaWZBv3XEm3Ae3NZn/7qy2KGAt3dexAgSVT+Hc97JKSZnqezgMlv9x6KV0ZkZY7UO5cNLCg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -1043,6 +1205,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.20.1:
+    resolution: {integrity: sha512-GhRuXlvRE+twf2ES+8REbeCb/zeikNqwD3+6S5y5/x+DYbAQUNl0HNBs4RQJqrechS4v4MruEr8ZtAin/hK5iw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.19.12:
     resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
     engines: {node: '>=12'}
@@ -1054,6 +1225,15 @@ packages:
 
   /@esbuild/sunos-x64@0.20.0:
     resolution: {integrity: sha512-GDwAqgHQm1mVoPppGsoq4WJwT3vhnz/2N62CzhvApFD1eJyTroob30FPpOZabN+FgCjhG+AgcZyOPIkR8dfD7g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.20.1:
+    resolution: {integrity: sha512-ZnWEyCM0G1Ex6JtsygvC3KUUrlDXqOihw8RicRuQAzw+c4f1D66YlPNNV3rkjVW90zXVsHwZYWbJh3v+oQFM9Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -1079,6 +1259,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.20.1:
+    resolution: {integrity: sha512-QZ6gXue0vVQY2Oon9WyLFCdSuYbXSoxaZrPuJ4c20j6ICedfsDilNPYfHLlMH7vGfU5DQR0czHLmJvH4Nzis/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.19.12:
     resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
     engines: {node: '>=12'}
@@ -1097,6 +1286,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.20.1:
+    resolution: {integrity: sha512-HzcJa1NcSWTAU0MJIxOho8JftNp9YALui3o+Ny7hCh0v5f90nprly1U3Sj1Ldj/CvKKdvvFsCRvDkpsEMp4DNw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.19.12:
     resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
@@ -1108,6 +1306,15 @@ packages:
 
   /@esbuild/win32-x64@0.20.0:
     resolution: {integrity: sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.20.1:
+    resolution: {integrity: sha512-0MBh53o6XtI6ctDnRMeQ+xoCN8kD2qI1rY1KgF/xdWQwoFeKou7puvDfV8/Wv4Ctx2rRpET/gGdz3YlNtNACSA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -1362,8 +1569,8 @@ packages:
       uri-js: 4.4.1
     dev: false
 
-  /@redocly/openapi-core@1.9.0:
-    resolution: {integrity: sha512-n8Uye07wx5ca59HPIxmfPYFnYW/L60i2uaBnOgmDXZIxA61xVJ48YTRSaSLUluoidfy9XwNJv0XX7Mz9uNnF2w==}
+  /@redocly/openapi-core@1.10.3:
+    resolution: {integrity: sha512-4SnIWh8r3EM1ylcoHIJSnQnuvqRTpQMnf2RU3BfVdcCBa0A1uEyH6XSxgcO5ehxfQGuGGpUXJ+vPh32PUaQDkA==}
     engines: {node: '>=14.19.0', npm: '>=7.0.0'}
     dependencies:
       '@redocly/ajv': 8.11.0
@@ -1530,7 +1737,7 @@ packages:
       sirv: 2.0.4
       svelte: 4.2.11
       tiny-glob: 0.2.9
-      vite: 5.1.4(@types/node@20.11.19)
+      vite: 5.1.4
     dev: true
 
   /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.11)(vite@5.1.4):
@@ -1544,7 +1751,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.11)(vite@5.1.4)
       debug: 4.3.4(supports-color@9.4.0)
       svelte: 4.2.11
-      vite: 5.1.4(@types/node@20.11.19)
+      vite: 5.1.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1563,7 +1770,7 @@ packages:
       magic-string: 0.30.7
       svelte: 4.2.11
       svelte-hmr: 0.15.3(svelte@4.2.11)
-      vite: 5.1.4(@types/node@20.11.19)
+      vite: 5.1.4
       vitefu: 0.2.5(vite@5.1.4)
     transitivePeerDependencies:
       - supports-color
@@ -1758,8 +1965,8 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@20.11.19:
-    resolution: {integrity: sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==}
+  /@types/node@20.11.24:
+    resolution: {integrity: sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -2010,7 +2217,7 @@ packages:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.4.2
-      vite: 5.1.4(@types/node@20.11.19)
+      vite: 5.1.4
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -2022,16 +2229,8 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.1.5
+      vite: 5.1.5(@types/node@20.11.24)
       vue: 3.4.21(typescript@5.3.3)
-    dev: true
-
-  /@vitest/expect@1.2.2:
-    resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
-    dependencies:
-      '@vitest/spy': 1.2.2
-      '@vitest/utils': 1.2.2
-      chai: 4.4.1
     dev: true
 
   /@vitest/expect@1.3.1:
@@ -2042,28 +2241,12 @@ packages:
       chai: 4.4.1
     dev: true
 
-  /@vitest/runner@1.2.2:
-    resolution: {integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==}
-    dependencies:
-      '@vitest/utils': 1.2.2
-      p-limit: 5.0.0
-      pathe: 1.1.2
-    dev: true
-
   /@vitest/runner@1.3.1:
     resolution: {integrity: sha512-5FzF9c3jG/z5bgCnjr8j9LNq/9OxV2uEBAITOXfoe3rdZJTdO7jzThth7FXv/6b+kdY65tpRQB7WaKhNZwX+Kg==}
     dependencies:
       '@vitest/utils': 1.3.1
       p-limit: 5.0.0
       pathe: 1.1.2
-    dev: true
-
-  /@vitest/snapshot@1.2.2:
-    resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
-    dependencies:
-      magic-string: 0.30.7
-      pathe: 1.1.2
-      pretty-format: 29.7.0
     dev: true
 
   /@vitest/snapshot@1.3.1:
@@ -2074,25 +2257,10 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.2.2:
-    resolution: {integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==}
-    dependencies:
-      tinyspy: 2.2.0
-    dev: true
-
   /@vitest/spy@1.3.1:
     resolution: {integrity: sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==}
     dependencies:
       tinyspy: 2.2.1
-    dev: true
-
-  /@vitest/utils@1.2.2:
-    resolution: {integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==}
-    dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
     dev: true
 
   /@vitest/utils@1.3.1:
@@ -2290,12 +2458,6 @@ packages:
   /acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
-    dev: true
-
-  /acorn@8.11.2:
-    resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
     dev: true
 
   /acorn@8.11.3:
@@ -3184,6 +3346,37 @@ packages:
       '@esbuild/win32-x64': 0.20.0
     dev: true
 
+  /esbuild@0.20.1:
+    resolution: {integrity: sha512-OJwEgrpWm/PCMsLVWXKqvcjme3bHNpOgN7Tb6cQnR5n0TPbQx1/Xrn7rqM+wn17bYeT6MGB5sn1Bh5YiGi70nA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.20.1
+      '@esbuild/android-arm': 0.20.1
+      '@esbuild/android-arm64': 0.20.1
+      '@esbuild/android-x64': 0.20.1
+      '@esbuild/darwin-arm64': 0.20.1
+      '@esbuild/darwin-x64': 0.20.1
+      '@esbuild/freebsd-arm64': 0.20.1
+      '@esbuild/freebsd-x64': 0.20.1
+      '@esbuild/linux-arm': 0.20.1
+      '@esbuild/linux-arm64': 0.20.1
+      '@esbuild/linux-ia32': 0.20.1
+      '@esbuild/linux-loong64': 0.20.1
+      '@esbuild/linux-mips64el': 0.20.1
+      '@esbuild/linux-ppc64': 0.20.1
+      '@esbuild/linux-riscv64': 0.20.1
+      '@esbuild/linux-s390x': 0.20.1
+      '@esbuild/linux-x64': 0.20.1
+      '@esbuild/netbsd-x64': 0.20.1
+      '@esbuild/openbsd-x64': 0.20.1
+      '@esbuild/sunos-x64': 0.20.1
+      '@esbuild/win32-arm64': 0.20.1
+      '@esbuild/win32-ia32': 0.20.1
+      '@esbuild/win32-x64': 0.20.1
+    dev: true
+
   /escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
@@ -3326,7 +3519,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
-      vitest: 1.3.1
+      vitest: 1.3.1(@types/node@20.11.24)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3454,7 +3647,7 @@ packages:
       human-signals: 4.3.1
       is-stream: 3.0.0
       merge-stream: 2.0.0
-      npm-run-path: 5.2.0
+      npm-run-path: 5.3.0
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
@@ -3469,7 +3662,7 @@ packages:
       human-signals: 5.0.0
       is-stream: 3.0.0
       merge-stream: 2.0.0
-      npm-run-path: 5.2.0
+      npm-run-path: 5.3.0
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
@@ -4229,8 +4422,8 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+  /jsonc-parser@3.2.1:
+    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
     dev: true
 
   /jsonfile@4.0.0:
@@ -4289,7 +4482,7 @@ packages:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
     dependencies:
-      mlly: 1.5.0
+      mlly: 1.6.1
       pkg-types: 1.0.3
     dev: true
 
@@ -4520,22 +4713,13 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /mlly@1.4.2:
-    resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
-    dependencies:
-      acorn: 8.11.2
-      pathe: 1.1.1
-      pkg-types: 1.0.3
-      ufo: 1.3.2
-    dev: true
-
-  /mlly@1.5.0:
-    resolution: {integrity: sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==}
+  /mlly@1.6.1:
+    resolution: {integrity: sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==}
     dependencies:
       acorn: 8.11.3
       pathe: 1.1.2
       pkg-types: 1.0.3
-      ufo: 1.3.2
+      ufo: 1.4.0
     dev: true
 
   /mri@1.2.0:
@@ -4643,8 +4827,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /npm-run-path@5.2.0:
-    resolution: {integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==}
+  /npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       path-key: 4.0.0
@@ -4864,10 +5048,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /pathe@1.1.1:
-    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
-    dev: true
-
   /pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
     dev: true
@@ -4911,9 +5091,9 @@ packages:
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
-      jsonc-parser: 3.2.0
-      mlly: 1.4.2
-      pathe: 1.1.1
+      jsonc-parser: 3.2.1
+      mlly: 1.6.1
+      pathe: 1.1.2
     dev: true
 
   /pluralize@8.0.0:
@@ -5561,12 +5741,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strip-literal@1.3.0:
-    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
-    dependencies:
-      acorn: 8.11.3
-    dev: true
-
   /strip-literal@2.0.0:
     resolution: {integrity: sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==}
     dependencies:
@@ -5771,11 +5945,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy@2.2.0:
-    resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
-    engines: {node: '>=14.0.0'}
-    dev: true
-
   /tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
@@ -5940,8 +6109,8 @@ packages:
     hasBin: true
     dev: true
 
-  /ufo@1.3.2:
-    resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
+  /ufo@1.4.0:
+    resolution: {integrity: sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==}
     dev: true
 
   /uglify-js@3.17.4:
@@ -5994,28 +6163,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@1.2.2(@types/node@20.11.19)(supports-color@9.4.0):
-    resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4(supports-color@9.4.0)
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      vite: 5.1.4(@types/node@20.11.19)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /vite-node@1.3.1:
+  /vite-node@1.3.1(@types/node@20.11.24)(supports-color@9.4.0):
     resolution: {integrity: sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -6024,7 +6172,7 @@ packages:
       debug: 4.3.4(supports-color@9.4.0)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.5
+      vite: 5.1.5(@types/node@20.11.24)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6036,7 +6184,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.1.4(@types/node@20.11.19):
+  /vite@5.1.4:
     resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -6064,7 +6212,6 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.11.19
       esbuild: 0.19.12
       postcss: 8.4.35
       rollup: 4.12.0
@@ -6072,7 +6219,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@5.1.5:
+  /vite@5.1.5(@types/node@20.11.24):
     resolution: {integrity: sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -6100,6 +6247,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.11.24
       esbuild: 0.19.12
       postcss: 8.4.35
       rollup: 4.12.0
@@ -6115,7 +6263,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.1.4(@types/node@20.11.19)
+      vite: 5.1.4
     dev: true
 
   /vitepress@1.0.0-rc.44(@algolia/client-search@4.22.1)(search-insights@2.13.0)(typescript@5.3.3):
@@ -6143,7 +6291,7 @@ packages:
       mark.js: 8.11.1
       minisearch: 6.3.0
       shiki: 1.1.7
-      vite: 5.1.5
+      vite: 5.1.5(@types/node@20.11.24)
       vue: 3.4.21(typescript@5.3.3)
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -6173,76 +6321,19 @@ packages:
       - universal-cookie
     dev: true
 
-  /vitest-fetch-mock@0.2.2(vitest@1.2.2):
+  /vitest-fetch-mock@0.2.2(vitest@1.3.1):
     resolution: {integrity: sha512-XmH6QgTSjCWrqXoPREIdbj40T7i1xnGmAsTAgfckoO75W1IEHKR8hcPCQ7SO16RsdW1t85oUm6pcQRLeBgjVYQ==}
     engines: {node: '>=14.14.0'}
     peerDependencies:
       vitest: '>=0.16.0'
     dependencies:
       cross-fetch: 3.1.8
-      vitest: 1.2.2(@types/node@20.11.19)(supports-color@9.4.0)
+      vitest: 1.3.1(@types/node@20.11.24)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
     dev: true
 
-  /vitest@1.2.2(@types/node@20.11.19)(supports-color@9.4.0):
-    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 20.11.19
-      '@vitest/expect': 1.2.2
-      '@vitest/runner': 1.2.2
-      '@vitest/snapshot': 1.2.2
-      '@vitest/spy': 1.2.2
-      '@vitest/utils': 1.2.2
-      acorn-walk: 8.3.2
-      cac: 6.7.14
-      chai: 4.4.1
-      debug: 4.3.4(supports-color@9.4.0)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.7
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 1.3.0
-      tinybench: 2.6.0
-      tinypool: 0.8.2
-      vite: 5.1.4(@types/node@20.11.19)
-      vite-node: 1.2.2(@types/node@20.11.19)(supports-color@9.4.0)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /vitest@1.3.1:
+  /vitest@1.3.1(@types/node@20.11.24)(supports-color@9.4.0):
     resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -6267,6 +6358,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
+      '@types/node': 20.11.24
       '@vitest/expect': 1.3.1
       '@vitest/runner': 1.3.1
       '@vitest/snapshot': 1.3.1
@@ -6284,8 +6376,8 @@ packages:
       strip-literal: 2.0.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.1.5
-      vite-node: 1.3.1
+      vite: 5.1.5(@types/node@20.11.24)
+      vite-node: 1.3.1(@types/node@20.11.24)(supports-color@9.4.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "removeComments": true,
-    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "target": "ESNext",


### PR DESCRIPTION
## Changes

Fixes #1549 by re-enabling `skipLibCheck: true`. Also updates some insignificant deps to make the fix easier.

The only significant changes are in `openapi-fetch`; all the other noise is from a type error from Vite/Vitest 🙃. There are probably other ways to have dealt with it, but this was the simplest. It seems to be [an upstream in issue in Rollup (maybe; who knows)](https://github.com/vitest-dev/vitest/issues/4567)

## How to Review

- The existing TS checks will fail now

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
