### PR TITLE
Update docs for new `default-non-nullable` default value in 7.x

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -108,11 +108,11 @@ The following flags are supported in the CLI:
 | `--additional-properties`          |       | `false`  | Allow arbitrary properties for all schema objects without `additionalProperties: false`                             |
 | `--alphabetize`                    |       | `false`  | Sort types alphabetically                                                                                           |
 | `--array-length`                   |       | `false`  | Generate tuples using array `minItems` / `maxItems`                                                                 |
-| `--default-non-nullable`           |       | `false`  | Treat schema objects with default values as non-nullable                                                            |
+| `--default-non-nullable`           |       | `true`   | Treat schema objects with default values as non-nullable (with the exception of parameters)                         |
 | `--properties-required-by-default` |       | `false`  | Treat schema objects without `required` as having all properties required.                                          |
 | `--empty-objects-unknown`          |       | `false`  | Allow arbitrary properties for schema objects with no specified properties, and no specified `additionalProperties` |
 | `--enum`                           |       | `false`  | Generate true [TS enums](https://www.typescriptlang.org/docs/handbook/enums.html) rather than string unions.        |
-| `--enum-values`                    |       | `false`  | Export enum values as arrays.                                                                                      |
+| `--enum-values`                    |       | `false`  | Export enum values as arrays.                                                                                       |
 | `--exclude-deprecated`             |       | `false`  | Exclude deprecated fields from types                                                                                |
 | `--export-type`                    | `-t`  | `false`  | Export `type` instead of `interface`                                                                                |
 | `--immutable`                      |       | `false`  | Generates immutable types (readonly properties and readonly array)                                                  |


### PR DESCRIPTION
## Changes

Document new default as mentioned in the [migration guide](https://github.com/drwpow/openapi-typescript/blob/main/docs/migration-guide.md#defaultnonnullable-true-by-default)

## How to Review

Verify against actual default value

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
