### PR TITLE
fix types on passing request options

### DIFF
--- a/.changeset/orange-coins-pull.md
+++ b/.changeset/orange-coins-pull.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+fix request option types don't showing optional props correctly

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -158,16 +158,16 @@ type PathMethods = Partial<Record<HttpMethod, {}>>;
 export type MaybeOptionalInit<P extends PathMethods, M extends keyof P> = HasRequiredKeys<
   FetchOptions<FilterKeys<P, M>>
 > extends never
-  ? [(FetchOptions<FilterKeys<P, M>> | undefined)?]
-  : [FetchOptions<FilterKeys<P, M>>];
+  ? FetchOptions<FilterKeys<P, M>> | undefined
+  : FetchOptions<FilterKeys<P, M>>;
 
 export type ClientMethod<Paths extends Record<string, PathMethods>, M extends HttpMethod, Media extends MediaType> = <
   P extends PathsWithMethod<Paths, M>,
   I extends MaybeOptionalInit<Paths[P], M>,
 >(
   url: P,
-  ...init: I
-) => Promise<FetchResponse<Paths[P][M], I[0], Media>>;
+  ...init: HasRequiredKeys<I> extends never ? [I?] : [I]
+) => Promise<FetchResponse<Paths[P][M], I, Media>>;
 
 export default function createClient<Paths extends {}, Media extends MediaType = MediaType>(
   clientOptions?: ClientOptions,


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._
This pull request fixs request options type when there is required keys and when set them the type the typing for the other optional properties dissapear, below is a example the current behavior vs the new behavior with this pull request

[current implementation](https://streamable.com/7a5b00)
[new implementation](https://streamable.com/c8l6bx)

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
