### PR TITLE
add custom properties to request object

### DIFF
--- a/.changeset/red-pants-cover.md
+++ b/.changeset/red-pants-cover.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Let request object have custom properties

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -166,7 +166,7 @@ export type ClientMethod<Paths extends Record<string, PathMethods>, M extends Ht
   I extends MaybeOptionalInit<Paths[P], M>,
 >(
   url: P,
-  ...init: HasRequiredKeys<I> extends never ? [I?] : [I]
+  ...init: HasRequiredKeys<I> extends never ? [(I & { [key: string]: unknown })?] : [I]
 ) => Promise<FetchResponse<Paths[P][M], I, Media>>;
 
 export default function createClient<Paths extends {}, Media extends MediaType = MediaType>(

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -6,6 +6,22 @@ const DEFAULT_HEADERS = {
 const PATH_PARAM_RE = /\{[^{}]+\}/g;
 
 /**
+ * Add custom parameters to Request object
+ */
+class CustomRequest extends Request {
+  constructor(input, init) {
+    super(input, init);
+
+    // add custom parameters
+    for (const key in init) {
+      if (!this[key]) {
+        this[key] = init[key];
+      }
+    }
+  }
+}
+
+/**
  * Create an openapi-fetch client.
  * @type {import("./index.js").default}
  */
@@ -67,7 +83,7 @@ export default function createClient(clientOptions) {
     if (requestInit.body instanceof FormData) {
       requestInit.headers.delete("Content-Type");
     }
-    let request = new Request(createFinalURL(url, { baseUrl, params, querySerializer }), requestInit);
+    let request = new CustomRequest(createFinalURL(url, { baseUrl, params, querySerializer }), requestInit);
     // middleware (request)
     const mergedOptions = {
       baseUrl,

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1,10 +1,5 @@
-import { HttpResponse, type StrictRequest, type StrictResponse } from "msw";
-import createClient, {
-  type BodyType,
-  type Middleware,
-  type MiddlewareRequest,
-  type QuerySerializerOptions,
-} from "../src/index.js";
+import { HttpResponse, type StrictResponse } from "msw";
+import createClient, { type Middleware, type MiddlewareRequest, type QuerySerializerOptions } from "../src/index.js";
 import type { paths } from "./fixtures/api.js";
 import { server, baseUrl, useMockRequestHandler, toAbsoluteURL } from "./fixtures/mock-server.js";
 


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._
This pull request lets request object attach custom properties like `next` prop on nextjs environment.

![image](https://github.com/drwpow/openapi-typescript/assets/45021001/2779083b-9911-4ddd-9e9b-89c7ddb734e8)
![image](https://github.com/drwpow/openapi-typescript/assets/45021001/4ea89350-102f-4bc9-8ab6-abb5ae8d537e)

## How to Review
It should works
_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
