### PR TITLE
fix: typo in swr docs code comment

### DIFF
--- a/docs/swr-openapi/index.md
+++ b/docs/swr-openapi/index.md
@@ -100,7 +100,7 @@ export const useInfinite = createInfiniteHook(client, prefix);
 export const useMutate = createMutateHook(
   client,
   prefix,
-  isMatch, // Or any comparision function
+  isMatch, // Or any comparison function
 );
 ```
 :::


### PR DESCRIPTION
## Changes

Fix a typo in the docs for openapi swr

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
