### PR TITLE
fix(openapi-react-query): mutation results type

### DIFF
--- a/.changeset/lazy-bobcats-hear.md
+++ b/.changeset/lazy-bobcats-hear.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": patch
+---
+
+fixes mutation results type

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -156,13 +156,16 @@ export type UseMutationMethod<Paths extends Record<string, Record<HttpMethod, {}
   Path extends PathsWithMethod<Paths, Method>,
   Init extends MaybeOptionalInit<Paths[Path], Method>,
   Response extends Required<FetchResponse<Paths[Path][Method], Init, Media>>, // note: Required is used to avoid repeating NonNullable in UseQuery types
-  Options extends Omit<UseMutationOptions<Response["data"], Response["error"], Init>, "mutationKey" | "mutationFn">,
+  TOnMutateResult = unknown,
 >(
   method: Method,
   url: Path,
-  options?: Options,
+  options?: Omit<
+    UseMutationOptions<Response["data"], Response["error"], Init, TOnMutateResult>,
+    "mutationKey" | "mutationFn"
+  >,
   queryClient?: QueryClient,
-) => UseMutationResult<Response["data"], Response["error"], Init>;
+) => UseMutationResult<Response["data"], Response["error"], Init, TOnMutateResult>;
 
 export interface OpenapiQueryClient<Paths extends {}, Media extends MediaType = MediaType> {
   queryOptions: QueryOptionsFunction<Paths, Media>;

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -792,6 +792,30 @@ describe("client", () => {
 
         await waitFor(() => rendered.findByText("data: Hello, status: success"));
       });
+
+      it("should type mutate results properly", async () => {
+        const fetchClient = createFetchClient<paths>({ baseUrl });
+        const client = createClient(fetchClient);
+
+        const onMutateReturnValue = { someArray: [1, 2, 3], someString: "abc" };
+        type expectedOnMutateResultType = typeof onMutateReturnValue | undefined;
+
+        const result = renderHook(
+          () =>
+            client.useMutation("put", "/comment", {
+              onMutate: () => onMutateReturnValue,
+              onError: (err, _, onMutateResult, context) => {
+                assertType<expectedOnMutateResultType>(onMutateResult);
+              },
+              onSettled: (_data, _error, _variables, onMutateResult, context) => {
+                assertType<expectedOnMutateResultType>(onMutateResult);
+              },
+            }),
+          { wrapper },
+        );
+
+        assertType<expectedOnMutateResultType>(result.result.current.context);
+      });
     });
 
     describe("mutateAsync", () => {


### PR DESCRIPTION
## Changes

Adds proper types to the useMutation's onMutateResults fields which are used in `onSettled`, `onError` & return object of this hook.

The open issue regarding this bug: https://github.com/openapi-ts/openapi-typescript/issues/2518

I ended up digging further & this seems to fix it, but looking forward for a second pair of eyes to check that my fix is correct 🙂 

Here I moved the `Options` type definition from the generic parameters to the actual `options` parameter themselves, thus not setting the `UseMutationOptions`'s `TOnMutateResult` to the default `unknown`.

## How to Review



## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
