### PR TITLE
chore: Fix bad versioning

### DIFF
--- a/packages/openapi-react-query/CHANGELOG.md
+++ b/packages/openapi-react-query/CHANGELOG.md
@@ -1,6 +1,6 @@
 # openapi-react-query
 
-## 1.0.0
+## 0.5.1
 
 ### Patch Changes
 

--- a/packages/openapi-react-query/package.json
+++ b/packages/openapi-react-query/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-react-query",
   "description": "Fast, type-safe @tanstack/react-query client to work with your OpenAPI schema.",
-  "version": "1.0.0",
+  "version": "0.5.1",
   "author": {
     "name": "Martin Paucot",
     "email": "contact@martin-paucot.fr"

--- a/packages/swr-openapi/CHANGELOG.md
+++ b/packages/swr-openapi/CHANGELOG.md
@@ -1,6 +1,6 @@
 # swr-openapi
 
-## 6.0.0
+## 5.4.2
 
 ### Patch Changes
 

--- a/packages/swr-openapi/package.json
+++ b/packages/swr-openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swr-openapi",
   "description": "Generate SWR hooks from OpenAPI schemas",
-  "version": "6.0.0",
+  "version": "5.4.2",
   "author": {
     "name": "Hunter Tunnicliff",
     "email": "hunter@tunnicliff.co"


### PR DESCRIPTION
## Changes

`openapi-react-query` and `swr-openapi` were mistakenly published at a major version from a Changesets error. This fixes that.

## How to Review

N/A

## Checklist

N/A