### PR TITLE
Do not add readonly on enum with the immutable option,

### DIFF
--- a/.changeset/tender-ducks-own.md
+++ b/.changeset/tender-ducks-own.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Do not add readonly on Typescript enum when the --immutable option is used.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist
 node_modules
 
 packages/openapi-typescript/test/fixtures/cli-outputs/out
+
+# IntelliJ IDEA settings folder
+/.idea

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -230,7 +230,7 @@ export function tsEnum(
   name: string,
   members: (string | number)[],
   metadata?: { name?: string; description?: string }[],
-  options?: { readonly?: boolean; export?: boolean },
+  options?: { export?: boolean },
 ) {
   let enumName = name.replace(JS_ENUM_INVALID_CHARS_RE, (c) => {
     const last = c[c.length - 1];
@@ -244,10 +244,7 @@ export function tsEnum(
   enumName = `${enumName[0].toUpperCase()}${enumName.substring(1)}`;
   return ts.factory.createEnumDeclaration(
     /* modifiers */ options
-      ? tsModifiers({
-          readonly: options.readonly ?? false,
-          export: options.export ?? false,
-        })
+      ? tsModifiers({ export: options.export ?? false })
       : undefined,
     /* name      */ enumName,
     /* members   */ members.map((value, i) =>

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -126,7 +126,11 @@ export function transformSchemaObjectWithComposition(
         enumName,
         schemaObject.enum as (string | number)[],
         metadata,
-        { export: true, readonly: options.ctx.immutable },
+
+        {
+          export: true,
+          // readonly: TS enum do not support the readonly modifier
+        },
       );
       options.ctx.injectFooter.push(enumType);
       return ts.factory.createTypeReferenceNode(enumType.name);

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -98,6 +98,20 @@ describe("tsEnum", () => {
 }`);
   });
 
+  test("with setting: export", () => {
+    expect(
+      astToString(
+        tsEnum("-my-color-", ["green", "red", "blue"], undefined, {
+          export: true,
+        }),
+      ).trim(),
+    ).toBe(`export enum MyColor {
+    green = "green",
+    red = "red",
+    blue = "blue"
+}`);
+  });
+
   test("name from path", () => {
     expect(
       astToString(


### PR DESCRIPTION
## Changes

Readonly modifier is not applicable to Typescript enum.
This PR makes sure the readonly modifiers is not applied on enum when the --immutable option is used.

Related discussion
https://github.com/drwpow/openapi-typescript/issues/1368#issuecomment-2025501642

## How to Review

A question would be how to test this ? As I did not found a way to test with the global --immutable option.
Alternatively I added a test for the 'export' modifier that is used in the code.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary) (not necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript) (=> no changes)
