### PR TITLE
fix(openapi-fetch): use text() when no content-length is provided to avoid errors parsing empty response (200 with no content)

### DIFF
--- a/.changeset/wet-waves-turn.md
+++ b/.changeset/wet-waves-turn.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Use text() when no content-length is provided to avoid errors parsing empty bodies (200 with no content)

--- a/packages/openapi-fetch/test/common/request.test.ts
+++ b/packages/openapi-fetch/test/common/request.test.ts
@@ -342,6 +342,7 @@ describe("request", () => {
         clone: () => ({ ...response }),
         headers: new Headers(),
         json: async () => data,
+        text: async () => JSON.stringify(data),
         status: 200,
         ok: true,
       } as Response;

--- a/packages/openapi-fetch/test/common/response.test.ts
+++ b/packages/openapi-fetch/test/common/response.test.ts
@@ -138,6 +138,18 @@ describe("response", () => {
   describe("parseAs", () => {
     const client = createObservedClient<paths>({}, async () => Response.json({}));
 
+    test("json with empty response", async () => {
+      const client = createObservedClient<paths>({}, async () => new Response());
+      const { data, error } = (await client.GET("/empty-json", {
+        parseAs: "json",
+      })) satisfies { data?: undefined };
+      if (error) {
+        throw new Error("parseAs json: error");
+      }
+
+      expect(data).toBe(undefined);
+    });
+
     test("text", async () => {
       const { data, error } = (await client.GET("/resources", {
         parseAs: "text",

--- a/packages/openapi-fetch/test/common/schemas/common.d.ts
+++ b/packages/openapi-fetch/test/common/schemas/common.d.ts
@@ -727,6 +727,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/empty-json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getEmptyJsonResponse"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -770,6 +786,32 @@ export interface operations {
                 };
             };
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getEmptyJsonResponse: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Empty JSON Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            default: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/openapi-fetch/test/common/schemas/common.yaml
+++ b/packages/openapi-fetch/test/common/schemas/common.yaml
@@ -421,6 +421,17 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /empty-json:
+    get:
+      operationId: getEmptyJsonResponse
+      responses:
+        200:
+          description: Empty JSON Response
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     Error:


### PR DESCRIPTION
## Changes

Fixes an issue where responses with HTTP 200 status and no `Content-Length` header would fail when parsing JSON, even when the response body is empty.

**Problem**: When a server returns a successful response (200 OK) without a `Content-Length` header and an empty body, calling `response.json()` directly throws an error because there's no content to parse. This is a valid HTTP scenario but was causing runtime errors.

**Solution**: Added a check for missing `Content-Length` headers when `parseAs: "json"`. The fix:
1. First reads the response as text using `response.text()`
2. Then conditionally parses it as JSON only if content exists
3. Returns `undefined` if the response is empty

## How to Review

1. **Review the logic**: Check the added condition in `index.js` around line 245 that handles the case when `parseAs === "json" && !contentLength`
2. **Run the test**: The new test `"json with empty response"` in `response.test.ts` verifies the fix works correctly
3. **Verify no regressions**: All existing tests should pass, confirming backward compatibility
4. **Consider edge cases**: The fix only applies when:
   - Response is successful (2** except 204)
   - `parseAs` is set to `"json"` (default)
   - `Content-Length` header is absent (not just `"0"`)

Key review points:
- Empty responses now return `{ data: undefined }` instead of throwing an error
- Responses with `Content-Length: "<any>"` are still handled by the existing logic
- The fix doesn't affect error responses or other `parseAs` options

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary) - No docs changes needed, internal bug fix
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript) - N/A, this is openapi-fetch
