### PR TITLE
feat(openapi-fetch): enable middleware request param module augmentation

### DIFF
--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -131,18 +131,20 @@ export type MergedOptions<T = unknown> = {
   fetch: typeof globalThis.fetch;
 };
 
+export interface MiddlewareRequestParams {
+  query?: Record<string, unknown>;
+  header?: Record<string, unknown>;
+  path?: Record<string, unknown>;
+  cookie?: Record<string, unknown>;
+}
+
 export interface MiddlewareCallbackParams {
   /** Current Request object */
   request: Request;
   /** The original OpenAPI schema path (including curly braces) */
   readonly schemaPath: string;
   /** OpenAPI parameters as provided from openapi-fetch */
-  readonly params: {
-    query?: Record<string, unknown>;
-    header?: Record<string, unknown>;
-    path?: Record<string, unknown>;
-    cookie?: Record<string, unknown>;
-  };
+  readonly params: MiddlewareRequestParams;
   /** Unique ID for this request */
   readonly id: string;
   /** createClient options (read-only) */


### PR DESCRIPTION
## Changes

Decided to open PR in lieu of issue.

I just changed the `.d.ts` file manually and extracted the `MiddlewareRequestParams` into their own interface. It opens up the possibility for using TS module augmentation to add parameters to the `params` property and use those in the middleware. 

My use-case is changing authentication logic based on a variable that isn't passed through to the API being invoked.

## How to Review

Look at the file, I guess? 🤗

Also, I would be open to going deeper in a follow-up PR to look into how the client facing types could mirror the custom parameter added, if this is indeed an avenue you're open to exploring.

## Checklist
(skipped all since it's just a small TS update and I didn't pull to local)
- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
