### PR TITLE
Add GitHub Sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: ['drwpow']
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
## Changes

This will add a **COMPLETELY OPTIONAL** sponsorship button to this GitHub Repo. For now, this only adds GitHub Sponsors and nothing else. But long-term, I’m interested in whatever fits this project best.

## FAQ

- **Why?**
  I maintain openapi-typescript in my free time and don’t receive any financial support. Receiving funding allows me to carve out additional time to support this library.
- **What will sponsors get?**
  <abbr title="to be determined">TBD</abbr>! This is my first time accepting any funding, really. Probably logo placement. Probably a mention somewhere in the docs and/or README. Probably other things. I am learning about how this works.
- **Where will the money go?**
  Also <abbr title="to be determined">TBD</abbr>. It depends on the level of sponsorship. I plan on using the money to continue support for the library from myself and all other active maintainers. But if the sponsorship happens to grow beyond what’s needed / what can be used, funding can always be donated/reallocated to other projects/funds in need.
- **Can we see who’s funded the project, or how much funding there is?**
  <abbr title="to be determined">TBD</abbr>, but I’m not aware of any restrictions, currently. Whatever GitHub doesn’t expose directly I’m interested in sharing.
- **Why GitHub sponsors? Why not platform ____?**
  🤷 GitHub Sponsors seems like the simplest/most automatic route to supporting this project, and they don’t collect fees for individuals. If there are alternate methods that better support this project long-term, I’m happy to consider them (and even switch entirely)!
  