### PR TITLE
docs: Change "`functionKey`" to query key

### DIFF
--- a/docs/openapi-react-query/use-query.md
+++ b/docs/openapi-react-query/use-query.md
@@ -8,7 +8,7 @@ The `useQuery` method allows you to use the original [useQuery](https://tanstack
 - The result is the same as the original function.
 - The query key is `[method, path, params]`.
 - `data` and `error` are fully typed.
-- You can pass queries options as fourth parameter.
+- You can pass query options as fourth parameter.
 
 ::: tip
 You can find more information about `useQuery` on the [@tanstack/react-query documentation](https://tanstack.com/query/latest/docs/framework/react/guides/queries).


### PR DESCRIPTION
## Changes

The docs for `useQuery` say "`functionKey`" - this is not a term anywhere in TanStack Query.
Changed to "query key" to be consistent with the original library.

Additionally, fixed a minor typo.