### PR TITLE
Fix prefixItems / minItems / maxItems tuple generation (#2053)

### DIFF
--- a/.changeset/clean-phones-deliver.md
+++ b/.changeset/clean-phones-deliver.md
@@ -1,0 +1,10 @@
+---
+"openapi-typescript": minor
+---
+
+Extract types generation for Array-type schemas to `transformArraySchemaObject` method.
+Generate correct number of union members for `minItems` * `maxItems` unions.
+Generate readonly tuple members for `minItems` & `maxItems` unions.
+Generate readonly spread member for `prefixItems` tuple.
+Preserve `prefixItems` type members in `minItems` & `maxItems` tuples.
+Generate spread member for `prefixItems` tuple with no `minItems` / `maxItems` constraints.

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -34,6 +34,10 @@ Options
   --root-types-no-schema-prefix (optional)
                              Do not add "Schema" prefix to types at the root level (should only be used with --root-types)
   --make-paths-enum          Generate ApiPaths enum for all paths
+
+Experimental features
+  --experimental-spread-array-members
+                             Array schemas with prefixItems spread remaining items
 `;
 
 const OUTPUT_FILE = "FILE";
@@ -77,6 +81,7 @@ const flags = parser(args, {
     "dedupeEnums",
     "check",
     "excludeDeprecated",
+    "experimentalArraySpreadMembers",
     "exportType",
     "help",
     "immutable",
@@ -133,7 +138,6 @@ async function generateSchema(schema, { redocly, silent = false }) {
       additionalProperties: flags.additionalProperties,
       alphabetize: flags.alphabetize,
       arrayLength: flags.arrayLength,
-      contentNever: flags.contentNever,
       propertiesRequiredByDefault: flags.propertiesRequiredByDefault,
       defaultNonNullable: flags.defaultNonNullable,
       emptyObjectsUnknown: flags.emptyObjectsUnknown,
@@ -142,6 +146,7 @@ async function generateSchema(schema, { redocly, silent = false }) {
       dedupeEnums: flags.dedupeEnums,
       excludeDeprecated: flags.excludeDeprecated,
       exportType: flags.exportType,
+      experimentalArraySpreadMembers: flags.experimentalArraySpreadMembers,
       immutable: flags.immutable,
       pathParamsAsTypes: flags.pathParamsAsTypes,
       rootTypes: flags.rootTypes,

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -68,6 +68,7 @@
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
+    "@total-typescript/ts-reset": "^0.6.1",
     "@types/degit": "^2.8.6",
     "@types/js-yaml": "^4.0.9",
     "degit": "^2.8.4",

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -77,6 +77,7 @@ export default async function openapiTS(
     enumValues: options.enumValues ?? false,
     dedupeEnums: options.dedupeEnums ?? false,
     excludeDeprecated: options.excludeDeprecated ?? false,
+    experimentalArraySpreadMembers: options.experimentalArraySpreadMembers ?? false,
     exportType: options.exportType ?? false,
     immutable: options.immutable ?? false,
     rootTypes: options.rootTypes ?? false,

--- a/packages/openapi-typescript/src/reset.ts
+++ b/packages/openapi-typescript/src/reset.ts
@@ -1,0 +1,2 @@
+// Do not add any other lines of code to this file!
+import "@total-typescript/ts-reset";

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -647,6 +647,8 @@ export interface OpenAPITSOptions {
   version?: number;
   /** (optional) Export type instead of interface */
   exportType?: boolean;
+  /** (optional) Experimental: Array schemas with prefixItems spread members */
+  experimentalArraySpreadMembers?: boolean;
   /** Export true TypeScript enums instead of unions */
   enum?: boolean;
   /** Export union values as arrays */
@@ -690,6 +692,7 @@ export interface GlobalContext {
   enumValues: boolean;
   dedupeEnums: boolean;
   excludeDeprecated: boolean;
+  experimentalArraySpreadMembers: boolean;
   exportType: boolean;
   immutable: boolean;
   injectFooter: ts.Node[];

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -15,6 +15,7 @@ export const DEFAULT_CTX: GlobalContext = {
   emptyObjectsUnknown: false,
   enum: false,
   enumValues: false,
+  experimentalArraySpreadMembers: false,
   dedupeEnums: false,
   excludeDeprecated: false,
   exportType: false,

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -15,11 +15,10 @@ describe("transformSchemaObject > array", () => {
       {
         given: { type: "array", items: { type: "string" } },
         want: "string[]",
-        // options: DEFAULT_OPTIONS,
       },
     ],
     [
-      "tuple > tuple items",
+      "tuple > tuple items (deprecated)",
       {
         given: {
           type: "array",
@@ -31,7 +30,21 @@ describe("transformSchemaObject > array", () => {
     string,
     number
 ]`,
-        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "tuple > prefixItems, items false",
+      {
+        given: {
+          type: "array",
+          items: false,
+          prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
+        },
+        want: `[
+    number,
+    number,
+    number
+]`,
       },
     ],
     [
@@ -47,7 +60,23 @@ describe("transformSchemaObject > array", () => {
     number,
     number
 ]`,
-        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "options: experimentalArraySpreadMembers: true, tuple > prefixItems",
+      {
+        given: {
+          type: "array",
+          items: { type: "number" },
+          prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
+        },
+        options: { ...DEFAULT_OPTIONS, ctx: { ...DEFAULT_CTX, experimentalArraySpreadMembers: true } },
+        want: `[
+    number,
+    number,
+    number,
+    ...number[]
+]`,
       },
     ],
     [
@@ -58,7 +87,6 @@ describe("transformSchemaObject > array", () => {
           items: { $ref: "#/components/schemas/ArrayItem" },
         },
         want: `components["schemas"]["ArrayItem"][]`,
-        // options: DEFAULT_OPTIONS,
       },
     ],
     [
@@ -66,7 +94,6 @@ describe("transformSchemaObject > array", () => {
       {
         given: { type: ["array", "null"], items: { type: "string" } },
         want: "string[] | null",
-        // options: DEFAULT_OPTIONS,
       },
     ],
     [
@@ -74,7 +101,6 @@ describe("transformSchemaObject > array", () => {
       {
         given: { type: "array", items: { type: "string" }, nullable: true },
         want: "string[] | null",
-        // options: DEFAULT_OPTIONS,
       },
     ],
     [
@@ -82,7 +108,6 @@ describe("transformSchemaObject > array", () => {
       {
         given: { type: "array", items: { type: ["string", "null"] } },
         want: "(string | null)[]",
-        // options: DEFAULT_OPTIONS,
       },
     ],
     [
@@ -90,7 +115,38 @@ describe("transformSchemaObject > array", () => {
       {
         given: { type: "array", items: { type: "string", nullable: true } },
         want: "(string | null)[]",
-        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "array > heterogeneous items",
+      {
+        given: {
+          type: "array",
+          items: { anyOf: [{ type: "number" }, { type: "string" }] },
+        },
+        want: "(number | string)[]",
+      },
+    ],
+    [
+      "options > arrayLength: false > minItems: 0",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 0 },
+        want: "string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: false },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: false > minItems: 1",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 1 },
+        want: "string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: false },
+        },
       },
     ],
     [
@@ -105,6 +161,28 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: true > minItems: 0",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 0 },
+        want: "string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > minItems: 0",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 0 },
+        want: "readonly string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
       "options > arrayLength: true > minItems: 1",
       {
         given: { type: "array", items: { type: "string" }, minItems: 1 },
@@ -115,6 +193,50 @@ describe("transformSchemaObject > array", () => {
         options: {
           ...DEFAULT_OPTIONS,
           ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > minItems: 1",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 1 },
+        want: `readonly [
+    string,
+    ...readonly string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > minItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 2 },
+        want: `[
+    string,
+    string,
+    ...string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > minItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 2 },
+        want: `readonly [
+    string,
+    string,
+    ...readonly string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
         },
       },
     ],
