### PR TITLE
Renovate: automerge lock file updates and non-major devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:js-lib"
   ],
+  "automergeType": "branch",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
## Changes

Going forward, Renovate will automatically merge lock file updates and non-major dev dependency updates.

We use [branch automerge](https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging) to avoid noise.

## How to Review

Have a look here: https://docs.renovatebot.com/key-concepts/automerge/

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
