### PR TITLE
fix: enums containing negative numbers

### DIFF
--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -294,7 +294,14 @@ export function tsLiteral(value: unknown): ts.TypeNode {
     return ts.factory.createIdentifier(JSON.stringify(value)) as unknown as ts.TypeNode;
   }
   if (typeof value === "number") {
-    return ts.factory.createLiteralTypeNode(ts.factory.createNumericLiteral(value));
+    const literal =
+      value < 0
+        ? ts.factory.createPrefixUnaryExpression(
+            ts.SyntaxKind.MinusToken,
+            ts.factory.createNumericLiteral(Math.abs(value)),
+          )
+        : ts.factory.createNumericLiteral(value);
+    return ts.factory.createLiteralTypeNode(literal);
   }
   if (typeof value === "boolean") {
     return value === true ? TRUE : FALSE;

--- a/packages/openapi-typescript/test/transform/schema-object/number.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/number.test.ts
@@ -21,8 +21,8 @@ describe("transformSchemaObject > number", () => {
     [
       "enum",
       {
-        given: { type: "number", enum: [50, 100, 200] },
-        want: "50 | 100 | 200",
+        given: { type: "number", enum: [-50, 50, 100, 200] },
+        want: "-50 | 50 | 100 | 200",
         // options: DEFAULT_OPTIONS,
       },
     ],


### PR DESCRIPTION
## Changes

This change fixes an error when a negative number appeared in an enum.

## How to Review

Run the unit tests with and without the change. The `src` change was basically copied from the `tsEnumMember` function.

## Checklist

- [X] Unit tests updated
- [X] `docs/` updated (if necessary)
- [X] `pnpm run update:examples` run (only applicable for openapi-typescript)
