### PR TITLE
Add propertiesRequired option to Node.js API and CLI #1570

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,7 @@ The following flags are supported in the CLI:
 | `--alphabetize`           |       | `false`  | Sort types alphabetically                                                                                           |
 | `--array-length`          |       | `false`  | Generate tuples using array `minItems` / `maxItems`                                                                 |
 | `--default-non-nullable`  |       | `false`  | Treat schema objects with default values as non-nullable                                                            |
+| `--properties-required`   |       | `false`  | Treat schema objects without `required` as having all properties required.                                          |
 | `--empty-objects-unknown` |       | `false`  | Allow arbitrary properties for schema objects with no specified properties, and no specified `additionalProperties` |
 | `--enum`                  |       | `false`  | Generate true [TS enums](https://www.typescriptlang.org/docs/handbook/enums.html) rather than string unions.        |
 | `--exclude-deprecated`    |       | `false`  | Exclude deprecated fields from types                                                                                |

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -29,6 +29,7 @@ Options
   --additional-properties    Treat schema objects as if \`additionalProperties: true\` is set
   --empty-objects-unknown    Generate \`unknown\` instead of \`Record<string, never>\` for empty objects
   --default-non-nullable     Set to \`false\` to ignore default values when generating non-nullable types
+  --properties-required      Treat schema objects as if \`required\` is set to all properties by default
   --array-length             Generate tuples using array minItems / maxItems
   --path-params-as-types     Convert paths to template literal types
   --alphabetize              Sort object keys alphabetically
@@ -69,6 +70,7 @@ const flags = parser(args, {
     "arrayLength",
     "contentNever",
     "defaultNonNullable",
+    "propertiesRequired",
     "emptyObjectsUnknown",
     "enum",
     "excludeDeprecated",
@@ -96,6 +98,7 @@ async function generateSchema(schema, { redoc, silent = false }) {
       alphabetize: flags.alphabetize,
       arrayLength: flags.arrayLength,
       contentNever: flags.contentNever,
+      propertiesRequired: flags.propertiesRequired,
       defaultNonNullable: flags.defaultNonNullable,
       emptyObjectsUnknown: flags.emptyObjectsUnknown,
       enum: flags.enum,

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -71,6 +71,7 @@ export default async function openapiTS(
     additionalProperties: options.additionalProperties ?? false,
     alphabetize: options.alphabetize ?? false,
     defaultNonNullable: options.defaultNonNullable ?? true,
+    propertiesRequired: options.propertiesRequired ?? false,
     discriminators: scanDiscriminators(schema, options),
     emptyObjectsUnknown: options.emptyObjectsUnknown ?? false,
     enum: options.enum ?? false,

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -479,6 +479,7 @@ function transformSchemaObjectCore(
         }
         let optional =
           schemaObject.required?.includes(k) ||
+          (schemaObject.required === undefined && options.ctx.propertiesRequired) ||
           ("default" in v &&
             options.ctx.defaultNonNullable &&
             !options.path?.includes("parameters")) // parameters can’t be required, even with defaults

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -647,6 +647,8 @@ export interface OpenAPITSOptions {
   cwd?: PathLike;
   /** Should schema objects with a default value not be considered optional? */
   defaultNonNullable?: boolean;
+  /** Treat all objects as if they have \`required\` set to all properties by default (default: false) */
+  propertiesRequired?: boolean;
   /** Manually transform certain Schema Objects with a custom TypeScript type */
   transform?: (
     schemaObject: SchemaObject,
@@ -686,6 +688,7 @@ export interface GlobalContext {
   additionalProperties: boolean;
   alphabetize: boolean;
   defaultNonNullable: boolean;
+  propertiesRequired: boolean;
   discriminators: {
     objects: Record<string, DiscriminatorObject>;
     refsHandled: string[];

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -10,6 +10,7 @@ export const DEFAULT_CTX: GlobalContext = {
   alphabetize: false,
   arrayLength: false,
   defaultNonNullable: true,
+  propertiesRequired: false,
   discriminators: {
     objects: {},
     refsHandled: [],

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -29,6 +29,27 @@ describe("transformSchemaObject > object", () => {
       },
     ],
     [
+      "basic > options.propertiesRequired: tre",
+      {
+        given: {
+          type: "object",
+          properties: {
+            required: { type: "boolean" },
+            optional: { type: "boolean" },
+          },
+          required: ["required"],
+        },
+        want: `{
+    required: boolean;
+    optional?: boolean;
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, propertiesRequired: true },
+        },
+      },
+    ],
+    [
       "empty",
       {
         given: { type: "object" },
@@ -275,6 +296,19 @@ describe("transformSchemaObject > object", () => {
         options: {
           ...DEFAULT_OPTIONS,
           ctx: { ...DEFAULT_OPTIONS.ctx, additionalProperties: true },
+        },
+      },
+    ],
+    [
+      "options > propertiesRequired: true",
+      {
+        given: { type: "object", properties: { string: { type: "string" } } },
+        want: `{
+    string: string;
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, propertiesRequired: true },
         },
       },
     ],


### PR DESCRIPTION
## Changes

Closes #1570.

Adds a `propertiesRequired` option to the Node.js API and global context and exposes this as `--properties-required` in the CLI.

### More nuanced description

Schema objects are allowed to have a `required` property that is set to an array of keys in `properties` that are considered required. The default for `required` is `[]` as specified by https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-6.5.3 and adopted by openapi via https://swagger.io/specification/#data-types. This may not be the intent of many API designers, so the `propertiesRequired` option changes the interpretation of section 6.5.3 from

> Omitting this keyword has the same behavior as an empty array.

to the following:

> Omitting this keyword has the same behavior as specifying an array containing the names of all properties in the instance.

## How to Review

Pay special attention to the naming of the option and cli flag. I'm open to any better names you can come up with 😄 My approach was inspired by the behaviour of `additionalProperties` and `defaultNonNullable`.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
