### PR TITLE
Added explanation and link to Nuxt3 example.

### DIFF
--- a/docs/openapi-fetch/examples.md
+++ b/docs/openapi-fetch/examples.md
@@ -34,6 +34,12 @@ _Note: if you’re using Svelte without SvelteKit, the root example in `src/rout
 
 [View a code example in GitHub](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch/examples/vue-3)
 
+## Nuxt 3
+
+[Nuxt 3](https://nuxtjs.org/) is a popular SSR framework for Vue 3. By combining Nuxt's built-in [useAsyncData](https://nuxt.com/docs/api/composables/use-async-data) composable with openapi-fetch, you can easily implement type-safe API communication with server-side rendering.
+
+[View a code example in GitHub](https://github.com/HasutoSasaki/nuxt3-openapi-typescript-example)
+
 ---
 
 Additional examples are always welcome! Please [open a PR](https://github.com/openapi-ts/openapi-typescript/pulls) with your examples.


### PR DESCRIPTION
## Changes

Added explanation and link to Nuxt3 example.

This is a continuation of the PR work.
https://github.com/openapi-ts/openapi-typescript/pull/2331

## How to Review

Is the explanation added to docs appropriate?

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
