### PR TITLE
Fix custom fetch type

### DIFF
--- a/.changeset/gorgeous-planes-rhyme.md
+++ b/.changeset/gorgeous-planes-rhyme.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix the custom fetch type

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -19,7 +19,7 @@ export interface ClientOptions extends Omit<RequestInit, "headers"> {
   /** set the common root URL for all API requests */
   baseUrl?: string;
   /** custom fetch (defaults to globalThis.fetch) */
-  fetch?: typeof fetch;
+  fetch?: (request: Request) => ReturnType<typeof fetch>;
   /** global querySerializer */
   querySerializer?: QuerySerializer<unknown> | QuerySerializerOptions;
   /** global bodySerializer */


### PR DESCRIPTION
## Changes

Fix the custom fetch type.
The custom fetch type does not strictly adhere to the parameter type when calling.

https://github.com/drwpow/openapi-typescript/blob/4e06f86934e11f3dbc3aabee4b4e61dd62680782/packages/openapi-fetch/src/index.js#L101

It results in the wrong type checking when using the custom fetch.

![image](https://github.com/drwpow/openapi-typescript/assets/19794813/3be37c2a-8bea-4c95-ada5-eb50f392f204)

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
