### PR TITLE
Fix type discrimination for non-overlapping content types

### DIFF
--- a/.changeset/gold-worms-wave.md
+++ b/.changeset/gold-worms-wave.md
@@ -1,0 +1,6 @@
+---
+"openapi-typescript-helpers": patch
+"openapi-fetch": patch
+---
+
+Fix data/error discrimination when there are empty-body errors

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -115,7 +115,11 @@ export type FetchOptions<T> = RequestOptions<T> &
 export type FetchResponse<T, O, Media extends MediaType> =
   | {
       data: ParseAsResponse<
-      GetValueWithDefault<SuccessResponse<ResponseObjectMap<T>>, Media, Record<string, never>>,
+        GetValueWithDefault<
+          SuccessResponse<ResponseObjectMap<T>>,
+          Media,
+          Record<string, never>
+        >,
         O
       >;
       error?: never;
@@ -123,7 +127,11 @@ export type FetchResponse<T, O, Media extends MediaType> =
     }
   | {
       data?: never;
-      error: GetValueWithDefault<ErrorResponse<ResponseObjectMap<T>>, Media, Record<string, never>>;
+      error: GetValueWithDefault<
+        ErrorResponse<ResponseObjectMap<T>>,
+        Media,
+        Record<string, never>
+      >;
       response: Response;
     };
 

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -1,6 +1,7 @@
 import type {
   ErrorResponse,
   FilterKeys,
+  GetValueWithDefault,
   HasRequiredKeys,
   HttpMethod,
   MediaType,
@@ -114,7 +115,7 @@ export type FetchOptions<T> = RequestOptions<T> &
 export type FetchResponse<T, O, Media extends MediaType> =
   | {
       data: ParseAsResponse<
-        FilterKeys<SuccessResponse<ResponseObjectMap<T>>, Media>,
+      GetValueWithDefault<SuccessResponse<ResponseObjectMap<T>>, Media, Record<string, never>>,
         O
       >;
       error?: never;
@@ -122,7 +123,7 @@ export type FetchResponse<T, O, Media extends MediaType> =
     }
   | {
       data?: never;
-      error: FilterKeys<ErrorResponse<ResponseObjectMap<T>>, Media>;
+      error: GetValueWithDefault<ErrorResponse<ResponseObjectMap<T>>, Media, Record<string, never>>;
       response: Response;
     };
 

--- a/packages/openapi-fetch/test/fixtures/api.d.ts
+++ b/packages/openapi-fetch/test/fixtures/api.d.ts
@@ -24,6 +24,7 @@ export interface paths {
       };
       responses: {
         200: components["responses"]["AllPostsGet"];
+        401: components["responses"]["EmptyError"];
         500: components["responses"]["Error"];
       };
     };
@@ -455,6 +456,10 @@ export interface components {
     Contact: {
       content: {
         "text/html": string;
+      };
+    };
+    EmptyError: {
+      content: {
       };
     };
     Error: {

--- a/packages/openapi-fetch/test/fixtures/api.yaml
+++ b/packages/openapi-fetch/test/fixtures/api.yaml
@@ -28,6 +28,8 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/AllPostsGet'
+        401:
+          $ref: '#/components/responses/EmptyError'
         500:
           $ref: '#/components/responses/Error'
     put:
@@ -623,6 +625,8 @@ components:
         text/html:
           schema:
             type: string
+    EmptyError:
+      content: {}
     Error:
       content:
         application/json:

--- a/packages/openapi-fetch/test/index.test-d.ts
+++ b/packages/openapi-fetch/test/index.test-d.ts
@@ -1,0 +1,66 @@
+import { test, expectTypeOf } from "vitest";
+
+import createClient from "../src/index.js";
+
+interface paths {
+  "/": {
+    get: operations["GetObjects"];
+  };
+}
+
+interface operations {
+  GetObjects: {
+    parameters: {};
+    responses: {
+      200: components["responses"]["MultipleObjectsResponse"];
+      401: components["responses"]["Unauthorized"];
+      422: components["responses"]["GenericError"];
+    };
+  };
+}
+
+interface components {
+  schemas: {
+    Object: {
+      id: string;
+      name: string;
+    };
+    GenericErrorModel: {
+      errors: {
+        body: string[];
+      };
+    };
+  };
+  responses: {
+    MultipleObjectsResponse: {
+      content: {
+        "application/json": {
+          objects: components["schemas"]["Object"][];
+        };
+      };
+    };
+    /** @description Unauthorized */
+    Unauthorized: {
+      content: {};
+    };
+    /** @description Unexpected error */
+    GenericError: {
+      content: {
+        "application/json": components["schemas"]["GenericErrorModel"];
+      };
+    };
+  };
+}
+
+const { GET } = createClient<paths>();
+
+test("the error type works properly", async () => {
+  const value = await GET("/");
+
+  if (value.data) {
+    expectTypeOf(value.data).toEqualTypeOf({ objects: [{ id: "", name: "" }] });
+  } else {
+    expectTypeOf(value.data).toBeUndefined();
+    expectTypeOf(value.error).toEqualTypeOf({ errors: [""] });
+  }
+});

--- a/packages/openapi-fetch/test/index.test-d.ts
+++ b/packages/openapi-fetch/test/index.test-d.ts
@@ -11,6 +11,8 @@ interface Blogpost {
   publish_date?: number | undefined;
 }
 
+// This is a type test that will not be executed
+// eslint-disable-next-line vitest/expect-expect
 test("the error type works properly", async () => {
   const value = await GET("/blogposts");
 
@@ -18,7 +20,11 @@ test("the error type works properly", async () => {
     expectTypeOf(value.data).toEqualTypeOf<Array<Blogpost>>();
   } else {
     expectTypeOf(value.data).toBeUndefined();
-    expectTypeOf(value.error).extract<{ code: number }>().toEqualTypeOf<{ code: number; message: string }>();
-    expectTypeOf(value.error).exclude<{ code: number }>().toEqualTypeOf<Record<string, never>>();
+    expectTypeOf(value.error)
+      .extract<{ code: number }>()
+      .toEqualTypeOf<{ code: number; message: string }>();
+    expectTypeOf(value.error)
+      .exclude<{ code: number }>()
+      .toEqualTypeOf<Record<string, never>>();
   }
 });

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -88,6 +88,9 @@ export type RequestBodyJSON<PathMethod> = JSONLike<
 
 /** Find first match of multiple keys */
 export type FilterKeys<Obj, Matchers> = Obj[keyof Obj & Matchers];
+/** Get the type of a value of an input object with a given key. If the key is not found, return a default type. Works with unions of objects too. */
+export type GetValueWithDefault<Obj, KeyPattern, Default> = Obj extends any ? (FilterKeys<Obj, KeyPattern> extends never ? Default : FilterKeys<Obj, KeyPattern>) : never;
+
 /** Return any `[string]/[string]` media type (important because openapi-fetch allows any content response, not just JSON-like) */
 export type MediaType = `${string}/${string}`;
 /** Return any media type containing "json" (works for "application/json", "application/vnd.api+json", "application/vnd.oai.openapi+json") */


### PR DESCRIPTION
## Changes

Fixes #1609 

## How to Review

I've added a new kind of test — Vitest type test, to verify the correctness of this solution.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
