### PR TITLE
fix(tests): updated redocly openapi schema location

### DIFF
--- a/packages/openapi-typescript/examples/simple-example.ts
+++ b/packages/openapi-typescript/examples/simple-example.ts
@@ -112,7 +112,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Checks if unevaluetedProperties work */
+        /** Checks if unevaluatedProperties work */
         get: operations["getUnevaluatedProperties"];
         put?: never;
         post?: never;

--- a/packages/openapi-typescript/examples/simple-example.yaml
+++ b/packages/openapi-typescript/examples/simple-example.yaml
@@ -109,7 +109,7 @@ paths:
   /unevaluated-properties:
     get:
       operationId: getUnevaluatedProperties
-      summary: Checks if unevaluetedProperties work
+      summary: Checks if unevaluatedProperties work
       responses:
         200:
           description: 'OK'

--- a/packages/openapi-typescript/test/fixtures/redocly-flag/openapi/a.yaml
+++ b/packages/openapi-typescript/test/fixtures/redocly-flag/openapi/a.yaml
@@ -109,7 +109,7 @@ paths:
   /unevaluated-properties:
     get:
       operationId: getUnevaluatedProperties
-      summary: Checks if unevaluetedProperties work
+      summary: Checks if unevaluatedProperties work
       responses:
         200:
           description: 'OK'

--- a/packages/openapi-typescript/test/fixtures/redocly-flag/openapi/b.yaml
+++ b/packages/openapi-typescript/test/fixtures/redocly-flag/openapi/b.yaml
@@ -109,7 +109,7 @@ paths:
   /unevaluated-properties:
     get:
       operationId: getUnevaluatedProperties
-      summary: Checks if unevaluetedProperties work
+      summary: Checks if unevaluatedProperties work
       responses:
         200:
           description: 'OK'

--- a/packages/openapi-typescript/test/fixtures/redocly-flag/openapi/c.yaml
+++ b/packages/openapi-typescript/test/fixtures/redocly-flag/openapi/c.yaml
@@ -109,7 +109,7 @@ paths:
   /unevaluated-properties:
     get:
       operationId: getUnevaluatedProperties
-      summary: Checks if unevaluetedProperties work
+      summary: Checks if unevaluatedProperties work
       responses:
         200:
           description: 'OK'

--- a/packages/openapi-typescript/test/fixtures/redocly/openapi/a.yaml
+++ b/packages/openapi-typescript/test/fixtures/redocly/openapi/a.yaml
@@ -109,7 +109,7 @@ paths:
   /unevaluated-properties:
     get:
       operationId: getUnevaluatedProperties
-      summary: Checks if unevaluetedProperties work
+      summary: Checks if unevaluatedProperties work
       responses:
         200:
           description: 'OK'

--- a/packages/openapi-typescript/test/fixtures/redocly/openapi/b.yaml
+++ b/packages/openapi-typescript/test/fixtures/redocly/openapi/b.yaml
@@ -109,7 +109,7 @@ paths:
   /unevaluated-properties:
     get:
       operationId: getUnevaluatedProperties
-      summary: Checks if unevaluetedProperties work
+      summary: Checks if unevaluatedProperties work
       responses:
         200:
           description: 'OK'

--- a/packages/openapi-typescript/test/fixtures/redocly/openapi/c.yaml
+++ b/packages/openapi-typescript/test/fixtures/redocly/openapi/c.yaml
@@ -109,7 +109,7 @@ paths:
   /unevaluated-properties:
     get:
       operationId: getUnevaluatedProperties
-      summary: Checks if unevaluetedProperties work
+      summary: Checks if unevaluatedProperties work
       responses:
         200:
           description: 'OK'

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -58,7 +58,8 @@ export type operations = Record<string, never>;`,
     [
       "input > string > URL",
       {
-        given: "https://raw.githubusercontent.com/Redocly/redocly-cli/main/__tests__/lint/oas3.1/openapi.yaml",
+        given:
+          "https://raw.githubusercontent.com/Redocly/redocly-cli/13e753a4ca008293dab212ad3b70109166bf93c5/__tests__/lint/oas3.1/openapi.yaml",
         want: new URL("simple-example.ts", EXAMPLES_DIR),
         // options: DEFAULT_OPTIONS,
       },
@@ -66,7 +67,9 @@ export type operations = Record<string, never>;`,
     [
       "input > URL > remote",
       {
-        given: new URL("https://raw.githubusercontent.com/Redocly/redocly-cli/main/__tests__/lint/oas3.1/openapi.yaml"),
+        given: new URL(
+          "https://raw.githubusercontent.com/Redocly/redocly-cli/13e753a4ca008293dab212ad3b70109166bf93c5/__tests__/lint/oas3.1/openapi.yaml",
+        ),
         want: new URL("simple-example.ts", EXAMPLES_DIR),
         // options: DEFAULT_OPTIONS,
       },


### PR DESCRIPTION
## Changes

Fixes the location of the redocly openapi schema used in tests.

Redocly recently refactored their test folder structure in [chore: refactor tests](https://github.com/Redocly/redocly-cli/commit/cf26d6038e7c75af3335164f4797133393ac84d3) and the openapi schema now lives [here](https://raw.githubusercontent.com/Redocly/redocly-cli/refs/heads/main/tests/e2e/lint/oas3.1/openapi.yaml)
I changed the url used in the tests to refer to the specific commit of the file, so these kind of test failures will not happen again even if they do further folder structure refactors.

Additionally they fixed some typos in [this commit](https://github.com/Redocly/redocly-cli/commit/13e753a4ca008293dab212ad3b70109166bf93c5), which led me to fix a few test files which depended on the typo

In general I think it would be better to avoid depending on an external resource in tests (thus not using a schema in Redocly but rather one defined in this very repository)
The problem is that somehow setting up schema in this repository which could be used equally in local tests & in github actions seemed a little out-of-scope for this fix, but perhaps this could be an improvement to think of for the future, although hopefully Redocly doesn't refactor their test suite very frequently 😉 

## How to Review

Checking that tests now pass (as opposed to PRs made in the last ~week)

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
