### PR TITLE
Allow to select the response content type

### DIFF
--- a/.changeset/few-tomatoes-try.md
+++ b/.changeset/few-tomatoes-try.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Allow to select the response content type

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -111,10 +111,10 @@ export type RequestBodyOption<T> =
 export type FetchOptions<T> = RequestOptions<T> &
   Omit<RequestInit, "body" | "headers">;
 
-export type FetchResponse<T, O> =
+export type FetchResponse<T, O, Media extends MediaType> =
   | {
       data: ParseAsResponse<
-        FilterKeys<SuccessResponse<ResponseObjectMap<T>>, MediaType>,
+        FilterKeys<SuccessResponse<ResponseObjectMap<T>>, Media>,
         O
       >;
       error?: never;
@@ -122,7 +122,7 @@ export type FetchResponse<T, O> =
     }
   | {
       data?: never;
-      error: FilterKeys<ErrorResponse<ResponseObjectMap<T>>, MediaType>;
+      error: FilterKeys<ErrorResponse<ResponseObjectMap<T>>, Media>;
       response: Response;
     };
 
@@ -180,33 +180,37 @@ export type MaybeOptionalInit<P extends PathMethods, M extends keyof P> =
 export type ClientMethod<
   Paths extends Record<string, PathMethods>,
   M extends HttpMethod,
+  Media extends MediaType,
 > = <
   P extends PathsWithMethod<Paths, M>,
   I extends MaybeOptionalInit<Paths[P], M>,
 >(
   url: P,
   ...init: I
-) => Promise<FetchResponse<Paths[P][M], I[0]>>;
+) => Promise<FetchResponse<Paths[P][M], I[0], Media>>;
 
-export default function createClient<Paths extends {}>(
+export default function createClient<
+  Paths extends {},
+  Media extends MediaType = MediaType,
+>(
   clientOptions?: ClientOptions,
 ): {
   /** Call a GET endpoint */
-  GET: ClientMethod<Paths, "get">;
+  GET: ClientMethod<Paths, "get", Media>;
   /** Call a PUT endpoint */
-  PUT: ClientMethod<Paths, "put">;
+  PUT: ClientMethod<Paths, "put", Media>;
   /** Call a POST endpoint */
-  POST: ClientMethod<Paths, "post">;
+  POST: ClientMethod<Paths, "post", Media>;
   /** Call a DELETE endpoint */
-  DELETE: ClientMethod<Paths, "delete">;
+  DELETE: ClientMethod<Paths, "delete", Media>;
   /** Call a OPTIONS endpoint */
-  OPTIONS: ClientMethod<Paths, "options">;
+  OPTIONS: ClientMethod<Paths, "options", Media>;
   /** Call a HEAD endpoint */
-  HEAD: ClientMethod<Paths, "head">;
+  HEAD: ClientMethod<Paths, "head", Media>;
   /** Call a PATCH endpoint */
-  PATCH: ClientMethod<Paths, "patch">;
+  PATCH: ClientMethod<Paths, "patch", Media>;
   /** Call a TRACE endpoint */
-  TRACE: ClientMethod<Paths, "trace">;
+  TRACE: ClientMethod<Paths, "trace", Media>;
   /** Register middleware */
   use(...middleware: Middleware[]): void;
   /** Unregister middleware */

--- a/packages/openapi-fetch/test/fixtures/api.d.ts
+++ b/packages/openapi-fetch/test/fixtures/api.d.ts
@@ -3,7 +3,6 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
   "/comment": {
     put: {
@@ -396,6 +395,13 @@ export interface paths {
       };
     };
   };
+  "/multiple-response-content": {
+    get: {
+      responses: {
+        200: components["responses"]["MultipleResponse"];
+      };
+    };
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -492,6 +498,20 @@ export interface components {
         "application/json": components["schemas"]["User"];
       };
     };
+    MultipleResponse: {
+      content: {
+        "application/json": {
+          id: string;
+          email: string;
+          name?: string;
+        };
+        "application/ld+json": {
+          "@id": string;
+          email: string;
+          name?: string;
+        };
+      };
+    };
   };
   parameters: never;
   requestBodies: {
@@ -557,7 +577,6 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
-
   getHeaderParams: {
     parameters: {
       header: {

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1049,6 +1049,42 @@ describe("client", () => {
 
         expect(data.byteLength).toBe(2);
       });
+
+      it("use the selected content", async () => {
+        const client = createClient<paths, "application/ld+json">();
+        mockFetchOnce({
+          status: 200,
+          headers: { "Content-Type": "application/ld+json" },
+          body: JSON.stringify({
+            "@id": "some-resource-identifier",
+            email: "foo@bar.fr",
+            name: null,
+          }),
+        });
+        const { data } = await client.GET("/multiple-response-content", {
+          headers: {
+            Accept: "application/ld+json",
+          },
+        });
+
+        data satisfies
+          | {
+              "@id": string;
+              email: string;
+              name?: string;
+            }
+          | undefined;
+
+        if (!data) {
+          throw new Error(`Missing response`);
+        }
+
+        expect(data).toEqual({
+          "@id": "some-resource-identifier",
+          email: "foo@bar.fr",
+          name: null,
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Changes

This is a simple change that for now only allow to select the content type of the response. Inspired by the @NikolaStojicic patch. 

Fix https://github.com/drwpow/openapi-typescript/issues/1291 


This solution is not perfect but allow to fix the issue. Clearly a more robust solution could be to infer the `MediaType` by reading the `Accept` header. If multiple content and the `Accept` header not set, the lib could fallback to an `unknown` data.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
