### PR TITLE
fix: only add custom properties that aren't in the request object

### DIFF
--- a/.changeset/wet-apples-hide.md
+++ b/.changeset/wet-apples-hide.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fixes issue where native properties were not excluded from custom properties in the CustomRequest class

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -14,7 +14,7 @@ class CustomRequest extends Request {
 
     // add custom parameters
     for (const key in init) {
-      if (!this[key]) {
+      if (!(key in this)) {
         this[key] = init[key];
       }
     }


### PR DESCRIPTION
## Changes

Closes #1666

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
