### PR TITLE
Handle negative numeric enum values

### DIFF
--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -265,16 +265,23 @@ export function tsEnumMember(
   if (!JS_PROPERTY_INDEX_RE.test(name)) {
     if (Number(name[0]) >= 0) {
       name = `Value${name}`.replace(".", "_"); // don't forged decimals;
+    } else if (name[0] === "-") {
+      name = `ValueMinus${name.slice(1)}`;
     }
     name = name.replace(JS_PROPERTY_INDEX_INVALID_CHARS_RE, "_");
   }
 
   let member;
   if (typeof value === "number") {
-    member = ts.factory.createEnumMember(
-      name,
-      ts.factory.createNumericLiteral(value),
-    );
+    const literal =
+      value < 0
+        ? ts.factory.createPrefixUnaryExpression(
+            ts.SyntaxKind.MinusToken,
+            ts.factory.createNumericLiteral(Math.abs(value)),
+          )
+        : ts.factory.createNumericLiteral(value);
+
+    member = ts.factory.createEnumMember(name, literal);
   } else {
     member = ts.factory.createEnumMember(
       name,

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -122,11 +122,12 @@ describe("tsEnum", () => {
   });
 
   test("number members", () => {
-    expect(astToString(tsEnum(".Error.code.", [100, 101, 102])).trim())
+    expect(astToString(tsEnum(".Error.code.", [100, 101, 102, -100])).trim())
       .toBe(`enum ErrorCode {
     Value100 = 100,
     Value101 = 101,
-    Value102 = 102
+    Value102 = 102,
+    ValueMinus100 = -100
 }`);
   });
 


### PR DESCRIPTION
## Changes

- append `ValueMinus` string to enum member names starting with a `-`, if a name is not explicitly provided
  - example:
  ```ts
  enum ErrorCode {
    ValueMinus1 = -1,
    Value1 = 1
  }
  ```

- create negative numeric enum member values using `ts.factory.createPrefixUnaryExpression()`
  - this is forced by: https://github.com/microsoft/TypeScript/pull/56570 (present in Typescript 5.4)


### Previous behavior:

When there is no name explicitly provided for them, numeric enum member names are constructed by prefixing the number with a `Value` string
The code did not take negative numbers into account, which resulted in enum members like:
```ts
enum ErrorCode {
  _1 = -1,
  Value1 = 1
}
```

### Context

Negative numeric enum members are not unusual in C# projects, and when combined with tools autogenerating OpenAPI schemas (i.e. Swashbuckle, NSwag), it is easy to hit the issue mentioned above.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
