### PR TITLE
Fix SecurityRequirementsObject to allow partial security schemes

### DIFF
--- a/.changeset/gorgeous-people-smile.md
+++ b/.changeset/gorgeous-people-smile.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fixed issue with security not allowing partial requirements

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -617,7 +617,7 @@ export interface OAuthFlowObject extends Extensable {
  * Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a security scheme declared in the Security Schemes under the Components Object.
  */
 export type SecurityRequirementObject = {
-  [P in keyof ComponentsObject["securitySchemes"]]?: string[]
+  [P in keyof ComponentsObject["securitySchemes"]]?: string[];
 };
 
 export interface OpenAPITSOptions {

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -616,7 +616,9 @@ export interface OAuthFlowObject extends Extensable {
  * [4.8.30] Security Requirements Object
  * Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a security scheme declared in the Security Schemes under the Components Object.
  */
-export type SecurityRequirementObject = Record<keyof ComponentsObject["securitySchemes"], string[]>;
+export type SecurityRequirementObject = {
+  [P in keyof ComponentsObject["securitySchemes"]]?: string[]
+};
 
 export interface OpenAPITSOptions {
   /** Treat all objects as if they have `additionalProperties: true` by default (default: false) */


### PR DESCRIPTION
## Changes

Fixes issue #1647 

## How to Review

See issue

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
