### PR TITLE
config(renovate): switch to automergeType: branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "renovate/**"
   pull_request:
 
 concurrency:

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:js-lib"
   ],
+  "automergeType": "branch",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
To do this, we enable push builds on the `renovate/**` branches in Github actions.

## Changes

Renovate will not open PRs for updates that are marked as automerge unless they have a CI failure.

## How to Review

Renovate docs: https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging
GH actions docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-branches

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
