### PR TITLE
feat: expose built-in loaders

### DIFF
--- a/.changeset/floppy-shrimps-knock.md
+++ b/.changeset/floppy-shrimps-knock.md
@@ -1,0 +1,5 @@
+---
+"openapi-metadata": minor
+---
+
+Expose built-in loaders and `loadType` itself.

--- a/packages/openapi-metadata/build.config.ts
+++ b/packages/openapi-metadata/build.config.ts
@@ -4,6 +4,7 @@ export default defineBuildConfig({
   entries: [
     "./src/index.ts",
     "./src/decorators/index.ts",
+    "./src/loaders/index.ts",
     "./src/metadata/index.ts",
     "./src/errors/index.ts",
     "./src/ui/index.ts",

--- a/packages/openapi-metadata/package.json
+++ b/packages/openapi-metadata/package.json
@@ -18,6 +18,10 @@
       "import": "./dist/decorators/index.mjs",
       "require": "./dist/decorators/index.cjs"
     },
+    "./loaders": {
+      "import": "./dist/loaders/index.mjs",
+      "require": "./dist/loaders/index.cjs"
+    },
     "./metadata": {
       "import": "./dist/metadata/index.mjs",
       "require": "./dist/metadata/index.cjs"

--- a/packages/openapi-metadata/src/loaders/index.ts
+++ b/packages/openapi-metadata/src/loaders/index.ts
@@ -1,0 +1,1 @@
+export * from "./type.js";


### PR DESCRIPTION
## Changes

This PR exposes the built-in package loaders, and the `loadType` helper itself.
This enables composability for custom types. For instance, by copying `ClassTypeLoader` into my code, I was able to make a custom decorator to generate different `oneOf` for http exceptions, with automatic inference of `title` and `description`.

## How to Review

Determine if exposing `loadType` could be problematic if you ever need to refactor its API. 

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
