### PR TITLE
Keep DTO as suffix when creating pascalCase

### DIFF
--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -101,7 +101,7 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
 
           if (!shouldSkipEnumSchema) {
             const componentKey = changeCase.pascalCase(singularizeComponentKey(key));
-            let aliasName = `${componentKey}${changeCase.pascalCase(name)}`;
+            let aliasName = `${componentKey}${changeCase.pascalCase(name, { suffixCharacters: "DTO" })}`;
 
             // Add counter suffix (e.g. "_2") if conflict in name
             let conflictCounter = 1;

--- a/packages/openapi-typescript/test/transform/components-object.test.ts
+++ b/packages/openapi-typescript/test/transform/components-object.test.ts
@@ -757,7 +757,48 @@ export type Item = components['schemas']['Item'];
 export type Document = components['schemas']['Document'];
 export type Error = components['schemas']['Error'];
 `,
-        options: { ...DEFAULT_OPTIONS, rootTypes: true, rootTypesNoSchemaPrefix: true },
+        options: {
+          ...DEFAULT_OPTIONS,
+          rootTypes: true,
+          rootTypesNoSchemaPrefix: true,
+        },
+      },
+    ],
+    [
+      "options > rootTypes: true but keep DTO",
+      {
+        given: {
+          schemas: {
+            ItemDTO: {
+              type: "object",
+              required: ["name", "url"],
+              properties: {
+                name: { type: "string" },
+                url: { type: "string" },
+              },
+            },
+          },
+        },
+        want: `{
+    schemas: {
+        ItemDTO: {
+            name: string;
+            url: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type ItemDTO = components['schemas']['ItemDTO'];
+`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          rootTypes: true,
+          rootTypesNoSchemaPrefix: true,
+        },
       },
     ],
     [


### PR DESCRIPTION
## Changes

Keeps the DTO suffix when exporting root types: https://github.com/openapi-ts/openapi-typescript/issues/2402

## How to Review

Quite possibly a bit too simple solution, but covers the issue (and my usecase).

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
