### PR TITLE
replace vitest-fetch-mock with msw

### DIFF
--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -75,7 +75,6 @@
     "openapi-typescript-fetch": "^1.1.3",
     "superagent": "^8.1.2",
     "typescript": "^5.3.3",
-    "vitest": "^1.3.1",
-    "vitest-fetch-mock": "^0.2.2"
+    "vitest": "^1.3.1"
   }
 }

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -69,6 +69,7 @@
     "axios": "^1.6.7",
     "del-cli": "^5.1.0",
     "esbuild": "^0.20.0",
+    "msw": "^2.2.3",
     "openapi-typescript": "^6.7.4",
     "openapi-typescript-codegen": "^0.25.0",
     "openapi-typescript-fetch": "^1.1.3",

--- a/packages/openapi-fetch/test/fixtures/api.d.ts
+++ b/packages/openapi-fetch/test/fixtures/api.d.ts
@@ -3,6 +3,7 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
   "/comment": {
     put: {
@@ -577,6 +578,7 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
+
   getHeaderParams: {
     parameters: {
       header: {

--- a/packages/openapi-fetch/test/fixtures/api.yaml
+++ b/packages/openapi-fetch/test/fixtures/api.yaml
@@ -447,6 +447,11 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/Contact'
+  /multiple-response-content:
+    get:
+      responses:
+        200:
+          $ref: '#/components/responses/MultipleResponse'
 components:
   schemas:
     Post:
@@ -672,3 +677,31 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/User'
+    MultipleResponse:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              email:
+                type: string
+              name:
+                type: string
+            required:
+              - id
+              - email
+        application/ld+json:
+          schema:
+            type: object
+            properties:
+              '@id':
+                type: string
+              email:
+                type: string
+              name:
+                type: string
+            required:
+              - '@id'
+              - email

--- a/packages/openapi-fetch/test/fixtures/mock-server.ts
+++ b/packages/openapi-fetch/test/fixtures/mock-server.ts
@@ -1,0 +1,124 @@
+import {
+  http,
+  HttpResponse,
+  type JsonBodyType,
+  type StrictRequest,
+  type DefaultBodyType,
+  type HttpResponseResolver,
+  type PathParams,
+  type AsyncResponseResolverReturnType,
+} from "msw";
+import { setupServer } from "msw/node";
+
+/**
+ * Mock server instance
+ */
+export const server = setupServer();
+
+/**
+ * Default baseUrl for tests
+ */
+export const baseUrl = "https://api.example.com" as const;
+
+/**
+ * Test path helper, returns a an absolute URL based on
+ * the given path and base
+ */
+export function toAbsoluteURL(path: string, base: string = baseUrl) {
+  // If we have absolute path
+  if (URL.canParse(path)) {
+    return new URL(path).toString();
+  }
+
+  // Otherwise we want to support relative paths
+  // where base may also contain some part of the path
+  // e.g.
+  // base = https://api.foo.bar/v1/
+  // path = /self
+  // should result in https://api.foo.bar/v1/self
+
+  // Construct base URL
+  const baseUrlInstance = new URL(base);
+
+  // prepend base url url pathname to path and ensure only one slash between the URL parts
+  const newPath = `${baseUrlInstance.pathname}/${path}`.replace(/\/+/g, "/");
+
+  return new URL(newPath, baseUrlInstance).toString();
+}
+
+export type MswHttpMethod = keyof typeof http;
+
+export interface MockRequestHandlerOptions<
+  // Recreate the generic signature of the HTTP resolver
+  // so the arguments passed to http handlers propagate here.
+  Params extends PathParams<keyof Params> = PathParams,
+  RequestBodyType extends DefaultBodyType = DefaultBodyType,
+  ResponseBodyType extends DefaultBodyType = undefined,
+> {
+  baseUrl?: string;
+  method: MswHttpMethod;
+  /**
+   * Relative or absolute path to match.
+   * When relative, baseUrl will be used as base.
+   */
+  path: string;
+  body?: JsonBodyType;
+  headers?: Record<string, string>;
+  status?: number;
+
+  /**
+   * Optional handler which will be called instead of using the body, headers and status
+   */
+  handler?: HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>;
+}
+
+/**
+ *  Configures a msw request handler using the provided options.
+ */
+export function useMockRequestHandler<
+  // Recreate the generic signature of the HTTP resolver
+  // so the arguments passed to http handlers propagate here.
+  Params extends PathParams<keyof Params> = PathParams,
+  RequestBodyType extends DefaultBodyType = DefaultBodyType,
+  ResponseBodyType extends DefaultBodyType = undefined,
+>({
+  baseUrl: requestBaseUrl,
+  method,
+  path,
+  body,
+  headers,
+  status,
+  handler,
+}: MockRequestHandlerOptions<Params, RequestBodyType, ResponseBodyType>) {
+  let requestUrl = "";
+  let receivedRequest: null | StrictRequest<DefaultBodyType> = null;
+  let receivedCookies: null | Record<string, string> = null;
+
+  const resolvedPath = toAbsoluteURL(path, requestBaseUrl);
+
+  server.use(
+    http[method]<Params, RequestBodyType, ResponseBodyType>(
+      resolvedPath,
+      (args) => {
+        requestUrl = args.request.url;
+        receivedRequest = args.request.clone();
+        receivedCookies = { ...args.cookies };
+
+        if (handler) {
+          return handler(args);
+        }
+
+        return HttpResponse.json(body, {
+          status: status ?? 200,
+          headers,
+        }) as AsyncResponseResolverReturnType<ResponseBodyType>;
+      },
+    ),
+  );
+
+  return {
+    getRequestCookies: () => receivedCookies!,
+    getRequest: () => receivedRequest!,
+    getRequestUrl: () => new URL(requestUrl),
+  };
+}

--- a/packages/openapi-fetch/test/fixtures/v7-beta.d.ts
+++ b/packages/openapi-fetch/test/fixtures/v7-beta.d.ts
@@ -729,6 +729,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/multiple-response-content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                200: components["responses"]["MultipleResponse"];
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -857,6 +884,23 @@ export interface components {
             };
             content: {
                 "application/json": components["schemas"]["User"];
+            };
+        };
+        MultipleResponse: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    id: string;
+                    email: string;
+                    name?: string;
+                };
+                "application/ld+json": {
+                    "@id": string;
+                    email: string;
+                    name?: string;
+                };
             };
         };
     };

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -128,7 +128,7 @@ function useTestRequestHandler<
   );
 
   return {
-    getCookies: () => receivedCookies!,
+    getRequestCookies: () => receivedCookies!,
     getRequest: () => receivedRequest!,
     getRequestUrl: () => new URL(requestUrl),
   };
