### PR TITLE
Expose original request on Middleware.onResponse

### DIFF
--- a/docs/openapi-fetch/api.md
+++ b/docs/openapi-fetch/api.md
@@ -206,16 +206,17 @@ And it expects either:
 ### onResponse
 
 ```ts
-onResponse(res, options) {
+onResponse(res, options, req) {
   // …
 }
 ```
 
-`onResponse()` also takes 2 params:
+`onResponse()` also takes 3 params:
 | Name | Type | Description |
 | :-------- | :-----------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `req` | `MiddlewareRequest` | A standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). |
+| `req` | `Response` | A standard [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response). |
 | `options` | `MergedOptions` | Combination of [createClient](/openapi-fetch/api#create-client) options + [fetch overrides](/openapi-fetch/api#fetch-options) |
+| `req` | `MiddlewareRequest` | A standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) with `schemaPath` (OpenAPI pathname) and `params` ([params](/openapi-fetch/api#fetch-options) object) |
 
 And it expects either:
 

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -144,7 +144,11 @@ export function onRequest(
   req: MiddlewareRequest,
   options: MergedOptions,
 ): Request | undefined | Promise<Request | undefined>;
-export function onResponse(res: Response, options: MergedOptions): Response | undefined | Promise<Response | undefined>;
+export function onResponse(
+  res: Response,
+  options: MergedOptions,
+  req: MiddlewareRequest,
+): Response | undefined | Promise<Response | undefined>;
 
 export interface Middleware {
   onRequest?: typeof onRequest;

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -114,7 +114,9 @@ export default function createClient(clientOptions) {
     for (let i = middlewares.length - 1; i >= 0; i--) {
       const m = middlewares[i];
       if (m && typeof m === "object" && typeof m.onResponse === "function") {
-        const result = await m.onResponse(response, mergedOptions);
+        request.schemaPath = url; // (re)attach original URL
+        request.params = params; // (re)attach params
+        const result = await m.onResponse(response, mergedOptions, request);
         if (result) {
           if (!(result instanceof Response)) {
             throw new Error("Middleware must return new Response() when modifying the response");

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1013,6 +1013,29 @@ describe("client", () => {
         expect(requestBaseUrl).toBe("https://api.foo.bar/v1");
       });
 
+      it("receives the original request", async () => {
+        useMockRequestHandler({
+          baseUrl: "https://api.foo.bar/v1/",
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: {},
+        });
+
+        const client = createClient<paths>({
+          baseUrl: "https://api.foo.bar/v1/",
+        });
+        client.use({
+          onResponse(res, options, req) {
+            expect(req).toBeInstanceOf(Request);
+
+            return undefined;
+          },
+        });
+
+        await client.GET("/self");
+      });
+
       it("receives OpenAPI options passed in from parent", async () => {
         useMockRequestHandler({
           method: "put",


### PR DESCRIPTION
## Changes

Add the `req` as thrid params of the onResponse middleware. Its useful to create log on the on response (the `Response` did not contains some information of the original request)

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary) (will be done if 
