### PR TITLE
feat: make able to provide fetch method in swr hook

### DIFF
--- a/packages/swr-openapi/src/query-base.ts
+++ b/packages/swr-openapi/src/query-base.ts
@@ -1,11 +1,11 @@
 import type { Client } from "openapi-fetch";
-import type { MediaType, PathsWithMethod, RequiredKeysOf } from "openapi-typescript-helpers";
+import type {HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf} from "openapi-typescript-helpers";
 import { useCallback, useDebugValue, useMemo } from "react";
 import type { Fetcher, SWRHook } from "swr";
 import type { Exact } from "type-fest";
 import type { TypesForRequest } from "./types.js";
 
-type HttpMethod = "get" | "post" | "put";
+export type DataHttpMethod = Extract<HttpMethod, "get" | "post" | "put">;
 
 /**
  * @private
@@ -24,7 +24,7 @@ export function configureBaseQueryHook(useHook: SWRHook) {
       Data extends R["Data"],
       Error extends R["Error"] | FetcherError,
       Config extends R["SWRConfig"],
-      M extends HttpMethod = "get",
+      M extends DataHttpMethod = "get",
     >(
       path: Path,
       ...[init, config]: RequiredKeysOf<Init> extends never


### PR DESCRIPTION
## Changes

Make able to utilize `useQuery` with non-GET endpoints

### Related

- [How to useQuery with non-GET endpoints? #2104](https://github.com/openapi-ts/openapi-typescript/issues/2104)

## How to Review

- Check types
- Unit testing passing

## Checklist _(will be added)_

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