@@ -1259,7 +1259,7 @@ describe("client", () => {
     it("respects cookie", async () => {
       const client = createClient<paths>({ baseUrl });
 
-      const { getCookies } = useTestRequestHandler({
+      const { getRequestCookies } = useTestRequestHandler({
         baseUrl,
         method: "get",
         path: "/blogposts",
@@ -1272,7 +1272,7 @@ describe("client", () => {
         },
       });
 
-      const cookies = getCookies();
+      const cookies = getRequestCookies();
       expect(cookies).toEqual({ session: "1234" });
     });
   });

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -28,7 +28,7 @@ const baseUrl = "https://api.example.com";
  * Test path helper, returns a an absolute URL based on
  * the given path and base
  */
-function testPath(path: string, base: string = baseUrl) {
+function toAbsoluteURL(path: string, base: string = baseUrl) {
   // If we have absolute path
   if (URL.canParse(path)) {
     return new URL(path).toString();
@@ -105,7 +105,7 @@ function useTestRequestHandler<
   let receivedRequest: null | StrictRequest<DefaultBodyType> = null;
   let receivedCookies: null | Record<string, string> = null;
 
-  const resolvedPath = testPath(path, requestBaseUrl);
+  const resolvedPath = toAbsoluteURL(path, requestBaseUrl);
 
   server.use(
     http[method]<Params, RequestBodyType, ResponseBodyType>(
@@ -806,12 +806,12 @@ describe("client", () => {
       await client.GET("/self");
 
       // assert baseUrl and path mesh as expected
-      expect(getRequestUrl().href).toBe(testPath("/self"));
+      expect(getRequestUrl().href).toBe(toAbsoluteURL("/self"));
 
       client = createClient<paths>({ baseUrl });
       await client.GET("/self");
       // assert trailing '/' was removed
-      expect(getRequestUrl().href).toBe(testPath("/self"));
+      expect(getRequestUrl().href).toBe(toAbsoluteURL("/self"));
     });
 
     describe("headers", () => {

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1300,16 +1300,21 @@ describe("client", () => {
       });
 
       it("use the selected content", async () => {
-        const client = createClient<paths, "application/ld+json">();
-        mockFetchOnce({
+        const client = createClient<paths, "application/ld+json">({ baseUrl });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/multiple-response-content",
           status: 200,
           headers: { "Content-Type": "application/ld+json" },
-          body: JSON.stringify({
+          body: {
             "@id": "some-resource-identifier",
             email: "foo@bar.fr",
             name: null,
-          }),
+          },
         });
+
         const { data } = await client.GET("/multiple-response-content", {
           headers: {
             Accept: "application/ld+json",
@@ -1364,7 +1369,6 @@ describe("client", () => {
         status: 200,
         body: mockData,
       });
-      // mockFetchOnce({ status: 200, body: JSON.stringify(mockData) });
       const { data, error, response } = await client.GET(
         "/blogposts/{post_id}",
         {

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1,54 +1,16 @@
-import {
-  http,
-  HttpResponse,
-  type JsonBodyType,
-  type StrictResponse,
-  type StrictRequest,
-  type DefaultBodyType,
-  type HttpResponseResolver,
-  type PathParams,
-  type AsyncResponseResolverReturnType,
-} from "msw";
-import { setupServer } from "msw/node";
+import { HttpResponse, type StrictResponse } from "msw";
 import createClient, {
   type Middleware,
   type MiddlewareRequest,
   type QuerySerializerOptions,
 } from "../src/index.js";
 import type { paths } from "./fixtures/api.js";
-
-const server = setupServer();
-
-/**
- * Default baseUrl for tests
- */
-const baseUrl = "https://api.example.com";
-
-/**
- * Test path helper, returns a an absolute URL based on
- * the given path and base
- */
-function toAbsoluteURL(path: string, base: string = baseUrl) {
-  // If we have absolute path
-  if (URL.canParse(path)) {
-    return new URL(path).toString();
-  }
-
-  // Otherwise we want to support relative paths
-  // where base may also contain some part of the path
-  // e.g.
-  // base = https://api.foo.bar/v1/
-  // path = /self
-  // should result in https://api.foo.bar/v1/self
-
-  // Construct base URL
-  const baseUrlInstance = new URL(base);
-
-  // prepend base url url pathname to path and ensure only one slash between the URL parts
-  const newPath = `${baseUrlInstance.pathname}/${path}`.replace(/\/+/g, "/");
-
-  return new URL(newPath, baseUrlInstance).toString();
-}
+import {
+  server,
+  baseUrl,
+  useMockRequestHandler,
+  toAbsoluteURL,
+} from "./fixtures/mock-server.js";
 
 beforeAll(() => {
   server.listen({
@@ -63,80 +25,6 @@ beforeAll(() => {
 afterEach(() => server.resetHandlers());
 
 afterAll(() => server.close());
-
-type MswHttpMethod = keyof typeof http;
-
-interface MockRequestHandlerOptions<
-  // Recreate the generic signature of the HTTP resolver
-  // so the arguments passed to http handlers propagate here.
-  Params extends PathParams<keyof Params> = PathParams,
-  RequestBodyType extends DefaultBodyType = DefaultBodyType,
-  ResponseBodyType extends DefaultBodyType = undefined,
-> {
-  baseUrl?: string;
-  method: MswHttpMethod;
-  /**
-   * Relative or absolute path to match.
-   * When relative, baseUrl will be used as base.
-   */
-  path: string;
-  body?: JsonBodyType;
-  headers?: Record<string, string>;
-  status?: number;
-
-  /**
-   * Optional handler which will be called instead of using the body, headers and status
-   */
-  handler?: HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>;
-}
-
-function useMockRequestHandler<
-  // Recreate the generic signature of the HTTP resolver
-  // so the arguments passed to http handlers propagate here.
-  Params extends PathParams<keyof Params> = PathParams,
-  RequestBodyType extends DefaultBodyType = DefaultBodyType,
-  ResponseBodyType extends DefaultBodyType = undefined,
->({
-  baseUrl: requestBaseUrl,
-  method,
-  path,
-  body,
-  headers,
-  status,
-  handler,
-}: MockRequestHandlerOptions<Params, RequestBodyType, ResponseBodyType>) {
-  let requestUrl = "";
-  let receivedRequest: null | StrictRequest<DefaultBodyType> = null;
-  let receivedCookies: null | Record<string, string> = null;
-
-  const resolvedPath = toAbsoluteURL(path, requestBaseUrl);
-
-  server.use(
-    http[method]<Params, RequestBodyType, ResponseBodyType>(
-      resolvedPath,
-      (args) => {
-        requestUrl = args.request.url;
-        receivedRequest = args.request.clone();
-        receivedCookies = { ...args.cookies };
-
-        if (handler) {
-          return handler(args);
-        }
-
-        return HttpResponse.json(body, {
-          status: status ?? 200,
-          headers,
-        }) as AsyncResponseResolverReturnType<ResponseBodyType>;
-      },
-    ),
-  );
-
-  return {
-    getRequestCookies: () => receivedCookies!,
-    getRequest: () => receivedRequest!,
-    getRequestUrl: () => new URL(requestUrl),
-  };
-}
 
 describe("client", () => {
   it("generates all proper functions", () => {

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -66,7 +66,7 @@ afterAll(() => server.close());
 
 type MswHttpMethod = keyof typeof http;
 
-interface TestRequestHandlerOptions<
+interface MockRequestHandlerOptions<
   // Recreate the generic signature of the HTTP resolver
   // so the arguments passed to http handlers propagate here.
   Params extends PathParams<keyof Params> = PathParams,
@@ -83,10 +83,14 @@ interface TestRequestHandlerOptions<
   body?: JsonBodyType;
   headers?: Record<string, string>;
   status?: number;
+
+  /**
+   * Optional handler which will be called instead of using the body, headers and status
+   */
   handler?: HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>;
 }
 
-function useTestRequestHandler<
+function useMockRequestHandler<
   // Recreate the generic signature of the HTTP resolver
   // so the arguments passed to http handlers propagate here.
   Params extends PathParams<keyof Params> = PathParams,
@@ -100,7 +104,7 @@ function useTestRequestHandler<
   headers,
   status,
   handler,
-}: TestRequestHandlerOptions<Params, RequestBodyType, ResponseBodyType>) {
+}: MockRequestHandlerOptions<Params, RequestBodyType, ResponseBodyType>) {
   let requestUrl = "";
   let receivedRequest: null | StrictRequest<DefaultBodyType> = null;
   let receivedCookies: null | Record<string, string> = null;
@@ -155,7 +159,7 @@ describe("client", () => {
       });
 
       // data
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/string-array",
@@ -181,7 +185,7 @@ describe("client", () => {
       }
 
       // error
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/string-array",
@@ -213,7 +217,7 @@ describe("client", () => {
             baseUrl,
           });
 
-          useTestRequestHandler({
+          useMockRequestHandler({
             baseUrl,
             method: "get",
             path: "/blogposts/:post_id",
@@ -241,7 +245,7 @@ describe("client", () => {
 
           // (no error)
           let calledPostId = "";
-          useTestRequestHandler<{ post_id: string }>({
+          useMockRequestHandler<{ post_id: string }>({
             baseUrl,
             method: "get",
             path: `/blogposts/:post_id`,
@@ -264,7 +268,7 @@ describe("client", () => {
             baseUrl,
           });
 
-          const { getRequestUrl } = useTestRequestHandler({
+          const { getRequestUrl } = useMockRequestHandler({
             baseUrl,
             method: "get",
             path: `/path-params/*`,
@@ -321,7 +325,7 @@ describe("client", () => {
 
         it("allows UTF-8 characters", async () => {
           const client = createClient<paths>({ baseUrl });
-          const { getRequestUrl } = useTestRequestHandler({
+          const { getRequestUrl } = useMockRequestHandler({
             baseUrl,
             method: "get",
             path: "/blogposts/*",
@@ -343,7 +347,7 @@ describe("client", () => {
       it("header", async () => {
         const client = createClient<paths>({ baseUrl });
 
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/header-params",
@@ -394,7 +398,7 @@ describe("client", () => {
           it("primitives", async () => {
             const client = createClient<paths>({ baseUrl });
 
-            const { getRequestUrl } = useTestRequestHandler({
+            const { getRequestUrl } = useMockRequestHandler({
               baseUrl,
               method: "get",
               path: "/query-params*",
@@ -414,7 +418,7 @@ describe("client", () => {
           it("array params (empty)", async () => {
             const client = createClient<paths>({ baseUrl });
 
-            const { getRequestUrl } = useTestRequestHandler({
+            const { getRequestUrl } = useMockRequestHandler({
               baseUrl,
               method: "get",
               path: "/query-params*",
@@ -434,7 +438,7 @@ describe("client", () => {
           it("empty/null params", async () => {
             const client = createClient<paths>({ baseUrl });
 
-            const { getRequestUrl } = useTestRequestHandler({
+            const { getRequestUrl } = useMockRequestHandler({
               baseUrl,
               method: "get",
               path: "/query-params*",
@@ -507,7 +511,7 @@ describe("client", () => {
                 querySerializer: { array: given },
               });
 
-              const { getRequestUrl } = useTestRequestHandler({
+              const { getRequestUrl } = useMockRequestHandler({
                 baseUrl,
                 method: "get",
                 path: "/query-params*",
@@ -566,7 +570,7 @@ describe("client", () => {
                 baseUrl,
                 querySerializer: { object: given },
               });
-              const { getRequestUrl } = useTestRequestHandler({
+              const { getRequestUrl } = useMockRequestHandler({
                 baseUrl,
                 method: "get",
                 path: "/query-params*",
@@ -589,7 +593,7 @@ describe("client", () => {
               baseUrl,
               querySerializer: { allowReserved: true },
             });
-            const { getRequestUrl } = useTestRequestHandler({
+            const { getRequestUrl } = useMockRequestHandler({
               baseUrl,
               method: "get",
               path: "/query-params*",
@@ -635,7 +639,7 @@ describe("client", () => {
                 querySerializer: (q) => `alpha=${q.version}&beta=${q.format}`,
               });
 
-              const { getRequestUrl } = useTestRequestHandler({
+              const { getRequestUrl } = useMockRequestHandler({
                 baseUrl,
                 method: "get",
                 path: "/blogposts/:post_id",
@@ -660,7 +664,7 @@ describe("client", () => {
                 querySerializer: () => "query",
               });
 
-              const { getRequestUrl } = useTestRequestHandler({
+              const { getRequestUrl } = useMockRequestHandler({
                 baseUrl,
                 method: "get",
                 path: "/blogposts/:post_id",
@@ -686,7 +690,7 @@ describe("client", () => {
               baseUrl,
               querySerializer: () => "?query",
             });
-            const { getRequestUrl } = useTestRequestHandler({
+            const { getRequestUrl } = useMockRequestHandler({
               baseUrl,
               method: "get",
               path: "/blogposts/:post_id",
@@ -710,7 +714,7 @@ describe("client", () => {
       it("requires necessary requestBodies", async () => {
         const client = createClient<paths>({ baseUrl });
 
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "put",
           path: "/blogposts",
@@ -738,7 +742,7 @@ describe("client", () => {
       it("requestBody (inline)", async () => {
         const client = createClient<paths>({ baseUrl });
 
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "put",
           path: "/blogposts-optional-inline",
@@ -764,7 +768,7 @@ describe("client", () => {
       it("requestBody with required: false", async () => {
         const client = createClient<paths>({ baseUrl });
 
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "put",
           path: "/blogposts-optional",
@@ -795,7 +799,7 @@ describe("client", () => {
     it("baseUrl", async () => {
       let client = createClient<paths>({ baseUrl });
 
-      const { getRequestUrl } = useTestRequestHandler({
+      const { getRequestUrl } = useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/self",
@@ -820,7 +824,7 @@ describe("client", () => {
 
         const client = createClient<paths>({ headers, baseUrl });
 
-        const { getRequest } = useTestRequestHandler({
+        const { getRequest } = useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/self",
@@ -845,7 +849,7 @@ describe("client", () => {
           headers: { "Cache-Control": "max-age=10000000" },
         });
 
-        const { getRequest } = useTestRequestHandler({
+        const { getRequest } = useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/self",
@@ -873,7 +877,7 @@ describe("client", () => {
           headers: { "Content-Type": null },
         });
 
-        const { getRequest } = useTestRequestHandler({
+        const { getRequest } = useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/self",
@@ -892,7 +896,7 @@ describe("client", () => {
 
         const list = ["one", "two", "three"];
 
-        const { getRequest } = useTestRequestHandler({
+        const { getRequest } = useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/self",
@@ -974,7 +978,7 @@ describe("client", () => {
           },
         });
 
-        const { getRequest } = useTestRequestHandler({
+        const { getRequest } = useMockRequestHandler({
           baseUrl,
           method: "options",
           path: `https://foo.bar/api/v1`,
@@ -999,7 +1003,7 @@ describe("client", () => {
           updated_at: "2024-01-20T00:00:00Z",
         };
 
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/self",
@@ -1041,7 +1045,7 @@ describe("client", () => {
       });
 
       it("executes in expected order", async () => {
-        const { getRequest } = useTestRequestHandler({
+        const { getRequest } = useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/self",
@@ -1104,7 +1108,7 @@ describe("client", () => {
       });
 
       it("receives correct options", async () => {
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl: "https://api.foo.bar/v1/",
           method: "get",
           path: "/self",
@@ -1129,7 +1133,7 @@ describe("client", () => {
       });
 
       it("receives OpenAPI options passed in from parent", async () => {
-        useTestRequestHandler({
+        useMockRequestHandler({
           method: "put",
           path: `https://api.foo.bar/v1/tag*`,
           status: 200,
@@ -1171,7 +1175,7 @@ describe("client", () => {
       });
 
       it("can be skipped without interrupting request", async () => {
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl: "https://api.foo.bar/v1/",
           method: "get",
           path: "/blogposts",
@@ -1193,7 +1197,7 @@ describe("client", () => {
       });
 
       it("can be ejected", async () => {
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl: "https://api.foo.bar/v1",
           method: "get",
           path: "/blogposts",
@@ -1225,7 +1229,7 @@ describe("client", () => {
     it("multipart/form-data", async () => {
       const client = createClient<paths>({ baseUrl });
 
-      const { getRequest } = useTestRequestHandler({
+      const { getRequest } = useMockRequestHandler({
         baseUrl,
         method: "put",
         path: "/contact",
@@ -1259,7 +1263,7 @@ describe("client", () => {
     it("respects cookie", async () => {
       const client = createClient<paths>({ baseUrl });
 
-      const { getRequestCookies } = useTestRequestHandler({
+      const { getRequestCookies } = useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/blogposts",
@@ -1280,7 +1284,7 @@ describe("client", () => {
   describe("responses", () => {
     it("returns empty object on 204", async () => {
       const client = createClient<paths>({ baseUrl });
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "delete",
         path: "/tag/*",
@@ -1304,7 +1308,7 @@ describe("client", () => {
         baseUrl,
         headers: { "Cache-Control": "max-age=10000000" },
       });
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/default-as-error",
@@ -1330,7 +1334,7 @@ describe("client", () => {
     describe("parseAs", () => {
       it("text", async () => {
         const client = createClient<paths>({ baseUrl });
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/anyMethod",
@@ -1347,7 +1351,7 @@ describe("client", () => {
 
       it("arrayBuffer", async () => {
         const client = createClient<paths>({ baseUrl });
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/anyMethod",
@@ -1364,7 +1368,7 @@ describe("client", () => {
 
       it("blob", async () => {
         const client = createClient<paths>({ baseUrl });
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/anyMethod",
@@ -1382,7 +1386,7 @@ describe("client", () => {
 
       it("stream", async () => {
         const client = createClient<paths>({ baseUrl });
-        useTestRequestHandler({
+        useMockRequestHandler({
           baseUrl,
           method: "get",
           path: "/anyMethod",
@@ -1442,7 +1446,7 @@ describe("client", () => {
   describe("GET()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>({ baseUrl });
-      const { getRequest } = useTestRequestHandler({
+      const { getRequest } = useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/anyMethod",
@@ -1459,7 +1463,7 @@ describe("client", () => {
       };
       const client = createClient<paths>({ baseUrl });
 
-      const { getRequestUrl } = useTestRequestHandler({
+      const { getRequestUrl } = useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/blogposts/:post_id",
@@ -1489,7 +1493,7 @@ describe("client", () => {
       const mockError = { code: 404, message: "Post not found" };
       const client = createClient<paths>({ baseUrl });
 
-      const { getRequest } = useTestRequestHandler({
+      const { getRequest } = useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/blogposts/:post_id",
@@ -1522,7 +1526,7 @@ describe("client", () => {
     it("handles array-type responses", async () => {
       const client = createClient<paths>({ baseUrl });
 
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/blogposts",
@@ -1542,7 +1546,7 @@ describe("client", () => {
     it("handles literal 2XX and 4XX codes", async () => {
       const client = createClient<paths>({ baseUrl });
 
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "put",
         path: "/media",
@@ -1567,7 +1571,7 @@ describe("client", () => {
     it("gracefully handles invalid JSON for errors", async () => {
       const client = createClient<paths>({ baseUrl });
 
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "get",
         path: "/blogposts",
@@ -1585,7 +1589,7 @@ describe("client", () => {
   describe("POST()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>({ baseUrl });
-      const { getRequest } = useTestRequestHandler({
+      const { getRequest } = useMockRequestHandler({
         baseUrl,
         method: "post",
         path: "/anyMethod",
@@ -1598,7 +1602,7 @@ describe("client", () => {
       const mockData = { status: "success" };
 
       const client = createClient<paths>({ baseUrl });
-      const { getRequestUrl } = useTestRequestHandler({
+      const { getRequestUrl } = useMockRequestHandler({
         baseUrl,
         method: "put",
         path: "/blogposts",
@@ -1628,7 +1632,7 @@ describe("client", () => {
     it("supports sepecifying utf-8 encoding", async () => {
       const mockData = { message: "My reply" };
       const client = createClient<paths>({ baseUrl });
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "put",
         path: "/comment",
@@ -1656,7 +1660,7 @@ describe("client", () => {
   describe("DELETE()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>({ baseUrl });
-      const { getRequest } = useTestRequestHandler({
+      const { getRequest } = useMockRequestHandler({
         baseUrl,
         method: "delete",
         path: "/anyMethod",
@@ -1667,7 +1671,7 @@ describe("client", () => {
 
     it("returns empty object on 204", async () => {
       const client = createClient<paths>({ baseUrl });
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "delete",
         path: "/blogposts/:post_id",
@@ -1688,7 +1692,7 @@ describe("client", () => {
 
     it("returns empty object on Content-Length: 0", async () => {
       const client = createClient<paths>({ baseUrl });
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "delete",
         path: `/blogposts/:post_id`,
@@ -1718,7 +1722,7 @@ describe("client", () => {
   describe("OPTIONS()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>({ baseUrl });
-      const { getRequest } = useTestRequestHandler({
+      const { getRequest } = useMockRequestHandler({
         baseUrl,
         method: "options",
         path: `/anyMethod`,
@@ -1731,7 +1735,7 @@ describe("client", () => {
   describe("HEAD()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>({ baseUrl });
-      const { getRequest } = useTestRequestHandler({
+      const { getRequest } = useMockRequestHandler({
         baseUrl,
         method: "head",
         path: "/anyMethod",
@@ -1744,7 +1748,7 @@ describe("client", () => {
   describe("PATCH()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>({ baseUrl });
-      const { getRequest } = useTestRequestHandler({
+      const { getRequest } = useMockRequestHandler({
         baseUrl,
         method: "patch",
         path: "/anyMethod",
@@ -1759,7 +1763,7 @@ describe("client", () => {
   describe("TRACE()", () => {
     it("sends the correct method", async () => {
       const client = createClient<paths>({ baseUrl });
-      useTestRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "all", // note: msw doesn’t support TRACE method
         path: "/anyMethod",
@@ -1788,7 +1792,7 @@ describe("examples", () => {
     const client = createClient<paths>({ baseUrl });
     client.use(authMiddleware);
 
-    const { getRequest } = useTestRequestHandler({
+    const { getRequest } = useMockRequestHandler({
       baseUrl,
       method: "get",
       path: "/blogposts/:post_id",

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -131,6 +131,12 @@ describe("client", () => {
             params: { path: { post_id: 1234 } },
           });
 
+          // expect error on unknown property in 'params'
+          await client.GET("/blogposts/{post_id}", {
+            // @ts-expect-error
+            TODO: "this should be an error",
+          });
+
           // (no error)
           let calledPostId = "";
           useMockRequestHandler<{ post_id: string }>({
@@ -1234,7 +1240,7 @@ describe("client", () => {
         if (error) {
           throw new Error(`parseAs text: error`);
         }
-        expect(data.toLowerCase()).toBe("{}");
+        expect(data).toBe("{}");
       });
 
       it("arrayBuffer", async () => {

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1,5 +1,15 @@
-// @ts-expect-error
-import createFetchMock from "vitest-fetch-mock";
+import {
+  http,
+  HttpResponse,
+  type JsonBodyType,
+  type StrictResponse,
+  type StrictRequest,
+  type DefaultBodyType,
+  type HttpResponseResolver,
+  type PathParams,
+  type AsyncResponseResolverReturnType,
+} from "msw";
+import { setupServer } from "msw/node";
 import createClient, {
   type Middleware,
   type MiddlewareRequest,
@@ -7,27 +17,121 @@ import createClient, {
 } from "../src/index.js";
 import type { paths } from "./fixtures/api.js";
 
-const fetchMocker = createFetchMock(vi);
+const server = setupServer();
+
+/**
+ * Default baseUrl for tests
+ */
+const baseUrl = "https://api.example.com";
+
+/**
+ * Test path helper, returns a an absolute URL based on
+ * the given path and base
+ */
+function testPath(path: string, base: string = baseUrl) {
+  // If we have absolute path
+  if (URL.canParse(path)) {
+    return new URL(path).toString();
+  }
+
+  // Otherwise we want to support relative paths
+  // where base may also contain some part of the path
+  // e.g.
+  // base = https://api.foo.bar/v1/
+  // path = /self
+  // should result in https://api.foo.bar/v1/self
+
+  // Construct base URL
+  const baseUrlInstance = new URL(base);
+
+  // prepend base url url pathname to path and ensure only one slash between the URL parts
+  const newPath = `${baseUrlInstance.pathname}/${path}`.replace(/\/+/g, "/");
+
+  return new URL(newPath, baseUrlInstance).toString();
+}
 
 beforeAll(() => {
-  fetchMocker.enableMocks();
-});
-afterEach(() => {
-  fetchMocker.resetMocks();
+  server.listen({
+    onUnhandledRequest: (request) => {
+      throw new Error(
+        `No request handler found for ${request.method} ${request.url}`,
+      );
+    },
+  });
 });
 
-interface MockResponse {
+afterEach(() => server.resetHandlers());
+
+afterAll(() => server.close());
+
+type MswHttpMethod = keyof typeof http;
+
+interface TestRequestHandlerOptions<
+  // Recreate the generic signature of the HTTP resolver
+  // so the arguments passed to http handlers propagate here.
+  Params extends PathParams<keyof Params> = PathParams,
+  RequestBodyType extends DefaultBodyType = DefaultBodyType,
+  ResponseBodyType extends DefaultBodyType = undefined,
+> {
+  baseUrl?: string;
+  method: MswHttpMethod;
+  /**
+   * Relative or absolute path to match.
+   * When relative, baseUrl will be used as base.
+   */
+  path: string;
+  body?: JsonBodyType;
   headers?: Record<string, string>;
-  status: number;
-  body: any;
+  status?: number;
+  handler?: HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>;
 }
 
-function mockFetch(res: MockResponse) {
-  fetchMocker.mockResponse(() => res);
-}
+function useTestRequestHandler<
+  // Recreate the generic signature of the HTTP resolver
+  // so the arguments passed to http handlers propagate here.
+  Params extends PathParams<keyof Params> = PathParams,
+  RequestBodyType extends DefaultBodyType = DefaultBodyType,
+  ResponseBodyType extends DefaultBodyType = undefined,
+>({
+  baseUrl: requestBaseUrl,
+  method,
+  path,
+  body,
+  headers,
+  status,
+  handler,
+}: TestRequestHandlerOptions<Params, RequestBodyType, ResponseBodyType>) {
+  let requestUrl = "";
+  let receivedRequest: null | StrictRequest<DefaultBodyType> = null;
+  let receivedCookies: null | Record<string, string> = null;
 
-function mockFetchOnce(res: MockResponse) {
-  fetchMocker.mockResponseOnce(() => res);
+  const resolvedPath = testPath(path, requestBaseUrl);
+
+  server.use(
+    http[method]<Params, RequestBodyType, ResponseBodyType>(
+      resolvedPath,
+      (args) => {
+        requestUrl = args.request.url;
+        receivedRequest = args.request.clone();
+        receivedCookies = { ...args.cookies };
+
+        if (handler) {
+          return handler(args);
+        }
+
+        return HttpResponse.json(body, {
+          status: status ?? 200,
+          headers,
+        }) as AsyncResponseResolverReturnType<ResponseBodyType>;
+      },
+    ),
+  );
+
+  return {
+    getCookies: () => receivedCookies!,
+    getRequest: () => receivedRequest!,
+    getRequestUrl: () => new URL(requestUrl),
+  };
 }
 
 describe("client", () => {
@@ -46,13 +150,19 @@ describe("client", () => {
 
   describe("TypeScript checks", () => {
     it("marks data or error as undefined, but never both", async () => {
-      const client = createClient<paths>();
+      const client = createClient<paths>({
+        baseUrl,
+      });
 
       // data
-      mockFetchOnce({
+      useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/string-array",
         status: 200,
-        body: JSON.stringify(["one", "two", "three"]),
+        body: ["one", "two", "three"],
       });
+
       const dataRes = await client.GET("/string-array");
 
       // … is initially possibly undefined
@@ -71,9 +181,12 @@ describe("client", () => {
       }
 
       // error
-      mockFetchOnce({
+      useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/string-array",
         status: 500,
-        body: JSON.stringify({ code: 500, message: "Something went wrong" }),
+        body: { code: 500, message: "Something went wrong" },
       });
       const errorRes = await client.GET("/string-array");
 
@@ -97,9 +210,16 @@ describe("client", () => {
       describe("path", () => {
         it("typechecks", async () => {
           const client = createClient<paths>({
-            baseUrl: "https://myapi.com/v1",
+            baseUrl,
           });
-          mockFetch({ status: 200, body: JSON.stringify({ message: "OK" }) });
+
+          useTestRequestHandler({
+            baseUrl,
+            method: "get",
+            path: "/blogposts/:post_id",
+            status: 200,
+            body: { message: "OK" },
+          });
 
           // expect error on missing 'params'
           // @ts-expect-error
@@ -120,22 +240,36 @@ describe("client", () => {
           });
 
           // (no error)
+          let calledPostId = "";
+          useTestRequestHandler<{ post_id: string }>({
+            baseUrl,
+            method: "get",
+            path: `/blogposts/:post_id`,
+            handler: ({ params }) => {
+              calledPostId = params.post_id;
+              return HttpResponse.json({ message: "OK" }, { status: 200 });
+            },
+          });
+
           await client.GET("/blogposts/{post_id}", {
             params: { path: { post_id: "1234" } },
           });
 
           // expect param passed correctly
-          const lastCall =
-            fetchMocker.mock.calls[fetchMocker.mock.calls.length - 1];
-          expect(lastCall[0].url).toBe("https://myapi.com/v1/blogposts/1234");
+          expect(calledPostId).toBe("1234");
         });
 
         it("serializes", async () => {
-          const client = createClient<paths>();
-          mockFetch({
-            status: 200,
-            body: JSON.stringify({ status: "success" }),
+          const client = createClient<paths>({
+            baseUrl,
           });
+
+          const { getRequestUrl } = useTestRequestHandler({
+            baseUrl,
+            method: "get",
+            path: `/path-params/*`,
+          });
+
           await client.GET(
             "/path-params/{simple_primitive}/{simple_obj_flat}/{simple_arr_flat}/{simple_obj_explode*}/{simple_arr_explode*}/{.label_primitive}/{.label_obj_flat}/{.label_arr_flat}/{.label_obj_explode*}/{.label_arr_explode*}/{;matrix_primitive}/{;matrix_obj_flat}/{;matrix_arr_flat}/{;matrix_obj_explode*}/{;matrix_arr_explode*}",
             {
@@ -161,8 +295,7 @@ describe("client", () => {
             },
           );
 
-          const reqURL = fetchMocker.mock.calls[0][0].url;
-          expect(reqURL).toBe(
+          expect(getRequestUrl().pathname).toBe(
             `/path-params/${[
               // simple
               "simple",
@@ -187,24 +320,49 @@ describe("client", () => {
         });
 
         it("allows UTF-8 characters", async () => {
-          const client = createClient<paths>();
-          mockFetchOnce({ status: 200, body: "{}" });
+          const client = createClient<paths>({ baseUrl });
+          const { getRequestUrl } = useTestRequestHandler({
+            baseUrl,
+            method: "get",
+            path: "/blogposts/*",
+          });
+
           await client.GET("/blogposts/{post_id}", {
             params: { path: { post_id: "post?id = 🥴" } },
           });
 
           // expect post_id to be encoded properly
-          expect(fetchMocker.mock.calls[0][0].url).toBe(
-            `/blogposts/post?id%20=%20🥴`,
+          const url = getRequestUrl();
+          expect(url.searchParams.get("id ")).toBe(" 🥴");
+          expect(url.pathname + url.search).toBe(
+            `/blogposts/post?id%20=%20%F0%9F%A5%B4`,
           );
         });
       });
 
       it("header", async () => {
-        const client = createClient<paths>({ baseUrl: "https://myapi.com/v1" });
-        mockFetch({ status: 200, body: JSON.stringify({ status: "success" }) });
+        const client = createClient<paths>({ baseUrl });
 
-        // expet error on missing header
+        useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/header-params",
+          handler: ({ request }) => {
+            const header = request.headers.get("x-required-header");
+            if (header !== "correct") {
+              return HttpResponse.json(
+                { code: 500, message: "missing correct header" },
+                { status: 500 },
+              ) as StrictResponse<any>;
+            }
+            return HttpResponse.json(
+              { status: header },
+              { status: 200, headers: request.headers },
+            );
+          },
+        });
+
+        // expect error on missing header
         // @ts-expect-error
         await client.GET("/header-params");
 
@@ -221,54 +379,76 @@ describe("client", () => {
         });
 
         // (no error)
-        await client.GET("/header-params", {
+        const response = await client.GET("/header-params", {
           params: { header: { "x-required-header": "correct" } },
         });
 
         // expect param passed correctly
-        const lastCall =
-          fetchMocker.mock.calls[fetchMocker.mock.calls.length - 1][0];
-        expect(lastCall.headers.get("x-required-header")).toBe("correct");
+        expect(response.response.headers.get("x-required-header")).toBe(
+          "correct",
+        );
       });
 
       describe("query", () => {
         describe("querySerializer", () => {
           it("primitives", async () => {
-            const client = createClient<paths>();
-            mockFetchOnce({ status: 200, body: "{}" });
+            const client = createClient<paths>({ baseUrl });
+
+            const { getRequestUrl } = useTestRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/query-params*",
+            });
+
             await client.GET("/query-params", {
               params: {
                 query: { string: "string", number: 0, boolean: false },
               },
             });
 
-            expect(fetchMocker.mock.calls[0][0].url).toBe(
-              "/query-params?string=string&number=0&boolean=false",
+            expect(getRequestUrl().search).toBe(
+              "?string=string&number=0&boolean=false",
             );
           });
 
           it("array params (empty)", async () => {
-            const client = createClient<paths>();
-            mockFetchOnce({ status: 200, body: "{}" });
+            const client = createClient<paths>({ baseUrl });
+
+            const { getRequestUrl } = useTestRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/query-params*",
+            });
+
             await client.GET("/query-params", {
               params: {
                 query: { array: [] },
               },
             });
 
-            expect(fetchMocker.mock.calls[0][0].url).toBe("/query-params");
+            const url = getRequestUrl();
+            expect(url.pathname).toBe("/query-params");
+            expect(url.search).toBe("");
           });
 
           it("empty/null params", async () => {
-            const client = createClient<paths>();
-            mockFetchOnce({ status: 200, body: "{}" });
+            const client = createClient<paths>({ baseUrl });
+
+            const { getRequestUrl } = useTestRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/query-params*",
+            });
+
             await client.GET("/query-params", {
               params: {
                 query: { string: undefined, number: null as any },
               },
             });
 
-            expect(fetchMocker.mock.calls[0][0].url).toBe("/query-params");
+            const url = getRequestUrl();
+            expect(url.pathname).toBe("/query-params");
+            expect(url.search).toBe("");
           });
 
           describe("array", () => {
@@ -323,16 +503,25 @@ describe("client", () => {
               },
             ][])("%s", async (_, { given, want }) => {
               const client = createClient<paths>({
+                baseUrl,
                 querySerializer: { array: given },
               });
-              mockFetch({ status: 200, body: "{}" });
+
+              const { getRequestUrl } = useTestRequestHandler({
+                baseUrl,
+                method: "get",
+                path: "/query-params*",
+              });
+
               await client.GET("/query-params", {
                 params: {
                   query: { array: ["1", "2", "3"], boolean: true },
                 },
               });
 
-              expect(fetchMocker.mock.calls[0][0].url.split("?")[1]).toBe(want);
+              const url = getRequestUrl();
+              // skip leading '?'
+              expect(url.search.substring(1)).toBe(want);
             });
           });
 
@@ -374,24 +563,37 @@ describe("client", () => {
               },
             ][])("%s", async (_, { given, want }) => {
               const client = createClient<paths>({
+                baseUrl,
                 querySerializer: { object: given },
               });
-              mockFetch({ status: 200, body: "{}" });
+              const { getRequestUrl } = useTestRequestHandler({
+                baseUrl,
+                method: "get",
+                path: "/query-params*",
+              });
+
               await client.GET("/query-params", {
                 params: {
                   query: { object: { foo: "bar", bar: "baz" }, boolean: true },
                 },
               });
 
-              expect(fetchMocker.mock.calls[0][0].url.split("?")[1]).toBe(want);
+              const url = getRequestUrl();
+              // skip leading '?'
+              expect(url.search.substring(1)).toBe(want);
             });
           });
 
           it("allowReserved", async () => {
             const client = createClient<paths>({
+              baseUrl,
               querySerializer: { allowReserved: true },
             });
-            mockFetch({ status: 200, body: "{}" });
+            const { getRequestUrl } = useTestRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/query-params*",
+            });
             await client.GET("/query-params", {
               params: {
                 query: {
@@ -399,8 +601,12 @@ describe("client", () => {
                 },
               },
             });
-            expect(fetchMocker.mock.calls[0][0].url.split("?")[1]).toBe(
-              "string=bad/character🐶",
+
+            expect(getRequestUrl().search).toBe(
+              "?string=bad/character%F0%9F%90%B6",
+            );
+            expect(getRequestUrl().searchParams.get("string")).toBe(
+              "bad/character🐶",
             );
 
             await client.GET("/query-params", {
@@ -413,17 +619,28 @@ describe("client", () => {
                 allowReserved: false,
               },
             });
-            expect(fetchMocker.mock.calls[1][0].url.split("?")[1]).toBe(
-              "string=bad%2Fcharacter%F0%9F%90%B6",
+
+            expect(getRequestUrl().search).toBe(
+              "?string=bad%2Fcharacter%F0%9F%90%B6",
+            );
+            expect(getRequestUrl().searchParams.get("string")).toBe(
+              "bad/character🐶",
             );
           });
 
           describe("function", () => {
             it("global default", async () => {
               const client = createClient<paths>({
+                baseUrl,
                 querySerializer: (q) => `alpha=${q.version}&beta=${q.format}`,
               });
-              mockFetchOnce({ status: 200, body: "{}" });
+
+              const { getRequestUrl } = useTestRequestHandler({
+                baseUrl,
+                method: "get",
+                path: "/blogposts/:post_id",
+              });
+
               await client.GET("/blogposts/{post_id}", {
                 params: {
                   path: { post_id: "my-post" },
@@ -431,16 +648,24 @@ describe("client", () => {
                 },
               });
 
-              expect(fetchMocker.mock.calls[0][0].url).toBe(
+              const url = getRequestUrl();
+              expect(url.pathname + url.search).toBe(
                 "/blogposts/my-post?alpha=2&beta=json",
               );
             });
 
             it("per-request", async () => {
               const client = createClient<paths>({
+                baseUrl,
                 querySerializer: () => "query",
               });
-              mockFetchOnce({ status: 200, body: "{}" });
+
+              const { getRequestUrl } = useTestRequestHandler({
+                baseUrl,
+                method: "get",
+                path: "/blogposts/:post_id",
+              });
+
               await client.GET("/blogposts/{post_id}", {
                 params: {
                   path: { post_id: "my-post" },
@@ -449,7 +674,8 @@ describe("client", () => {
                 querySerializer: (q) => `alpha=${q.version}&beta=${q.format}`,
               });
 
-              expect(fetchMocker.mock.calls[0][0].url).toBe(
+              const url = getRequestUrl();
+              expect(url.pathname + url.search).toBe(
                 "/blogposts/my-post?alpha=2&beta=json",
               );
             });
@@ -457,18 +683,22 @@ describe("client", () => {
 
           it("ignores leading ? characters", async () => {
             const client = createClient<paths>({
+              baseUrl,
               querySerializer: () => "?query",
             });
-            mockFetchOnce({ status: 200, body: "{}" });
+            const { getRequestUrl } = useTestRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/blogposts/:post_id",
+            });
             await client.GET("/blogposts/{post_id}", {
               params: {
                 path: { post_id: "my-post" },
                 query: { version: 2, format: "json" },
               },
             });
-            expect(fetchMocker.mock.calls[0][0].url).toBe(
-              "/blogposts/my-post?query",
-            );
+            const url = getRequestUrl();
+            expect(url.pathname + url.search).toBe("/blogposts/my-post?query");
           });
         });
       });
@@ -478,8 +708,13 @@ describe("client", () => {
       // these are pure type tests; no runtime assertions needed
       /* eslint-disable vitest/expect-expect */
       it("requires necessary requestBodies", async () => {
-        const client = createClient<paths>({ baseUrl: "https://myapi.com/v1" });
-        mockFetch({ status: 200, body: JSON.stringify({ message: "OK" }) });
+        const client = createClient<paths>({ baseUrl });
+
+        useTestRequestHandler({
+          baseUrl,
+          method: "put",
+          path: "/blogposts",
+        });
 
         // expect error on missing `body`
         // @ts-expect-error
@@ -501,8 +736,14 @@ describe("client", () => {
       });
 
       it("requestBody (inline)", async () => {
-        mockFetch({ status: 201, body: "{}" });
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
+
+        useTestRequestHandler({
+          baseUrl,
+          method: "put",
+          path: "/blogposts-optional-inline",
+          status: 201,
+        });
 
         // expect error on wrong body type
         await client.PUT("/blogposts-optional-inline", {
@@ -521,8 +762,14 @@ describe("client", () => {
       });
 
       it("requestBody with required: false", async () => {
-        mockFetch({ status: 201, body: "{}" });
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
+
+        useTestRequestHandler({
+          baseUrl,
+          method: "put",
+          path: "/blogposts-optional",
+          status: 201,
+        });
 
         // assert missing `body` doesn’t raise a TS error
         await client.PUT("/blogposts-optional");
@@ -546,36 +793,45 @@ describe("client", () => {
 
   describe("options", () => {
     it("baseUrl", async () => {
-      let client = createClient<paths>({ baseUrl: "https://myapi.com/v1" });
-      mockFetch({ status: 200, body: JSON.stringify({ message: "OK" }) });
+      let client = createClient<paths>({ baseUrl });
+
+      const { getRequestUrl } = useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/self",
+        status: 200,
+        body: { message: "OK" },
+      });
+
       await client.GET("/self");
 
       // assert baseUrl and path mesh as expected
-      expect(fetchMocker.mock.calls[0][0].url).toBe(
-        "https://myapi.com/v1/self",
-      );
+      expect(getRequestUrl().href).toBe(testPath("/self"));
 
-      client = createClient<paths>({ baseUrl: "https://myapi.com/v1/" });
+      client = createClient<paths>({ baseUrl });
       await client.GET("/self");
       // assert trailing '/' was removed
-      expect(fetchMocker.mock.calls[1][0].url).toBe(
-        "https://myapi.com/v1/self",
-      );
+      expect(getRequestUrl().href).toBe(testPath("/self"));
     });
 
     describe("headers", () => {
       it("persist", async () => {
         const headers: HeadersInit = { Authorization: "Bearer secrettoken" };
 
-        const client = createClient<paths>({ headers });
-        mockFetchOnce({
+        const client = createClient<paths>({ headers, baseUrl });
+
+        const { getRequest } = useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
           status: 200,
-          body: JSON.stringify({ email: "user@user.com" }),
+          body: { email: "user@user.com" },
         });
+
         await client.GET("/self");
 
         // assert default headers were passed
-        expect(fetchMocker.mock.calls[0][0].headers).toEqual(
+        expect(getRequest().headers).toEqual(
           new Headers({
             ...headers, // assert new header got passed
             "Content-Type": "application/json", //  probably doesn’t need to get tested, but this was simpler than writing lots of code to ignore these
@@ -585,19 +841,25 @@ describe("client", () => {
 
       it("can be overridden", async () => {
         const client = createClient<paths>({
+          baseUrl,
           headers: { "Cache-Control": "max-age=10000000" },
         });
-        mockFetchOnce({
+
+        const { getRequest } = useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
           status: 200,
-          body: JSON.stringify({ email: "user@user.com" }),
+          body: { email: "user@user.com" },
         });
+
         await client.GET("/self", {
           params: {},
           headers: { "Cache-Control": "no-cache" },
         });
 
         // assert default headers were passed
-        expect(fetchMocker.mock.calls[0][0].headers).toEqual(
+        expect(getRequest().headers).toEqual(
           new Headers({
             "Cache-Control": "no-cache",
             "Content-Type": "application/json",
@@ -607,29 +869,40 @@ describe("client", () => {
 
       it("can be unset", async () => {
         const client = createClient<paths>({
+          baseUrl,
           headers: { "Content-Type": null },
         });
-        mockFetchOnce({
+
+        const { getRequest } = useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
           status: 200,
-          body: JSON.stringify({ email: "user@user.com" }),
+          body: { email: "user@user.com" },
         });
+
         await client.GET("/self", { params: {} });
 
         // assert default headers were passed
-        expect(fetchMocker.mock.calls[0][0].headers).toEqual(new Headers());
+        expect(getRequest().headers).toEqual(new Headers());
       });
 
       it("supports arrays", async () => {
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
 
         const list = ["one", "two", "three"];
 
-        mockFetchOnce({ status: 200, body: "{}" });
+        const { getRequest } = useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: {},
+        });
+
         await client.GET("/self", { headers: { list } });
 
-        expect(fetchMocker.mock.calls[0][0].headers.get("list")).toEqual(
-          list.join(", "),
-        );
+        expect(getRequest().headers.get("list")).toEqual(list.join(", "));
       });
     });
 
@@ -647,16 +920,15 @@ describe("client", () => {
         }
 
         const customFetch = createCustomFetch({ works: true });
-        mockFetchOnce({ status: 200, body: "{}" });
 
-        const client = createClient<paths>({ fetch: customFetch });
+        const client = createClient<paths>({ fetch: customFetch, baseUrl });
         const { data } = await client.GET("/self");
 
         // assert data was returned from custom fetcher
         expect(data).toEqual({ works: true });
 
-        // assert global fetch was never called
-        expect(fetchMocker).not.toHaveBeenCalled();
+        // TODO: do we need to assert nothing was called?
+        // msw should throw an error if there was an unused handler
       });
 
       it("per-request", async () => {
@@ -674,9 +946,7 @@ describe("client", () => {
         const fallbackFetch = createCustomFetch({ fetcher: "fallback" });
         const overrideFetch = createCustomFetch({ fetcher: "override" });
 
-        mockFetchOnce({ status: 200, body: "{}" });
-
-        const client = createClient<paths>({ fetch: fallbackFetch });
+        const client = createClient<paths>({ fetch: fallbackFetch, baseUrl });
 
         // assert override function was called
         const fetch1 = await client.GET("/self", { fetch: overrideFetch });
@@ -686,16 +956,14 @@ describe("client", () => {
         const fetch2 = await client.GET("/self");
         expect(fetch2.data).toEqual({ fetcher: "fallback" });
 
-        // assert global fetch was never called
-        expect(fetchMocker).not.toHaveBeenCalled();
+        // TODO: do we need to assert nothing was called?
+        // msw should throw an error if there was an unused handler
       });
     });
 
     describe("middleware", () => {
       it("can modify request", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
-
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
         client.use({
           async onRequest(req) {
             return new Request("https://foo.bar/api/v1", {
@@ -705,9 +973,18 @@ describe("client", () => {
             });
           },
         });
+
+        const { getRequest } = useTestRequestHandler({
+          baseUrl,
+          method: "options",
+          path: `https://foo.bar/api/v1`,
+          status: 200,
+          body: {},
+        });
+
         await client.GET("/self");
 
-        const req = fetchMocker.mock.calls[0][0];
+        const req = getRequest();
         expect(req.url).toBe("https://foo.bar/api/v1");
         expect(req.method).toBe("OPTIONS");
         expect(req.headers.get("foo")).toBe("bar");
@@ -721,13 +998,17 @@ describe("client", () => {
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-20T00:00:00Z",
         };
-        mockFetchOnce({
+
+        useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
           status: 200,
-          body: JSON.stringify(rawBody),
+          body: rawBody,
           headers: { foo: "bar" },
         });
 
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
         client.use({
           // convert date string to unix time
           async onResponse(res) {
@@ -738,7 +1019,7 @@ describe("client", () => {
             headers.set("middleware", "value");
             return new Response(JSON.stringify(body), {
               ...res,
-              status: 205,
+              status: 201,
               headers,
             });
           },
@@ -752,7 +1033,7 @@ describe("client", () => {
         // assert rest of body was preserved
         expect(data?.email).toBe(rawBody.email);
         // assert status changed
-        expect(response.status).toBe(205);
+        expect(response.status).toBe(201);
         // assert server headers were preserved
         expect(response.headers.get("foo")).toBe("bar");
         // assert middleware heaers were added
@@ -760,9 +1041,15 @@ describe("client", () => {
       });
 
       it("executes in expected order", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
+        const { getRequest } = useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: {},
+        });
 
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
         // this middleware passes along the “step” header
         // for both requests and responses, but first checks if
         // it received the end result of the previous middleware step
@@ -810,33 +1097,44 @@ describe("client", () => {
         const { response } = await client.GET("/self");
 
         // assert requests ended up on step C (array order)
-        expect(fetchMocker.mock.calls[0][0].headers.get("step")).toBe("C");
+        expect(getRequest().headers.get("step")).toBe("C");
 
         // assert responses ended up on step A (reverse order)
         expect(response.headers.get("step")).toBe("A");
       });
 
       it("receives correct options", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
+        useTestRequestHandler({
+          baseUrl: "https://api.foo.bar/v1/",
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: {},
+        });
 
-        let baseUrl = "";
+        let requestBaseUrl = "";
 
         const client = createClient<paths>({
           baseUrl: "https://api.foo.bar/v1/",
         });
         client.use({
           onRequest(_, options) {
-            baseUrl = options.baseUrl;
+            requestBaseUrl = options.baseUrl;
             return undefined;
           },
         });
 
         await client.GET("/self");
-        expect(baseUrl).toBe("https://api.foo.bar/v1");
+        expect(requestBaseUrl).toBe("https://api.foo.bar/v1");
       });
 
       it("receives OpenAPI options passed in from parent", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
+        useTestRequestHandler({
+          method: "put",
+          path: `https://api.foo.bar/v1/tag*`,
+          status: 200,
+          body: {},
+        });
 
         const pathname = "/tag/{name}";
         const tagData = {
@@ -873,7 +1171,13 @@ describe("client", () => {
       });
 
       it("can be skipped without interrupting request", async () => {
-        mockFetchOnce({ status: 200, body: JSON.stringify({ success: true }) });
+        useTestRequestHandler({
+          baseUrl: "https://api.foo.bar/v1/",
+          method: "get",
+          path: "/blogposts",
+          status: 200,
+          body: { success: true },
+        });
 
         const client = createClient<paths>({
           baseUrl: "https://api.foo.bar/v1/",
@@ -889,7 +1193,13 @@ describe("client", () => {
       });
 
       it("can be ejected", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
+        useTestRequestHandler({
+          baseUrl: "https://api.foo.bar/v1",
+          method: "get",
+          path: "/blogposts",
+          status: 200,
+          body: { success: true },
+        });
 
         let called = false;
         const errorMiddleware = {
@@ -913,8 +1223,14 @@ describe("client", () => {
 
   describe("requests", () => {
     it("multipart/form-data", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: JSON.stringify({ success: true }) });
+      const client = createClient<paths>({ baseUrl });
+
+      const { getRequest } = useTestRequestHandler({
+        baseUrl,
+        method: "put",
+        path: "/contact",
+      });
+
       const reqBody = {
         name: "John Doe",
         email: "test@email.email",
@@ -932,31 +1248,45 @@ describe("client", () => {
         },
       });
 
-      // expect post_id to be encoded properly
-      const req = fetchMocker.mock.calls[0][0];
-      // note: this is FormData, but Node.js doesn’t handle new Request() properly with formData bodies. So this is only in tests.
-      expect(req.body).toBeInstanceOf(Buffer);
-      expect((req.headers as Headers).get("Content-Type")).toBe(
-        "text/plain;charset=UTF-8",
-      );
+      // expect request to contain correct headers and body
+      const req = getRequest();
+      expect(req.body).toBeInstanceOf(ReadableStream);
+      const body = await req.formData();
+      expect(body.get("name")).toBe("John Doe");
+      expect(req.headers.get("Content-Type")).toMatch(/multipart\/form-data;/);
     });
 
-    // Node Requests eat credentials (no cookies), but this works in frontend
-    // TODO: find a way to reliably test this without too much mocking
-    it.skip("respects cookie", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
-      await client.GET("/blogposts", { credentials: "include" });
+    it("respects cookie", async () => {
+      const client = createClient<paths>({ baseUrl });
 
-      const req = fetchMocker.mock.calls[0][0];
-      expect(req.credentials).toBe("include");
+      const { getCookies } = useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts",
+      });
+
+      await client.GET("/blogposts", {
+        credentials: "include",
+        headers: {
+          Cookie: "session=1234",
+        },
+      });
+
+      const cookies = getCookies();
+      expect(cookies).toEqual({ session: "1234" });
     });
   });
 
   describe("responses", () => {
     it("returns empty object on 204", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 204, body: "" });
+      const client = createClient<paths>({ baseUrl });
+      useTestRequestHandler({
+        baseUrl,
+        method: "delete",
+        path: "/tag/*",
+        handler: () => new HttpResponse(null, { status: 204 }),
+      });
+
       const { data, error, response } = await client.DELETE("/tag/{name}", {
         params: { path: { name: "New Tag" } },
       });
@@ -971,15 +1301,18 @@ describe("client", () => {
 
     it("treats `default` as an error", async () => {
       const client = createClient<paths>({
+        baseUrl,
         headers: { "Cache-Control": "max-age=10000000" },
       });
-      mockFetchOnce({
+      useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/default-as-error",
         status: 500,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+        body: {
           code: 500,
           message: "An unexpected error occurred",
-        }),
+        },
       });
       const { error } = await client.GET("/default-as-error");
 
@@ -996,8 +1329,13 @@ describe("client", () => {
 
     describe("parseAs", () => {
       it("text", async () => {
-        const client = createClient<paths>();
-        mockFetchOnce({ status: 200, body: "{}" });
+        const client = createClient<paths>({ baseUrl });
+        useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/anyMethod",
+          body: {},
+        });
         const { data, error } = (await client.GET("/anyMethod", {
           parseAs: "text",
         })) satisfies { data?: string };
@@ -1008,8 +1346,13 @@ describe("client", () => {
       });
 
       it("arrayBuffer", async () => {
-        const client = createClient<paths>();
-        mockFetchOnce({ status: 200, body: "{}" });
+        const client = createClient<paths>({ baseUrl });
+        useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/anyMethod",
+          body: {},
+        });
         const { data, error } = (await client.GET("/anyMethod", {
           parseAs: "arrayBuffer",
         })) satisfies { data?: ArrayBuffer };
@@ -1020,8 +1363,13 @@ describe("client", () => {
       });
 
       it("blob", async () => {
-        const client = createClient<paths>();
-        mockFetchOnce({ status: 200, body: "{}" });
+        const client = createClient<paths>({ baseUrl });
+        useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/anyMethod",
+          body: {},
+        });
         const { data, error } = (await client.GET("/anyMethod", {
           parseAs: "blob",
         })) satisfies { data?: Blob };
@@ -1033,8 +1381,13 @@ describe("client", () => {
       });
 
       it("stream", async () => {
-        const client = createClient<paths>();
-        mockFetchOnce({ status: 200, body: "{}" });
+        const client = createClient<paths>({ baseUrl });
+        useTestRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/anyMethod",
+          body: {},
+        });
         const { data } = (await client.GET("/anyMethod", {
           parseAs: "stream",
         })) satisfies { data?: ReadableStream<Uint8Array> | null };
@@ -1042,12 +1395,10 @@ describe("client", () => {
           throw new Error(`parseAs stream: error`);
         }
 
-        expect(data instanceof Buffer).toBe(true);
-        if (!(data instanceof Buffer)) {
-          throw Error("Data should be an instance of Buffer in Node context");
-        }
-
-        expect(data.byteLength).toBe(2);
+        expect(data).toBeInstanceOf(ReadableStream);
+        const reader = data.getReader();
+        const result = await reader.read();
+        expect(result.value!.length).toBe(2);
       });
 
       it("use the selected content", async () => {
@@ -1090,10 +1441,14 @@ describe("client", () => {
 
   describe("GET()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/anyMethod",
+      });
       await client.GET("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("GET");
+      expect(getRequest().method).toBe("GET");
     });
 
     it("sends correct options, returns success", async () => {
@@ -1102,8 +1457,16 @@ describe("client", () => {
         body: "<p>This is a very good post</p>",
         publish_date: new Date("2023-03-01T12:00:00Z").getTime(),
       };
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: JSON.stringify(mockData) });
+      const client = createClient<paths>({ baseUrl });
+
+      const { getRequestUrl } = useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts/:post_id",
+        status: 200,
+        body: mockData,
+      });
+      // mockFetchOnce({ status: 200, body: JSON.stringify(mockData) });
       const { data, error, response } = await client.GET(
         "/blogposts/{post_id}",
         {
@@ -1112,7 +1475,7 @@ describe("client", () => {
       );
 
       // assert correct URL was called
-      expect(fetchMocker.mock.calls[0][0].url).toBe("/blogposts/my-post");
+      expect(getRequestUrl().pathname).toBe("/blogposts/my-post");
 
       // assert correct data was returned
       expect(data).toEqual(mockData);
@@ -1124,8 +1487,16 @@ describe("client", () => {
 
     it("sends correct options, returns error", async () => {
       const mockError = { code: 404, message: "Post not found" };
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 404, body: JSON.stringify(mockError) });
+      const client = createClient<paths>({ baseUrl });
+
+      const { getRequest } = useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts/:post_id",
+        status: 404,
+        body: mockError,
+      });
+
       const { data, error, response } = await client.GET(
         "/blogposts/{post_id}",
         {
@@ -1134,10 +1505,10 @@ describe("client", () => {
       );
 
       // assert correct URL was called
-      expect(fetchMocker.mock.calls[0][0].url).toBe("/blogposts/my-post");
+      expect(getRequest().url).toBe(baseUrl + "/blogposts/my-post");
 
       // assert correct method was called
-      expect(fetchMocker.mock.calls[0][0].method).toBe("GET");
+      expect(getRequest().method).toBe("GET");
 
       // assert correct error was returned
       expect(error).toEqual(mockError);
@@ -1149,8 +1520,16 @@ describe("client", () => {
 
     // note: this was a previous bug in the type inference
     it("handles array-type responses", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "[]" });
+      const client = createClient<paths>({ baseUrl });
+
+      useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts",
+        status: 200,
+        body: [],
+      });
+
       const { data } = await client.GET("/blogposts", { params: {} });
       if (!data) {
         throw new Error("data empty");
@@ -1161,8 +1540,16 @@ describe("client", () => {
     });
 
     it("handles literal 2XX and 4XX codes", async () => {
-      const client = createClient<paths>();
-      mockFetch({ status: 201, body: '{"status": "success"}' });
+      const client = createClient<paths>({ baseUrl });
+
+      useTestRequestHandler({
+        baseUrl,
+        method: "put",
+        path: "/media",
+        status: 201,
+        body: { status: "success" },
+      });
+
       const { data, error } = await client.PUT("/media", {
         body: { media: "base64", name: "myImage" },
       });
@@ -1178,8 +1565,16 @@ describe("client", () => {
     });
 
     it("gracefully handles invalid JSON for errors", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 401, body: "Unauthorized" });
+      const client = createClient<paths>({ baseUrl });
+
+      useTestRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts",
+        status: 401,
+        body: "Unauthorized",
+      });
+
       const { data, error } = await client.GET("/blogposts");
 
       expect(data).toBeUndefined();
@@ -1189,16 +1584,28 @@ describe("client", () => {
 
   describe("POST()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useTestRequestHandler({
+        baseUrl,
+        method: "post",
+        path: "/anyMethod",
+      });
       await client.POST("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("POST");
+      expect(getRequest().method).toBe("POST");
     });
 
     it("sends correct options, returns success", async () => {
       const mockData = { status: "success" };
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 201, body: JSON.stringify(mockData) });
+
+      const client = createClient<paths>({ baseUrl });
+      const { getRequestUrl } = useTestRequestHandler({
+        baseUrl,
+        method: "put",
+        path: "/blogposts",
+        status: 201,
+        body: mockData,
+      });
+
       const { data, error, response } = await client.PUT("/blogposts", {
         body: {
           title: "New Post",
@@ -1208,7 +1615,7 @@ describe("client", () => {
       });
 
       // assert correct URL was called
-      expect(fetchMocker.mock.calls[0][0].url).toBe("/blogposts");
+      expect(getRequestUrl().pathname).toBe("/blogposts");
 
       // assert correct data was returned
       expect(data).toEqual(mockData);
@@ -1220,8 +1627,15 @@ describe("client", () => {
 
     it("supports sepecifying utf-8 encoding", async () => {
       const mockData = { message: "My reply" };
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 201, body: JSON.stringify(mockData) });
+      const client = createClient<paths>({ baseUrl });
+      useTestRequestHandler({
+        baseUrl,
+        method: "put",
+        path: "/comment",
+        status: 201,
+        body: mockData,
+      });
+
       const { data, error, response } = await client.PUT("/comment", {
         params: {},
         body: {
@@ -1241,15 +1655,24 @@ describe("client", () => {
 
   describe("DELETE()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useTestRequestHandler({
+        baseUrl,
+        method: "delete",
+        path: "/anyMethod",
+      });
       await client.DELETE("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("DELETE");
+      expect(getRequest().method).toBe("DELETE");
     });
 
     it("returns empty object on 204", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 204, body: "" });
+      const client = createClient<paths>({ baseUrl });
+      useTestRequestHandler({
+        baseUrl,
+        method: "delete",
+        path: "/blogposts/:post_id",
+        handler: () => new HttpResponse(null, { status: 204 }),
+      });
       const { data, error } = await client.DELETE("/blogposts/{post_id}", {
         params: {
           path: { post_id: "123" },
@@ -1264,12 +1687,20 @@ describe("client", () => {
     });
 
     it("returns empty object on Content-Length: 0", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({
-        headers: { "Content-Length": "0" },
-        status: 200,
-        body: "",
+      const client = createClient<paths>({ baseUrl });
+      useTestRequestHandler({
+        baseUrl,
+        method: "delete",
+        path: `/blogposts/:post_id`,
+        handler: () =>
+          new HttpResponse(null, {
+            status: 200,
+            headers: {
+              "Content-Length": "0",
+            },
+          }),
       });
+
       const { data, error } = await client.DELETE("/blogposts/{post_id}", {
         params: {
           path: { post_id: "123" },
@@ -1286,37 +1717,57 @@ describe("client", () => {
 
   describe("OPTIONS()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useTestRequestHandler({
+        baseUrl,
+        method: "options",
+        path: `/anyMethod`,
+      });
       await client.OPTIONS("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("OPTIONS");
+      expect(getRequest().method).toBe("OPTIONS");
     });
   });
 
   describe("HEAD()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useTestRequestHandler({
+        baseUrl,
+        method: "head",
+        path: "/anyMethod",
+      });
       await client.HEAD("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("HEAD");
+      expect(getRequest().method).toBe("HEAD");
     });
   });
 
   describe("PATCH()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useTestRequestHandler({
+        baseUrl,
+        method: "patch",
+        path: "/anyMethod",
+      });
       await client.PATCH("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("PATCH");
+      expect(getRequest().method).toBe("PATCH");
     });
   });
 
+  // NOTE: msw does not support TRACE method
+  // so instead we verify that calling TRACE() with msw throws an error
   describe("TRACE()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
-      await client.TRACE("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("TRACE");
+      const client = createClient<paths>({ baseUrl });
+      useTestRequestHandler({
+        baseUrl,
+        method: "all", // note: msw doesn’t support TRACE method
+        path: "/anyMethod",
+      });
+
+      await expect(
+        async () => await client.TRACE("/anyMethod"),
+      ).rejects.toThrowError("'TRACE' HTTP method is unsupported");
     });
   });
 });
@@ -1334,25 +1785,27 @@ describe("examples", () => {
       },
     };
 
-    const client = createClient<paths>();
+    const client = createClient<paths>({ baseUrl });
     client.use(authMiddleware);
 
+    const { getRequest } = useTestRequestHandler({
+      baseUrl,
+      method: "get",
+      path: "/blogposts/:post_id",
+    });
+
     // assert initial call is unauthenticated
-    mockFetchOnce({ status: 200, body: "{}" });
     await client.GET("/blogposts/{post_id}", {
       params: { path: { post_id: "1234" } },
     });
-    expect(
-      fetchMocker.mock.calls[0][0].headers.get("authorization"),
-    ).toBeNull();
+    expect(getRequest().headers.get("authorization")).toBeNull();
 
     // assert after setting token, client is authenticated
     accessToken = "real_token";
-    mockFetchOnce({ status: 200, body: "{}" });
     await client.GET("/blogposts/{post_id}", {
       params: { path: { post_id: "1234" } },
     });
-    expect(fetchMocker.mock.calls[1][0].headers.get("authorization")).toBe(
+    expect(getRequest().headers.get("authorization")).toBe(
       `Bearer ${accessToken}`,
     );
   });

--- a/packages/openapi-fetch/test/v7-beta.test.ts
+++ b/packages/openapi-fetch/test/v7-beta.test.ts
@@ -1303,6 +1303,47 @@ describe("client", () => {
         const result = await reader.read();
         expect(result.value!.length).toBe(2);
       });
+
+      it("use the selected content", async () => {
+        const client = createClient<paths, "application/ld+json">({ baseUrl });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/multiple-response-content",
+          status: 200,
+          headers: { "Content-Type": "application/ld+json" },
+          body: {
+            "@id": "some-resource-identifier",
+            email: "foo@bar.fr",
+            name: null,
+          },
+        });
+
+        const { data } = await client.GET("/multiple-response-content", {
+          headers: {
+            Accept: "application/ld+json",
+          },
+        });
+
+        data satisfies
+          | {
+              "@id": string;
+              email: string;
+              name?: string;
+            }
+          | undefined;
+
+        if (!data) {
+          throw new Error(`Missing response`);
+        }
+
+        expect(data).toEqual({
+          "@id": "some-resource-identifier",
+          email: "foo@bar.fr",
+          name: null,
+        });
+      });
     });
   });
 

--- a/packages/openapi-fetch/test/v7-beta.test.ts
+++ b/packages/openapi-fetch/test/v7-beta.test.ts
@@ -1,10 +1,15 @@
-// @ts-expect-error
-import createFetchMock from "vitest-fetch-mock";
+import { HttpResponse, type StrictResponse } from "msw";
 import createClient, {
   type Middleware,
   type MiddlewareRequest,
   type QuerySerializerOptions,
 } from "../src/index.js";
+import {
+  server,
+  baseUrl,
+  useMockRequestHandler,
+  toAbsoluteURL,
+} from "./fixtures/mock-server.js";
 import type { paths } from "./fixtures/v7-beta.js";
 
 // Note
@@ -12,28 +17,19 @@ import type { paths } from "./fixtures/v7-beta.js";
 // This tests upcoming compatibility until openapi-typescript@7 is stable and the two tests
 // merged together.
 
-const fetchMocker = createFetchMock(vi);
-
 beforeAll(() => {
-  fetchMocker.enableMocks();
+  server.listen({
+    onUnhandledRequest: (request) => {
+      throw new Error(
+        `No request handler found for ${request.method} ${request.url}`,
+      );
+    },
+  });
 });
-afterEach(() => {
-  fetchMocker.resetMocks();
-});
 
-interface MockResponse {
-  headers?: Record<string, string>;
-  status: number;
-  body: any;
-}
+afterEach(() => server.resetHandlers());
 
-function mockFetch(res: MockResponse) {
-  fetchMocker.mockResponse(() => res);
-}
-
-function mockFetchOnce(res: MockResponse) {
-  fetchMocker.mockResponseOnce(() => res);
-}
+afterAll(() => server.close());
 
 describe("client", () => {
   it("generates all proper functions", () => {
@@ -51,13 +47,19 @@ describe("client", () => {
 
   describe("TypeScript checks", () => {
     it("marks data or error as undefined, but never both", async () => {
-      const client = createClient<paths>();
+      const client = createClient<paths>({
+        baseUrl,
+      });
 
       // data
-      mockFetchOnce({
+      useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/string-array",
         status: 200,
-        body: JSON.stringify(["one", "two", "three"]),
+        body: ["one", "two", "three"],
       });
+
       const dataRes = await client.GET("/string-array");
 
       // … is initially possibly undefined
@@ -76,9 +78,12 @@ describe("client", () => {
       }
 
       // error
-      mockFetchOnce({
+      useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/string-array",
         status: 500,
-        body: JSON.stringify({ code: 500, message: "Something went wrong" }),
+        body: { code: 500, message: "Something went wrong" },
       });
       const errorRes = await client.GET("/string-array");
 
@@ -102,21 +107,24 @@ describe("client", () => {
       describe("path", () => {
         it("typechecks", async () => {
           const client = createClient<paths>({
-            baseUrl: "https://myapi.com/v1",
+            baseUrl,
           });
-          mockFetch({ status: 200, body: JSON.stringify({ message: "OK" }) });
+
+          useMockRequestHandler({
+            baseUrl,
+            method: "get",
+            path: "/blogposts/:post_id",
+            status: 200,
+            body: { message: "OK" },
+          });
 
           // expect error on missing 'params'
-          await client.GET("/blogposts/{post_id}", {
-            // @ts-expect-error
-            TODO: "this should be an error",
-          });
+          // @ts-expect-error
+          await client.GET("/blogposts/{post_id}");
 
           // expect error on empty params
-          await client.GET("/blogposts/{post_id}", {
-            // @ts-expect-error
-            params: { TODO: "this should be an error" },
-          });
+          // @ts-expect-error
+          await client.GET("/blogposts/{post_id}", { params: {} });
 
           // expect error on empty params.path
           // @ts-expect-error
@@ -128,23 +136,43 @@ describe("client", () => {
             params: { path: { post_id: 1234 } },
           });
 
+          // expect error on unknown property in 'params'
+          await client.GET("/blogposts/{post_id}", {
+            // @ts-expect-error
+            TODO: "this should be an error",
+          });
+
           // (no error)
+          let calledPostId = "";
+          useMockRequestHandler<{ post_id: string }>({
+            baseUrl,
+            method: "get",
+            path: `/blogposts/:post_id`,
+            handler: ({ params }) => {
+              calledPostId = params.post_id;
+              return HttpResponse.json({ message: "OK" }, { status: 200 });
+            },
+          });
+
           await client.GET("/blogposts/{post_id}", {
             params: { path: { post_id: "1234" } },
           });
 
           // expect param passed correctly
-          const lastCall =
-            fetchMocker.mock.calls[fetchMocker.mock.calls.length - 1];
-          expect(lastCall[0].url).toBe("https://myapi.com/v1/blogposts/1234");
+          expect(calledPostId).toBe("1234");
         });
 
         it("serializes", async () => {
-          const client = createClient<paths>();
-          mockFetch({
-            status: 200,
-            body: JSON.stringify({ status: "success" }),
+          const client = createClient<paths>({
+            baseUrl,
           });
+
+          const { getRequestUrl } = useMockRequestHandler({
+            baseUrl,
+            method: "get",
+            path: `/path-params/*`,
+          });
+
           await client.GET(
             "/path-params/{simple_primitive}/{simple_obj_flat}/{simple_arr_flat}/{simple_obj_explode*}/{simple_arr_explode*}/{.label_primitive}/{.label_obj_flat}/{.label_arr_flat}/{.label_obj_explode*}/{.label_arr_explode*}/{;matrix_primitive}/{;matrix_obj_flat}/{;matrix_arr_flat}/{;matrix_obj_explode*}/{;matrix_arr_explode*}",
             {
@@ -170,7 +198,7 @@ describe("client", () => {
             },
           );
 
-          expect(fetchMocker.mock.calls[0][0].url).toBe(
+          expect(getRequestUrl().pathname).toBe(
             `/path-params/${[
               // simple
               "simple",
@@ -195,27 +223,51 @@ describe("client", () => {
         });
 
         it("allows UTF-8 characters", async () => {
-          const client = createClient<paths>();
-          mockFetchOnce({ status: 200, body: "{}" });
+          const client = createClient<paths>({ baseUrl });
+          const { getRequestUrl } = useMockRequestHandler({
+            baseUrl,
+            method: "get",
+            path: "/blogposts/*",
+          });
 
           await client.GET("/blogposts/{post_id}", {
             params: { path: { post_id: "post?id = 🥴" } },
           });
 
           // expect post_id to be encoded properly
-          expect(fetchMocker.mock.calls[0][0].url).toBe(
-            `/blogposts/post?id%20=%20🥴`,
+          const url = getRequestUrl();
+          expect(url.searchParams.get("id ")).toBe(" 🥴");
+          expect(url.pathname + url.search).toBe(
+            `/blogposts/post?id%20=%20%F0%9F%A5%B4`,
           );
         });
       });
 
       it("header", async () => {
-        const client = createClient<paths>({ baseUrl: "https://myapi.com/v1" });
-        mockFetch({ status: 200, body: JSON.stringify({ status: "success" }) });
+        const client = createClient<paths>({ baseUrl });
 
-        // expet error on missing header
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/header-params",
+          handler: ({ request }) => {
+            const header = request.headers.get("x-required-header");
+            if (header !== "correct") {
+              return HttpResponse.json(
+                { code: 500, message: "missing correct header" },
+                { status: 500 },
+              ) as StrictResponse<any>;
+            }
+            return HttpResponse.json(
+              { status: header },
+              { status: 200, headers: request.headers },
+            );
+          },
+        });
+
+        // expect error on missing header
         // @ts-expect-error
-        await client.GET("/header-params", { TODO: "this should be an error" });
+        await client.GET("/header-params");
 
         // expect error on incorrect header
         await client.GET("/header-params", {
@@ -230,54 +282,76 @@ describe("client", () => {
         });
 
         // (no error)
-        await client.GET("/header-params", {
+        const response = await client.GET("/header-params", {
           params: { header: { "x-required-header": "correct" } },
         });
 
         // expect param passed correctly
-        const lastCall =
-          fetchMocker.mock.calls[fetchMocker.mock.calls.length - 1][0];
-        expect(lastCall.headers.get("x-required-header")).toBe("correct");
+        expect(response.response.headers.get("x-required-header")).toBe(
+          "correct",
+        );
       });
 
       describe("query", () => {
         describe("querySerializer", () => {
           it("primitives", async () => {
-            const client = createClient<paths>();
-            mockFetchOnce({ status: 200, body: "{}" });
+            const client = createClient<paths>({ baseUrl });
+
+            const { getRequestUrl } = useMockRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/query-params*",
+            });
+
             await client.GET("/query-params", {
               params: {
                 query: { string: "string", number: 0, boolean: false },
               },
             });
 
-            expect(fetchMocker.mock.calls[0][0].url).toBe(
-              "/query-params?string=string&number=0&boolean=false",
+            expect(getRequestUrl().search).toBe(
+              "?string=string&number=0&boolean=false",
             );
           });
 
           it("array params (empty)", async () => {
-            const client = createClient<paths>();
-            mockFetchOnce({ status: 200, body: "{}" });
+            const client = createClient<paths>({ baseUrl });
+
+            const { getRequestUrl } = useMockRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/query-params*",
+            });
+
             await client.GET("/query-params", {
               params: {
                 query: { array: [] },
               },
             });
 
-            expect(fetchMocker.mock.calls[0][0].url).toBe("/query-params");
+            const url = getRequestUrl();
+            expect(url.pathname).toBe("/query-params");
+            expect(url.search).toBe("");
           });
 
           it("empty/null params", async () => {
-            const client = createClient<paths>();
-            mockFetchOnce({ status: 200, body: "{}" });
+            const client = createClient<paths>({ baseUrl });
+
+            const { getRequestUrl } = useMockRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/query-params*",
+            });
+
             await client.GET("/query-params", {
               params: {
                 query: { string: undefined, number: null as any },
               },
             });
 
-            expect(fetchMocker.mock.calls[0][0].url).toBe("/query-params");
+            const url = getRequestUrl();
+            expect(url.pathname).toBe("/query-params");
+            expect(url.search).toBe("");
           });
 
           describe("array", () => {
@@ -332,17 +406,25 @@ describe("client", () => {
               },
             ][])("%s", async (_, { given, want }) => {
               const client = createClient<paths>({
+                baseUrl,
                 querySerializer: { array: given },
               });
-              mockFetch({ status: 200, body: "{}" });
+
+              const { getRequestUrl } = useMockRequestHandler({
+                baseUrl,
+                method: "get",
+                path: "/query-params*",
+              });
+
               await client.GET("/query-params", {
                 params: {
                   query: { array: ["1", "2", "3"], boolean: true },
                 },
               });
 
-              const req = fetchMocker.mock.calls[0][0].url;
-              expect(req.split("?")[1]).toBe(want);
+              const url = getRequestUrl();
+              // skip leading '?'
+              expect(url.search.substring(1)).toBe(want);
             });
           });
 
@@ -384,24 +466,37 @@ describe("client", () => {
               },
             ][])("%s", async (_, { given, want }) => {
               const client = createClient<paths>({
+                baseUrl,
                 querySerializer: { object: given },
               });
-              mockFetch({ status: 200, body: "{}" });
+              const { getRequestUrl } = useMockRequestHandler({
+                baseUrl,
+                method: "get",
+                path: "/query-params*",
+              });
+
               await client.GET("/query-params", {
                 params: {
                   query: { object: { foo: "bar", bar: "baz" }, boolean: true },
                 },
               });
 
-              expect(fetchMocker.mock.calls[0][0].url.split("?")[1]).toBe(want);
+              const url = getRequestUrl();
+              // skip leading '?'
+              expect(url.search.substring(1)).toBe(want);
             });
           });
 
           it("allowReserved", async () => {
             const client = createClient<paths>({
+              baseUrl,
               querySerializer: { allowReserved: true },
             });
-            mockFetch({ status: 200, body: "{}" });
+            const { getRequestUrl } = useMockRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/query-params*",
+            });
             await client.GET("/query-params", {
               params: {
                 query: {
@@ -409,8 +504,12 @@ describe("client", () => {
                 },
               },
             });
-            expect(fetchMocker.mock.calls[0][0].url.split("?")[1]).toBe(
-              "string=bad/character🐶",
+
+            expect(getRequestUrl().search).toBe(
+              "?string=bad/character%F0%9F%90%B6",
+            );
+            expect(getRequestUrl().searchParams.get("string")).toBe(
+              "bad/character🐶",
             );
 
             await client.GET("/query-params", {
@@ -423,17 +522,28 @@ describe("client", () => {
                 allowReserved: false,
               },
             });
-            expect(fetchMocker.mock.calls[1][0].url.split("?")[1]).toBe(
-              "string=bad%2Fcharacter%F0%9F%90%B6",
+
+            expect(getRequestUrl().search).toBe(
+              "?string=bad%2Fcharacter%F0%9F%90%B6",
+            );
+            expect(getRequestUrl().searchParams.get("string")).toBe(
+              "bad/character🐶",
             );
           });
 
           describe("function", () => {
             it("global default", async () => {
               const client = createClient<paths>({
+                baseUrl,
                 querySerializer: (q) => `alpha=${q.version}&beta=${q.format}`,
               });
-              mockFetchOnce({ status: 200, body: "{}" });
+
+              const { getRequestUrl } = useMockRequestHandler({
+                baseUrl,
+                method: "get",
+                path: "/blogposts/:post_id",
+              });
+
               await client.GET("/blogposts/{post_id}", {
                 params: {
                   path: { post_id: "my-post" },
@@ -441,16 +551,24 @@ describe("client", () => {
                 },
               });
 
-              expect(fetchMocker.mock.calls[0][0].url).toBe(
+              const url = getRequestUrl();
+              expect(url.pathname + url.search).toBe(
                 "/blogposts/my-post?alpha=2&beta=json",
               );
             });
 
             it("per-request", async () => {
               const client = createClient<paths>({
+                baseUrl,
                 querySerializer: () => "query",
               });
-              mockFetchOnce({ status: 200, body: "{}" });
+
+              const { getRequestUrl } = useMockRequestHandler({
+                baseUrl,
+                method: "get",
+                path: "/blogposts/:post_id",
+              });
+
               await client.GET("/blogposts/{post_id}", {
                 params: {
                   path: { post_id: "my-post" },
@@ -459,7 +577,8 @@ describe("client", () => {
                 querySerializer: (q) => `alpha=${q.version}&beta=${q.format}`,
               });
 
-              expect(fetchMocker.mock.calls[0][0].url).toBe(
+              const url = getRequestUrl();
+              expect(url.pathname + url.search).toBe(
                 "/blogposts/my-post?alpha=2&beta=json",
               );
             });
@@ -467,18 +586,22 @@ describe("client", () => {
 
           it("ignores leading ? characters", async () => {
             const client = createClient<paths>({
+              baseUrl,
               querySerializer: () => "?query",
             });
-            mockFetchOnce({ status: 200, body: "{}" });
+            const { getRequestUrl } = useMockRequestHandler({
+              baseUrl,
+              method: "get",
+              path: "/blogposts/:post_id",
+            });
             await client.GET("/blogposts/{post_id}", {
               params: {
                 path: { post_id: "my-post" },
                 query: { version: 2, format: "json" },
               },
             });
-            expect(fetchMocker.mock.calls[0][0].url).toBe(
-              "/blogposts/my-post?query",
-            );
+            const url = getRequestUrl();
+            expect(url.pathname + url.search).toBe("/blogposts/my-post?query");
           });
         });
       });
@@ -488,8 +611,13 @@ describe("client", () => {
       // these are pure type tests; no runtime assertions needed
       /* eslint-disable vitest/expect-expect */
       it("requires necessary requestBodies", async () => {
-        const client = createClient<paths>({ baseUrl: "https://myapi.com/v1" });
-        mockFetch({ status: 200, body: JSON.stringify({ message: "OK" }) });
+        const client = createClient<paths>({ baseUrl });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "put",
+          path: "/blogposts",
+        });
 
         // expect error on missing `body`
         // @ts-expect-error
@@ -511,8 +639,14 @@ describe("client", () => {
       });
 
       it("requestBody (inline)", async () => {
-        mockFetch({ status: 201, body: "{}" });
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "put",
+          path: "/blogposts-optional-inline",
+          status: 201,
+        });
 
         // expect error on wrong body type
         await client.PUT("/blogposts-optional-inline", {
@@ -531,8 +665,14 @@ describe("client", () => {
       });
 
       it("requestBody with required: false", async () => {
-        mockFetch({ status: 201, body: "{}" });
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "put",
+          path: "/blogposts-optional",
+          status: 201,
+        });
 
         // assert missing `body` doesn’t raise a TS error
         await client.PUT("/blogposts-optional");
@@ -556,36 +696,45 @@ describe("client", () => {
 
   describe("options", () => {
     it("baseUrl", async () => {
-      let client = createClient<paths>({ baseUrl: "https://myapi.com/v1" });
-      mockFetch({ status: 200, body: JSON.stringify({ message: "OK" }) });
+      let client = createClient<paths>({ baseUrl });
+
+      const { getRequestUrl } = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/self",
+        status: 200,
+        body: { message: "OK" },
+      });
+
       await client.GET("/self");
 
       // assert baseUrl and path mesh as expected
-      expect(fetchMocker.mock.calls[0][0].url).toBe(
-        "https://myapi.com/v1/self",
-      );
+      expect(getRequestUrl().href).toBe(toAbsoluteURL("/self"));
 
-      client = createClient<paths>({ baseUrl: "https://myapi.com/v1/" });
+      client = createClient<paths>({ baseUrl });
       await client.GET("/self");
       // assert trailing '/' was removed
-      expect(fetchMocker.mock.calls[1][0].url).toBe(
-        "https://myapi.com/v1/self",
-      );
+      expect(getRequestUrl().href).toBe(toAbsoluteURL("/self"));
     });
 
     describe("headers", () => {
       it("persist", async () => {
         const headers: HeadersInit = { Authorization: "Bearer secrettoken" };
 
-        const client = createClient<paths>({ headers });
-        mockFetchOnce({
+        const client = createClient<paths>({ headers, baseUrl });
+
+        const { getRequest } = useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
           status: 200,
-          body: JSON.stringify({ email: "user@user.com" }),
+          body: { email: "user@user.com" },
         });
+
         await client.GET("/self");
 
         // assert default headers were passed
-        expect(fetchMocker.mock.calls[0][0].headers).toEqual(
+        expect(getRequest().headers).toEqual(
           new Headers({
             ...headers, // assert new header got passed
             "Content-Type": "application/json", //  probably doesn’t need to get tested, but this was simpler than writing lots of code to ignore these
@@ -595,19 +744,25 @@ describe("client", () => {
 
       it("can be overridden", async () => {
         const client = createClient<paths>({
+          baseUrl,
           headers: { "Cache-Control": "max-age=10000000" },
         });
-        mockFetchOnce({
+
+        const { getRequest } = useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
           status: 200,
-          body: JSON.stringify({ email: "user@user.com" }),
+          body: { email: "user@user.com" },
         });
+
         await client.GET("/self", {
           params: {},
           headers: { "Cache-Control": "no-cache" },
         });
 
         // assert default headers were passed
-        expect(fetchMocker.mock.calls[0][0].headers).toEqual(
+        expect(getRequest().headers).toEqual(
           new Headers({
             "Cache-Control": "no-cache",
             "Content-Type": "application/json",
@@ -617,29 +772,40 @@ describe("client", () => {
 
       it("can be unset", async () => {
         const client = createClient<paths>({
+          baseUrl,
           headers: { "Content-Type": null },
         });
-        mockFetchOnce({
+
+        const { getRequest } = useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
           status: 200,
-          body: JSON.stringify({ email: "user@user.com" }),
+          body: { email: "user@user.com" },
         });
+
         await client.GET("/self", { params: {} });
 
         // assert default headers were passed
-        expect(fetchMocker.mock.calls[0][0].headers).toEqual(new Headers());
+        expect(getRequest().headers).toEqual(new Headers());
       });
 
       it("supports arrays", async () => {
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
 
         const list = ["one", "two", "three"];
 
-        mockFetchOnce({ status: 200, body: "{}" });
+        const { getRequest } = useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: {},
+        });
+
         await client.GET("/self", { headers: { list } });
 
-        expect(fetchMocker.mock.calls[0][0].headers.get("list")).toEqual(
-          list.join(", "),
-        );
+        expect(getRequest().headers.get("list")).toEqual(list.join(", "));
       });
     });
 
@@ -657,16 +823,15 @@ describe("client", () => {
         }
 
         const customFetch = createCustomFetch({ works: true });
-        mockFetchOnce({ status: 200, body: "{}" });
 
-        const client = createClient<paths>({ fetch: customFetch });
+        const client = createClient<paths>({ fetch: customFetch, baseUrl });
         const { data } = await client.GET("/self");
 
         // assert data was returned from custom fetcher
         expect(data).toEqual({ works: true });
 
-        // assert global fetch was never called
-        expect(fetchMocker).not.toHaveBeenCalled();
+        // TODO: do we need to assert nothing was called?
+        // msw should throw an error if there was an unused handler
       });
 
       it("per-request", async () => {
@@ -684,9 +849,7 @@ describe("client", () => {
         const fallbackFetch = createCustomFetch({ fetcher: "fallback" });
         const overrideFetch = createCustomFetch({ fetcher: "override" });
 
-        mockFetchOnce({ status: 200, body: "{}" });
-
-        const client = createClient<paths>({ fetch: fallbackFetch });
+        const client = createClient<paths>({ fetch: fallbackFetch, baseUrl });
 
         // assert override function was called
         const fetch1 = await client.GET("/self", { fetch: overrideFetch });
@@ -696,16 +859,14 @@ describe("client", () => {
         const fetch2 = await client.GET("/self");
         expect(fetch2.data).toEqual({ fetcher: "fallback" });
 
-        // assert global fetch was never called
-        expect(fetchMocker).not.toHaveBeenCalled();
+        // TODO: do we need to assert nothing was called?
+        // msw should throw an error if there was an unused handler
       });
     });
 
     describe("middleware", () => {
       it("can modify request", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
-
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
         client.use({
           async onRequest(req) {
             return new Request("https://foo.bar/api/v1", {
@@ -715,9 +876,18 @@ describe("client", () => {
             });
           },
         });
+
+        const { getRequest } = useMockRequestHandler({
+          baseUrl,
+          method: "options",
+          path: `https://foo.bar/api/v1`,
+          status: 200,
+          body: {},
+        });
+
         await client.GET("/self");
 
-        const req = fetchMocker.mock.calls[0][0];
+        const req = getRequest();
         expect(req.url).toBe("https://foo.bar/api/v1");
         expect(req.method).toBe("OPTIONS");
         expect(req.headers.get("foo")).toBe("bar");
@@ -731,13 +901,17 @@ describe("client", () => {
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-20T00:00:00Z",
         };
-        mockFetchOnce({
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
           status: 200,
-          body: JSON.stringify(rawBody),
+          body: rawBody,
           headers: { foo: "bar" },
         });
 
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
         client.use({
           // convert date string to unix time
           async onResponse(res) {
@@ -748,7 +922,7 @@ describe("client", () => {
             headers.set("middleware", "value");
             return new Response(JSON.stringify(body), {
               ...res,
-              status: 205,
+              status: 201,
               headers,
             });
           },
@@ -762,7 +936,7 @@ describe("client", () => {
         // assert rest of body was preserved
         expect(data?.email).toBe(rawBody.email);
         // assert status changed
-        expect(response.status).toBe(205);
+        expect(response.status).toBe(201);
         // assert server headers were preserved
         expect(response.headers.get("foo")).toBe("bar");
         // assert middleware heaers were added
@@ -770,9 +944,15 @@ describe("client", () => {
       });
 
       it("executes in expected order", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
+        const { getRequest } = useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: {},
+        });
 
-        const client = createClient<paths>();
+        const client = createClient<paths>({ baseUrl });
         // this middleware passes along the “step” header
         // for both requests and responses, but first checks if
         // it received the end result of the previous middleware step
@@ -820,33 +1000,44 @@ describe("client", () => {
         const { response } = await client.GET("/self");
 
         // assert requests ended up on step C (array order)
-        expect(fetchMocker.mock.calls[0][0].headers.get("step")).toBe("C");
+        expect(getRequest().headers.get("step")).toBe("C");
 
         // assert responses ended up on step A (reverse order)
         expect(response.headers.get("step")).toBe("A");
       });
 
       it("receives correct options", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
+        useMockRequestHandler({
+          baseUrl: "https://api.foo.bar/v1/",
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: {},
+        });
 
-        let baseUrl = "";
+        let requestBaseUrl = "";
 
         const client = createClient<paths>({
           baseUrl: "https://api.foo.bar/v1/",
         });
         client.use({
           onRequest(_, options) {
-            baseUrl = options.baseUrl;
+            requestBaseUrl = options.baseUrl;
             return undefined;
           },
         });
 
         await client.GET("/self");
-        expect(baseUrl).toBe("https://api.foo.bar/v1");
+        expect(requestBaseUrl).toBe("https://api.foo.bar/v1");
       });
 
       it("receives OpenAPI options passed in from parent", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
+        useMockRequestHandler({
+          method: "put",
+          path: `https://api.foo.bar/v1/tag*`,
+          status: 200,
+          body: {},
+        });
 
         const pathname = "/tag/{name}";
         const tagData = {
@@ -883,7 +1074,13 @@ describe("client", () => {
       });
 
       it("can be skipped without interrupting request", async () => {
-        mockFetchOnce({ status: 200, body: JSON.stringify({ success: true }) });
+        useMockRequestHandler({
+          baseUrl: "https://api.foo.bar/v1/",
+          method: "get",
+          path: "/blogposts",
+          status: 200,
+          body: { success: true },
+        });
 
         const client = createClient<paths>({
           baseUrl: "https://api.foo.bar/v1/",
@@ -899,7 +1096,13 @@ describe("client", () => {
       });
 
       it("can be ejected", async () => {
-        mockFetchOnce({ status: 200, body: "{}" });
+        useMockRequestHandler({
+          baseUrl: "https://api.foo.bar/v1",
+          method: "get",
+          path: "/blogposts",
+          status: 200,
+          body: { success: true },
+        });
 
         let called = false;
         const errorMiddleware = {
@@ -923,15 +1126,22 @@ describe("client", () => {
 
   describe("requests", () => {
     it("multipart/form-data", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+
+      const { getRequest } = useMockRequestHandler({
+        baseUrl,
+        method: "put",
+        path: "/contact",
+      });
+
+      const reqBody = {
+        name: "John Doe",
+        email: "test@email.email",
+        subject: "Test Message",
+        message: "This is a test message",
+      };
       await client.PUT("/contact", {
-        body: {
-          name: "John Doe",
-          email: "test@email.email",
-          subject: "Test Message",
-          message: "This is a test message",
-        },
+        body: reqBody,
         bodySerializer(body) {
           const fd = new FormData();
           for (const name in body) {
@@ -941,31 +1151,45 @@ describe("client", () => {
         },
       });
 
-      // expect post_id to be encoded properly
-      const req = fetchMocker.mock.calls[0][0];
-      // note: this is FormData, but Node.js doesn’t handle new Request() properly with formData bodies. So this is only in tests.
-      expect(req.body).toBeInstanceOf(Buffer);
-      expect((req.headers as Headers).get("Content-Type")).toBe(
-        "text/plain;charset=UTF-8",
-      );
+      // expect request to contain correct headers and body
+      const req = getRequest();
+      expect(req.body).toBeInstanceOf(ReadableStream);
+      const body = await req.formData();
+      expect(body.get("name")).toBe("John Doe");
+      expect(req.headers.get("Content-Type")).toMatch(/multipart\/form-data;/);
     });
 
-    // Node Requests eat credentials (no cookies), but this works in frontend
-    // TODO: find a way to reliably test this without too much mocking
-    it.skip("respects cookie", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
-      await client.GET("/blogposts", { credentials: "include" });
+    it("respects cookie", async () => {
+      const client = createClient<paths>({ baseUrl });
 
-      const req = fetchMocker.mock.calls[0][0];
-      expect(req.credentials).toBe("include");
+      const { getRequestCookies } = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts",
+      });
+
+      await client.GET("/blogposts", {
+        credentials: "include",
+        headers: {
+          Cookie: "session=1234",
+        },
+      });
+
+      const cookies = getRequestCookies();
+      expect(cookies).toEqual({ session: "1234" });
     });
   });
 
   describe("responses", () => {
     it("returns empty object on 204", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 204, body: "" });
+      const client = createClient<paths>({ baseUrl });
+      useMockRequestHandler({
+        baseUrl,
+        method: "delete",
+        path: "/tag/*",
+        handler: () => new HttpResponse(null, { status: 204 }),
+      });
+
       const { data, error, response } = await client.DELETE("/tag/{name}", {
         params: { path: { name: "New Tag" } },
       });
@@ -980,15 +1204,18 @@ describe("client", () => {
 
     it("treats `default` as an error", async () => {
       const client = createClient<paths>({
+        baseUrl,
         headers: { "Cache-Control": "max-age=10000000" },
       });
-      mockFetchOnce({
+      useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/default-as-error",
         status: 500,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+        body: {
           code: 500,
           message: "An unexpected error occurred",
-        }),
+        },
       });
       const { error } = await client.GET("/default-as-error");
 
@@ -1005,54 +1232,90 @@ describe("client", () => {
 
     describe("parseAs", () => {
       it("text", async () => {
-        const client = createClient<paths>();
-        mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: string } = await client.GET("/anyMethod", {
-          parseAs: "text",
+        const client = createClient<paths>({ baseUrl });
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/anyMethod",
+          body: {},
         });
+        const { data, error } = (await client.GET("/anyMethod", {
+          parseAs: "text",
+        })) satisfies { data?: string };
+        if (error) {
+          throw new Error(`parseAs text: error`);
+        }
         expect(data).toBe("{}");
       });
 
       it("arrayBuffer", async () => {
-        const client = createClient<paths>();
-        mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: ArrayBuffer } = await client.GET(
-          "/anyMethod",
-          {
-            parseAs: "arrayBuffer",
-          },
-        );
-        expect(data instanceof ArrayBuffer).toBe(true);
+        const client = createClient<paths>({ baseUrl });
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/anyMethod",
+          body: {},
+        });
+        const { data, error } = (await client.GET("/anyMethod", {
+          parseAs: "arrayBuffer",
+        })) satisfies { data?: ArrayBuffer };
+        if (error) {
+          throw new Error(`parseAs arrayBuffer: error`);
+        }
+        expect(data.byteLength).toBe(2);
       });
 
       it("blob", async () => {
-        const client = createClient<paths>();
-        mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: Blob } = await client.GET("/anyMethod", {
-          parseAs: "blob",
+        const client = createClient<paths>({ baseUrl });
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/anyMethod",
+          body: {},
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        expect((data as any).constructor.name).toBe("Blob");
+        const { data, error } = (await client.GET("/anyMethod", {
+          parseAs: "blob",
+        })) satisfies { data?: Blob };
+        if (error) {
+          throw new Error(`parseAs blob: error`);
+        }
+
+        expect(data.constructor.name).toBe("Blob");
       });
 
       it("stream", async () => {
-        const client = createClient<paths>();
-        mockFetchOnce({ status: 200, body: "{}" });
-        const { data }: { data?: ReadableStream | null } = await client.GET(
-          "/anyMethod",
-          { parseAs: "stream" },
-        );
-        expect(data instanceof Buffer).toBe(true);
+        const client = createClient<paths>({ baseUrl });
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/anyMethod",
+          body: {},
+        });
+        const { data } = (await client.GET("/anyMethod", {
+          parseAs: "stream",
+        })) satisfies { data?: ReadableStream<Uint8Array> | null };
+        if (!data) {
+          throw new Error(`parseAs stream: error`);
+        }
+
+        expect(data).toBeInstanceOf(ReadableStream);
+        const reader = data.getReader();
+        const result = await reader.read();
+        expect(result.value!.length).toBe(2);
       });
     });
   });
 
   describe("GET()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/anyMethod",
+      });
       await client.GET("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("GET");
+      expect(getRequest().method).toBe("GET");
     });
 
     it("sends correct options, returns success", async () => {
@@ -1061,8 +1324,16 @@ describe("client", () => {
         body: "<p>This is a very good post</p>",
         publish_date: new Date("2023-03-01T12:00:00Z").getTime(),
       };
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: JSON.stringify(mockData) });
+      const client = createClient<paths>({ baseUrl });
+
+      const { getRequestUrl } = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts/:post_id",
+        status: 200,
+        body: mockData,
+      });
+      // mockFetchOnce({ status: 200, body: JSON.stringify(mockData) });
       const { data, error, response } = await client.GET(
         "/blogposts/{post_id}",
         {
@@ -1071,7 +1342,7 @@ describe("client", () => {
       );
 
       // assert correct URL was called
-      expect(fetchMocker.mock.calls[0][0].url).toBe("/blogposts/my-post");
+      expect(getRequestUrl().pathname).toBe("/blogposts/my-post");
 
       // assert correct data was returned
       expect(data).toEqual(mockData);
@@ -1083,8 +1354,16 @@ describe("client", () => {
 
     it("sends correct options, returns error", async () => {
       const mockError = { code: 404, message: "Post not found" };
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 404, body: JSON.stringify(mockError) });
+      const client = createClient<paths>({ baseUrl });
+
+      const { getRequest } = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts/:post_id",
+        status: 404,
+        body: mockError,
+      });
+
       const { data, error, response } = await client.GET(
         "/blogposts/{post_id}",
         {
@@ -1093,10 +1372,10 @@ describe("client", () => {
       );
 
       // assert correct URL was called
-      expect(fetchMocker.mock.calls[0][0].url).toBe("/blogposts/my-post");
+      expect(getRequest().url).toBe(baseUrl + "/blogposts/my-post");
 
       // assert correct method was called
-      expect(fetchMocker.mock.calls[0][0].method).toBe("GET");
+      expect(getRequest().method).toBe("GET");
 
       // assert correct error was returned
       expect(error).toEqual(mockError);
@@ -1108,8 +1387,16 @@ describe("client", () => {
 
     // note: this was a previous bug in the type inference
     it("handles array-type responses", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "[]" });
+      const client = createClient<paths>({ baseUrl });
+
+      useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts",
+        status: 200,
+        body: [],
+      });
+
       const { data } = await client.GET("/blogposts", { params: {} });
       if (!data) {
         throw new Error("data empty");
@@ -1120,8 +1407,16 @@ describe("client", () => {
     });
 
     it("handles literal 2XX and 4XX codes", async () => {
-      const client = createClient<paths>();
-      mockFetch({ status: 201, body: '{"status": "success"}' });
+      const client = createClient<paths>({ baseUrl });
+
+      useMockRequestHandler({
+        baseUrl,
+        method: "put",
+        path: "/media",
+        status: 201,
+        body: { status: "success" },
+      });
+
       const { data, error } = await client.PUT("/media", {
         body: { media: "base64", name: "myImage" },
       });
@@ -1137,8 +1432,16 @@ describe("client", () => {
     });
 
     it("gracefully handles invalid JSON for errors", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 401, body: "Unauthorized" });
+      const client = createClient<paths>({ baseUrl });
+
+      useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/blogposts",
+        status: 401,
+        body: "Unauthorized",
+      });
+
       const { data, error } = await client.GET("/blogposts");
 
       expect(data).toBeUndefined();
@@ -1148,16 +1451,28 @@ describe("client", () => {
 
   describe("POST()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useMockRequestHandler({
+        baseUrl,
+        method: "post",
+        path: "/anyMethod",
+      });
       await client.POST("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("POST");
+      expect(getRequest().method).toBe("POST");
     });
 
     it("sends correct options, returns success", async () => {
       const mockData = { status: "success" };
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 201, body: JSON.stringify(mockData) });
+
+      const client = createClient<paths>({ baseUrl });
+      const { getRequestUrl } = useMockRequestHandler({
+        baseUrl,
+        method: "put",
+        path: "/blogposts",
+        status: 201,
+        body: mockData,
+      });
+
       const { data, error, response } = await client.PUT("/blogposts", {
         body: {
           title: "New Post",
@@ -1167,7 +1482,7 @@ describe("client", () => {
       });
 
       // assert correct URL was called
-      expect(fetchMocker.mock.calls[0][0].url).toBe("/blogposts");
+      expect(getRequestUrl().pathname).toBe("/blogposts");
 
       // assert correct data was returned
       expect(data).toEqual(mockData);
@@ -1179,8 +1494,15 @@ describe("client", () => {
 
     it("supports sepecifying utf-8 encoding", async () => {
       const mockData = { message: "My reply" };
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 201, body: JSON.stringify(mockData) });
+      const client = createClient<paths>({ baseUrl });
+      useMockRequestHandler({
+        baseUrl,
+        method: "put",
+        path: "/comment",
+        status: 201,
+        body: mockData,
+      });
+
       const { data, error, response } = await client.PUT("/comment", {
         params: {},
         body: {
@@ -1200,15 +1522,24 @@ describe("client", () => {
 
   describe("DELETE()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useMockRequestHandler({
+        baseUrl,
+        method: "delete",
+        path: "/anyMethod",
+      });
       await client.DELETE("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("DELETE");
+      expect(getRequest().method).toBe("DELETE");
     });
 
     it("returns empty object on 204", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 204, body: "" });
+      const client = createClient<paths>({ baseUrl });
+      useMockRequestHandler({
+        baseUrl,
+        method: "delete",
+        path: "/blogposts/:post_id",
+        handler: () => new HttpResponse(null, { status: 204 }),
+      });
       const { data, error } = await client.DELETE("/blogposts/{post_id}", {
         params: {
           path: { post_id: "123" },
@@ -1223,12 +1554,20 @@ describe("client", () => {
     });
 
     it("returns empty object on Content-Length: 0", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({
-        headers: { "Content-Length": "0" },
-        status: 200,
-        body: "",
+      const client = createClient<paths>({ baseUrl });
+      useMockRequestHandler({
+        baseUrl,
+        method: "delete",
+        path: `/blogposts/:post_id`,
+        handler: () =>
+          new HttpResponse(null, {
+            status: 200,
+            headers: {
+              "Content-Length": "0",
+            },
+          }),
       });
+
       const { data, error } = await client.DELETE("/blogposts/{post_id}", {
         params: {
           path: { post_id: "123" },
@@ -1245,37 +1584,57 @@ describe("client", () => {
 
   describe("OPTIONS()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useMockRequestHandler({
+        baseUrl,
+        method: "options",
+        path: `/anyMethod`,
+      });
       await client.OPTIONS("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("OPTIONS");
+      expect(getRequest().method).toBe("OPTIONS");
     });
   });
 
   describe("HEAD()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useMockRequestHandler({
+        baseUrl,
+        method: "head",
+        path: "/anyMethod",
+      });
       await client.HEAD("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("HEAD");
+      expect(getRequest().method).toBe("HEAD");
     });
   });
 
   describe("PATCH()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
+      const client = createClient<paths>({ baseUrl });
+      const { getRequest } = useMockRequestHandler({
+        baseUrl,
+        method: "patch",
+        path: "/anyMethod",
+      });
       await client.PATCH("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("PATCH");
+      expect(getRequest().method).toBe("PATCH");
     });
   });
 
+  // NOTE: msw does not support TRACE method
+  // so instead we verify that calling TRACE() with msw throws an error
   describe("TRACE()", () => {
     it("sends the correct method", async () => {
-      const client = createClient<paths>();
-      mockFetchOnce({ status: 200, body: "{}" });
-      await client.TRACE("/anyMethod");
-      expect(fetchMocker.mock.calls[0][0].method).toBe("TRACE");
+      const client = createClient<paths>({ baseUrl });
+      useMockRequestHandler({
+        baseUrl,
+        method: "all", // note: msw doesn’t support TRACE method
+        path: "/anyMethod",
+      });
+
+      await expect(
+        async () => await client.TRACE("/anyMethod"),
+      ).rejects.toThrowError("'TRACE' HTTP method is unsupported");
     });
   });
 });
@@ -1293,25 +1652,27 @@ describe("examples", () => {
       },
     };
 
-    const client = createClient<paths>();
+    const client = createClient<paths>({ baseUrl });
     client.use(authMiddleware);
 
+    const { getRequest } = useMockRequestHandler({
+      baseUrl,
+      method: "get",
+      path: "/blogposts/:post_id",
+    });
+
     // assert initial call is unauthenticated
-    mockFetchOnce({ status: 200, body: "{}" });
     await client.GET("/blogposts/{post_id}", {
       params: { path: { post_id: "1234" } },
     });
-    expect(
-      fetchMocker.mock.calls[0][0].headers.get("authorization"),
-    ).toBeNull();
+    expect(getRequest().headers.get("authorization")).toBeNull();
 
     // assert after setting token, client is authenticated
     accessToken = "real_token";
-    mockFetchOnce({ status: 200, body: "{}" });
     await client.GET("/blogposts/{post_id}", {
       params: { path: { post_id: "1234" } },
     });
-    expect(fetchMocker.mock.calls[1][0].headers.get("authorization")).toBe(
+    expect(getRequest().headers.get("authorization")).toBe(
       `Bearer ${accessToken}`,
     );
   });

--- a/packages/openapi-fetch/test/v7-beta.test.ts
+++ b/packages/openapi-fetch/test/v7-beta.test.ts
@@ -1333,7 +1333,6 @@ describe("client", () => {
         status: 200,
         body: mockData,
       });
-      // mockFetchOnce({ status: 200, body: JSON.stringify(mockData) });
       const { data, error, response } = await client.GET(
         "/blogposts/{post_id}",
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,10 +89,7 @@ importers:
         version: 5.3.3
       vitest:
         specifier: ^1.3.1
-        version: 1.3.1(@types/node@20.11.24)(supports-color@9.4.0)
-      vitest-fetch-mock:
-        specifier: ^0.2.2
-        version: 0.2.2(vitest@1.3.1)
+        version: 1.3.1
 
   packages/openapi-fetch/examples/nextjs:
     dependencies:
@@ -3061,14 +3058,6 @@ packages:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
     dev: true
 
-  /cross-fetch@3.1.8:
-    resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
   /cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
     dependencies:
@@ -3133,6 +3122,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+    dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
     dev: true
 
   /debug@4.3.4(supports-color@9.4.0):
@@ -5970,7 +5971,7 @@ packages:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 2.1.2
@@ -6373,6 +6374,27 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /vite-node@1.3.1:
+    resolution: {integrity: sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.1.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-node@1.3.1(@types/node@20.11.24)(supports-color@9.4.0):
     resolution: {integrity: sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -6396,6 +6418,41 @@ packages:
 
   /vite@5.1.4:
     resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.19.12
+      postcss: 8.4.35
+      rollup: 4.12.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vite@5.1.5:
+    resolution: {integrity: sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -6531,16 +6588,59 @@ packages:
       - universal-cookie
     dev: true
 
-  /vitest-fetch-mock@0.2.2(vitest@1.3.1):
-    resolution: {integrity: sha512-XmH6QgTSjCWrqXoPREIdbj40T7i1xnGmAsTAgfckoO75W1IEHKR8hcPCQ7SO16RsdW1t85oUm6pcQRLeBgjVYQ==}
-    engines: {node: '>=14.14.0'}
+  /vitest@1.3.1:
+    resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
     peerDependencies:
-      vitest: '>=0.16.0'
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.3.1
+      '@vitest/ui': 1.3.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
     dependencies:
-      cross-fetch: 3.1.8
-      vitest: 1.3.1(@types/node@20.11.24)(supports-color@9.4.0)
+      '@vitest/expect': 1.3.1
+      '@vitest/runner': 1.3.1
+      '@vitest/snapshot': 1.3.1
+      '@vitest/spy': 1.3.1
+      '@vitest/utils': 1.3.1
+      acorn-walk: 8.3.2
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.8
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.0.0
+      tinybench: 2.6.0
+      tinypool: 0.8.2
+      vite: 5.1.5
+      vite-node: 1.3.1
+      why-is-node-running: 2.2.2
     transitivePeerDependencies:
-      - encoding
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vitest@1.3.1(@types/node@20.11.24)(supports-color@9.4.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       esbuild:
         specifier: ^0.20.0
         version: 0.20.0
+      msw:
+        specifier: ^2.2.3
+        version: 2.2.3(typescript@5.3.3)
       openapi-typescript:
         specifier: ^6.7.4
         version: 6.7.4
@@ -454,6 +457,18 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+    dev: true
+
+  /@bundled-es-modules/cookie@2.0.0:
+    resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
+    dependencies:
+      cookie: 0.5.0
+    dev: true
+
+  /@bundled-es-modules/statuses@1.0.1:
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+    dependencies:
+      statuses: 2.0.1
     dev: true
 
   /@changesets/apply-release-plan@7.0.0:
@@ -1384,6 +1399,39 @@ packages:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
     dev: true
 
+  /@inquirer/confirm@3.0.2:
+    resolution: {integrity: sha512-eEhoJXten380e2t2yahRRMz1LqB4gKknl5//38k1KvKXhBcV+lFfkIPmr6nFivpIwtOwkaRjGcHz67wBmi3h6Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/core': 7.0.2
+      '@inquirer/type': 1.2.0
+    dev: true
+
+  /@inquirer/core@7.0.2:
+    resolution: {integrity: sha512-yya2GLO8lIi+yGytrOQ6unbrRGi8JiC+lWtlIsCUsDgMcCdO75vOuqGIUKXvfBkeZLOzs4WcSioXvpBzo0B0+Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/type': 1.2.0
+      '@types/mute-stream': 0.0.4
+      '@types/node': 20.11.25
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      figures: 3.2.0
+      mute-stream: 1.0.0
+      run-async: 3.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+    dev: true
+
+  /@inquirer/type@1.2.0:
+    resolution: {integrity: sha512-/vvkUkYhrjbm+RolU7V1aUFDydZVKNKqKHR5TsE+j5DXgXFwrsOPcoGUJ02K0O7q7O53CU2DOTMYCHeGZ25WHA==}
+    engines: {node: '>=18'}
+    dev: true
+
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1443,6 +1491,23 @@ packages:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+    dev: true
+
+  /@mswjs/cookies@1.1.0:
+    resolution: {integrity: sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@mswjs/interceptors@0.25.16:
+    resolution: {integrity: sha512-8QC8JyKztvoGAdPgyZy49c9vSHHAZjHagwl4RY9E8carULk8ym3iTaiawrT1YoLF/qb449h48f71XDPgkUSOUg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      strict-event-emitter: 0.5.1
     dev: true
 
   /@next/env@14.1.0:
@@ -1549,6 +1614,21 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
+    dev: true
+
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
     dev: true
 
   /@pkgr/core@0.1.1:
@@ -1961,12 +2041,24 @@ packages:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
     dev: true
 
+  /@types/mute-stream@0.0.4:
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+    dependencies:
+      '@types/node': 20.11.24
+    dev: true
+
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
   /@types/node@20.11.24:
     resolution: {integrity: sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
+  /@types/node@20.11.25:
+    resolution: {integrity: sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -2009,8 +2101,16 @@ packages:
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
     dev: true
 
+  /@types/statuses@2.0.5:
+    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+    dev: true
+
   /@types/web-bluetooth@0.0.20:
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
+    dev: true
+
+  /@types/wrap-ansi@3.0.0:
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@7.1.1(@typescript-eslint/parser@7.1.1)(eslint@8.57.0)(typescript@5.3.3):
@@ -2506,6 +2606,13 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  /ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.21.3
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2849,6 +2956,16 @@ packages:
       escape-string-regexp: 5.0.0
     dev: true
 
+  /cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+    dev: true
+
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: false
@@ -2928,6 +3045,11 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
+
+  /cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
     dev: true
 
   /cookie@0.6.0:
@@ -3728,6 +3850,13 @@ packages:
       reusify: 1.0.4
     dev: true
 
+  /figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+    dependencies:
+      escape-string-regexp: 1.0.5
+    dev: true
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4005,6 +4134,11 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /graphql@16.8.1:
+    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
+
   /handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -4077,6 +4211,10 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
+    dev: true
+
+  /headers-polyfill@4.0.2:
+    resolution: {integrity: sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==}
     dev: true
 
   /hexoid@1.0.0:
@@ -4254,6 +4392,10 @@ packages:
   /is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
     dev: true
 
   /is-number-object@1.0.7:
@@ -4740,6 +4882,42 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
+  /msw@2.2.3(typescript@5.3.3):
+    resolution: {integrity: sha512-84CoNCkcJ/EvY8Tv0tD/6HKVd4S5HyGowHjM5W12K8Wgryp4fikqS7IaTOceyQgP5dNedxo2icTLDXo7dkpxCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.7.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/statuses': 1.0.1
+      '@inquirer/confirm': 3.0.2
+      '@mswjs/cookies': 1.1.0
+      '@mswjs/interceptors': 0.25.16
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.5
+      chalk: 4.1.2
+      graphql: 16.8.1
+      headers-polyfill: 4.0.2
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      path-to-regexp: 6.2.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.12.0
+      typescript: 5.3.3
+      yargs: 17.7.2
+    dev: true
+
+  /mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
+
   /nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4943,6 +5121,10 @@ packages:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: true
 
+  /outvariant@1.4.2:
+    resolution: {integrity: sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==}
+    dev: true
+
   /p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -5041,6 +5223,10 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /path-to-regexp@6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
     dev: true
 
   /path-type@4.0.0:
@@ -5389,6 +5575,11 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /run-async@3.0.0:
+    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -5656,6 +5847,11 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
+  /statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
   /std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
     dev: true
@@ -5670,6 +5866,10 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
     dev: false
+
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+    dev: true
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -6044,6 +6244,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+    dev: true
+
   /type-fest@0.6.0:
     resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
     engines: {node: '>=8'}
@@ -6057,6 +6262,11 @@ packages:
   /type-fest@1.4.0:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@4.12.0:
+    resolution: {integrity: sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==}
+    engines: {node: '>=16'}
     dev: true
 
   /typed-array-buffer@1.0.2:


### PR DESCRIPTION
## Changes

- replaces vitest-fetch-mock with msw in openapi-fetch tests (including `index.bench.js`)

Fixes #1581

## How to Review

I've made an effort to keep the existing tests as close as possible to their original implementation, with the exception of replacing `mockFetch*` with the equivalent `msw` test handler. Due to `msw`, it's necessary to pass `baseUrl` around to ensure we're using the correct request URLs. Therefore, it has been provided for each `createClient` and equivalent test handler.

Please note, the current usage of `msw` contradicts `msw`'s best practices ([Avoid Request Assertions](https://mswjs.io/docs/best-practices/avoid-request-assertions)). However, given the nature of this library, I believe this approach is acceptable in this context. In most of these tests, we aim to validate that the client is indeed calling the expected handler with the expected request parameters.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
