### PR TITLE
Fix path method object types

### DIFF
--- a/.changeset/funny-keys-judge.md
+++ b/.changeset/funny-keys-judge.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Update types for path-methods object

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -169,17 +169,16 @@ export interface Middleware {
   onResponse?: typeof onResponse;
 }
 
+type PathMethods = Partial<Record<HttpMethod, {}>>;
+
 /** This type helper makes the 2nd function param required if params/requestBody are required; otherwise, optional */
-export type MaybeOptionalInit<
-  P extends Record<HttpMethod, {}>,
-  M extends keyof P,
-> =
+export type MaybeOptionalInit<P extends PathMethods, M extends keyof P> =
   HasRequiredKeys<FetchOptions<FilterKeys<P, M>>> extends never
     ? [(FetchOptions<FilterKeys<P, M>> | undefined)?]
     : [FetchOptions<FilterKeys<P, M>>];
 
 export type ClientMethod<
-  Paths extends Record<string, Record<HttpMethod, {}>>,
+  Paths extends Record<string, PathMethods>,
   M extends HttpMethod,
 > = <
   P extends PathsWithMethod<Paths, M>,


### PR DESCRIPTION
## Changes

The issue is that the path-method object is a partial. This updates the types to match.

Fixes #1584

## How to Review

Take a look. It's very brief. I created a new type (`PathMethods`) to keep the other type definitions from getting too long.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
