### PR TITLE
bump openapi-typescript-fetch version

### DIFF
--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -71,7 +71,7 @@
     "msw": "^2.2.14",
     "openapi-typescript": "^6.7.5",
     "openapi-typescript-codegen": "^0.25.0",
-    "openapi-typescript-fetch": "^1.1.3",
+    "openapi-typescript-fetch": "^2.0.0",
     "superagent": "^9.0.0",
     "typescript": "^5.4.5",
     "vitest": "^1.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^0.25.0
         version: 0.25.0
       openapi-typescript-fetch:
-        specifier: ^1.1.3
-        version: 1.1.3
+        specifier: ^2.0.0
+        version: 2.0.0
       superagent:
         specifier: ^9.0.0
         version: 9.0.0
@@ -2275,8 +2275,8 @@ packages:
     resolution: {integrity: sha512-nN/TnIcGbP58qYgwEEy5FrAAjePcYgfMaCe3tsmYyTgI3v4RR9v8os14L+LEWDvV50+CmqiyTzRkKKtJeb6Ybg==}
     hasBin: true
 
-  openapi-typescript-fetch@1.1.3:
-    resolution: {integrity: sha512-smLZPck4OkKMNExcw8jMgrMOGgVGx2N/s6DbKL2ftNl77g5HfoGpZGFy79RBzU/EkaO0OZpwBnslfdBfh7ZcWg==}
+  openapi-typescript-fetch@2.0.0:
+    resolution: {integrity: sha512-9YkzVKIx9RVIET0lFjJOuf15VjI9AUsoNByBk5WYM66xVlAKDNy8anj08Ci3zZA+HgTwdDamYz5FCVYt2VoHkA==}
     engines: {node: '>= 12.0.0', npm: '>= 7.0.0'}
 
   openapi-typescript@6.7.5:
@@ -5363,7 +5363,7 @@ snapshots:
       handlebars: 4.7.8
       json-schema-ref-parser: 9.0.9
 
-  openapi-typescript-fetch@1.1.3: {}
+  openapi-typescript-fetch@2.0.0: {}
 
   openapi-typescript@6.7.5:
     dependencies:


### PR DESCRIPTION
## Changes

Bumps the version of openapi-typescript-fetch for benchmark

## How to Review

No code changes, all tests should pass

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