@@ -136,6 +258,55 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: true, immutable: true > maxItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, maxItems: 2 },
+        want: `readonly [
+] | readonly [
+    string
+] | readonly [
+    string,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > minItems: 1, maxItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 2 },
+        want: `[
+    string
+] | [
+    string,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > minItems: 1, maxItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 2 },
+        want: `readonly [
+    string
+] | readonly [
+    string,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
       "options > arrayLength: true > maxItems: 20",
       {
         given: { type: "array", items: { type: "string" }, maxItems: 20 },
@@ -143,6 +314,17 @@ describe("transformSchemaObject > array", () => {
         options: {
           ...DEFAULT_OPTIONS,
           ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > maxItems: 20",
+      {
+        given: { type: "array", items: { type: "string" }, maxItems: 20 },
+        want: "readonly string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
         },
       },
     ],
@@ -158,6 +340,254 @@ describe("transformSchemaObject > array", () => {
           ...DEFAULT_OPTIONS,
           ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
         },
+      },
+    ],
+    [
+      "options > arrayLength: true > prefixItems, minItems: 2, maxItems: 2",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+          ],
+          minItems: 2,
+          maxItems: 2,
+        },
+        want: `[
+    "calcium",
+    "magnesium"
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > no items, prefixItems, minItems: 2, maxItems: 3",
+      {
+        given: {
+          type: "array",
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+          ],
+          minItems: 2,
+          maxItems: 3,
+        },
+        want: `[
+    "calcium",
+    "magnesium"
+] | [
+    "calcium",
+    "magnesium",
+    unknown
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > no items, prefixItems, minItems: 3",
+      {
+        given: {
+          type: "array",
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+          ],
+          minItems: 3,
+        },
+        want: `[
+    "calcium",
+    "magnesium",
+    unknown
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, experimentalArraySpreadMembers: true > no items, prefixItems, minItems: 3",
+      {
+        given: {
+          type: "array",
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+          ],
+          minItems: 3,
+        },
+        want: `[
+    "calcium",
+    "magnesium",
+    unknown,
+    ...unknown[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, experimentalArraySpreadMembers: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > no items, prefixItems, minItems: 2, maxItems: 5",
+      {
+        given: {
+          type: "array",
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+            { type: "string", enum: ["tungsten"] },
+          ],
+          minItems: 2,
+          maxItems: 5,
+        },
+        want: `[
+    "calcium",
+    "magnesium"
+] | [
+    "calcium",
+    "magnesium",
+    "tungsten"
+] | [
+    "calcium",
+    "magnesium",
+    "tungsten",
+    unknown
+] | [
+    "calcium",
+    "magnesium",
+    "tungsten",
+    unknown,
+    unknown
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > prefixItems, minItems: 3",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          minItems: 3,
+        },
+        want: `readonly [
+    string,
+    number,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, experimentalArraySpreadMembers: true, immutable: true > prefixItems, minItems: 3",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          minItems: 3,
+        },
+        want: `readonly [
+    string,
+    number,
+    string,
+    ...readonly string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true, experimentalArraySpreadMembers: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > prefixItems, minItems: 3, maxItems: 3",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          minItems: 3,
+          maxItems: 3,
+        },
+        want: `readonly [
+    string,
+    number,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: false, immutable: true > prefixItems, minItems: 3, maxItems: 5",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          minItems: 3,
+          maxItems: 5,
+        },
+        want: `readonly [
+    string,
+    number
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: false, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: false, experimentalArraySpreadMembers: true, immutable: true > prefixItems, minItems: 3, maxItems: 5",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          minItems: 3,
+          maxItems: 5,
+        },
+        want: `readonly [
+    string,
+    number,
+    ...readonly string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: false, experimentalArraySpreadMembers: true, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: false > prefixItems, items: false",
+      {
+        given: {
+          type: "array",
+          items: false,
+          prefixItems: [{ type: "string", enum: ["professor"] }],
+        },
+        want: `[
+    "professor"
+]`,
       },
     ],
     [
@@ -190,6 +620,26 @@ describe("transformSchemaObject > array", () => {
         options: {
           ...DEFAULT_OPTIONS,
           ctx: { ...DEFAULT_OPTIONS.ctx, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > experimentalArraySpreadMembers: true, immutable: true (tuple)",
+      {
+        given: {
+          type: "array",
+          items: { type: "number" },
+          prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
+        },
+        want: `readonly [
+    number,
+    number,
+    number,
+    ...readonly number[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, experimentalArraySpreadMembers: true, immutable: true },
         },
       },
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
         specifier: ^21.1.1
         version: 21.1.1
     devDependencies:
+      '@total-typescript/ts-reset':
+        specifier: ^0.6.1
+        version: 0.6.1
       '@types/degit':
         specifier: ^2.8.6
         version: 2.8.6
@@ -1742,6 +1745,9 @@ packages:
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+
+  '@total-typescript/ts-reset@0.6.1':
+    resolution: {integrity: sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -6489,6 +6495,8 @@ snapshots:
 
   '@tootallnate/once@2.0.0':
     optional: true
+
+  '@total-typescript/ts-reset@0.6.1': {}
 
   '@trysound/sax@0.2.0': {}
 


### PR DESCRIPTION
## 🗣️ Discussion

This PR is an extraction of some work that has already landed in the 8.x branch. This is my first step in porting those changes to the 7.x branch.

Closes #2048

## Changes

* Simplify `minItems` / `maxItems` tuple generation
* Introduces [@total-typescript](https://www.totaltypescript.com/ts-reset) to accommodate `Array.prototype.filter(Boolean)` pattern
* Extract subroutine for transforming array schema objects
* Support `items: false; prefixItems: …` schemas; treat `prefixItems` as explicit tuple value.
* Support `items: […schemas]`, treating `items` as explicit tuple value.

## How to Review

* [ ] Ensure changes to newly-generated types are valid bug-fixes
* [ ] Ensure old behaviors are preserved where appropriate, to break fewer things when we release
* [ ] Ensure new behavior is gated behind `--experimental-array-spread-members` flag
* [ ] Ensure ts-reset types don't affect published `openapi-ts` types
  * `ts-reset` behaviors should not be active in plain repo with `openapi-ts` dependency
  * Importing `openapi-ts` for programmatic use shouldn't start allowing `ts-reset` behaviors.
* [ ] Ensure `ts-reset` types don't affect generated types
  * Importing `openapi-typescript`-generated types shouldn't start allowing `ts-reset` behavior.

## 🔧 Backwards-compatibility

In order to get a sense for the backwards-compatibility of this PR I pulled the full suite of tests from `array.test.ts` and ran them in `main`. [Test output](https://gist.github.com/duncanbeevers/e706e8f5febaa64db6813da5b45190be)

Many test cases in this corpus cover behavior not-yet-tested in `main`, so this gives us a better sense of what will actually change.

Many of the new tests (expectedly) failed in this older context, and the errors fell into four categories.

1. New behavior gated behind the new `--experimental-array-spread-members` flag.
1. Mutable spread members for array schemas when `immutable: true` is set
1. Mutable tuples for array schemas with prefixItems when `immutable: true` is set
1. Broken tuples (original #2048 problem)

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
