### PR TITLE
feat: allow CLI flags in Redocly config

### DIFF
--- a/.changeset/yellow-meteors-rush.md
+++ b/.changeset/yellow-meteors-rush.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Add ability to set flags in redocly.yaml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,6 +41,7 @@ apis:
     root: ./openapi/external.yaml
     x-openapi-ts:
       output: ./openapi/external.ts
+      additional-properties: true # CLI flags are also supported, either in kebab-case or camelCase format
 ```
 
 :::

--- a/packages/openapi-fetch/test/redocly.yaml
+++ b/packages/openapi-fetch/test/redocly.yaml
@@ -53,3 +53,8 @@ apis:
     root: ../../openapi-typescript/examples/stripe-api.yaml
     x-openapi-ts:
       output: ./examples/schemas/stripe.d.ts
+  read-write-visibility:
+    root: ./read-write-visibility/schemas/read-write.yaml
+    x-openapi-ts:
+      output: ./read-write-visibility/schemas/read-write.d.ts
+      read-write-markers: true

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { createConfig, findConfig, loadConfig } from "@redocly/openapi-core";
+import { kebabCase } from "scule";
 import parser from "yargs-parser";
 import openapiTS, { astToString, COMMENT_HEADER, c, error, formatTime, warn } from "../dist/index.mjs";
 
@@ -31,8 +32,8 @@ Options
   --path-params-as-types     Convert paths to template literal types
   --alphabetize              Sort object keys alphabetically
   --exclude-deprecated       Exclude deprecated types
-  --root-types (optional)    Export schemas types at root level
-  --root-types-no-schema-prefix (optional)
+  --root-types               Export schemas types at root level
+  --root-types-no-schema-prefix
                              Do not add "Schema" prefix to types at the root level (should only be used with --root-types)
   --root-types-keep-casing   Keep casing of root types (should only be used with --root-types)
   --make-paths-enum          Generate ApiPaths enum for all paths
@@ -71,32 +72,34 @@ if (args.includes("--root-types-keep-casing") && !args.includes("--root-types"))
   console.warn("--root-types-keep-casing has no effect without --root-types flag");
 }
 
+const BOOLEAN_FLAGS = [
+  "additionalProperties",
+  "alphabetize",
+  "arrayLength",
+  "check",
+  "conditionalEnums",
+  "contentNever",
+  "dedupeEnums",
+  "defaultNonNullable",
+  "emptyObjectsUnknown",
+  "enum",
+  "enumValues",
+  "excludeDeprecated",
+  "exportType",
+  "generatePathParams",
+  "help",
+  "immutable",
+  "makePathsEnum",
+  "pathParamsAsTypes",
+  "propertiesRequiredByDefault",
+  "readWriteMarkers",
+  "rootTypes",
+  "rootTypesKeepCasing",
+  "rootTypesNoSchemaPrefix",
+];
+
 const flags = parser(args, {
-  boolean: [
-    "additionalProperties",
-    "alphabetize",
-    "arrayLength",
-    "contentNever",
-    "defaultNonNullable",
-    "propertiesRequiredByDefault",
-    "emptyObjectsUnknown",
-    "enum",
-    "enumValues",
-    "conditionalEnums",
-    "dedupeEnums",
-    "check",
-    "excludeDeprecated",
-    "exportType",
-    "help",
-    "immutable",
-    "pathParamsAsTypes",
-    "rootTypes",
-    "rootTypesNoSchemaPrefix",
-    "rootTypesKeepCasing",
-    "makePathsEnum",
-    "generatePathParams",
-    "readWriteMarkers",
-  ],
+  boolean: BOOLEAN_FLAGS,
   string: ["output", "redocly"],
   alias: {
     redocly: ["c"],
@@ -136,36 +139,10 @@ function checkStaleOutput(current, outputPath) {
 
 /**
  * @param {string | URL} schema
- * @param {@type import('@redocly/openapi-core').Config} redocly
+ * @param {@type import('@redocly/openapi-core').Config} config
  */
-async function generateSchema(schema, { redocly, silent = false }) {
-  return `${COMMENT_HEADER}${astToString(
-    await openapiTS(schema, {
-      additionalProperties: flags.additionalProperties,
-      alphabetize: flags.alphabetize,
-      arrayLength: flags.arrayLength,
-      contentNever: flags.contentNever,
-      propertiesRequiredByDefault: flags.propertiesRequiredByDefault,
-      defaultNonNullable: flags.defaultNonNullable,
-      emptyObjectsUnknown: flags.emptyObjectsUnknown,
-      enum: flags.enum,
-      enumValues: flags.enumValues,
-      conditionalEnums: flags.conditionalEnums,
-      dedupeEnums: flags.dedupeEnums,
-      excludeDeprecated: flags.excludeDeprecated,
-      exportType: flags.exportType,
-      immutable: flags.immutable,
-      pathParamsAsTypes: flags.pathParamsAsTypes,
-      rootTypes: flags.rootTypes,
-      rootTypesNoSchemaPrefix: flags.rootTypesNoSchemaPrefix,
-      rootTypesKeepCasing: flags.rootTypesKeepCasing,
-      makePathsEnum: flags.makePathsEnum,
-      generatePathParams: flags.generatePathParams,
-      readWriteMarkers: flags.readWriteMarkers,
-      redocly,
-      silent,
-    }),
-  )}`;
+async function generateSchema(schema, config) {
+  return `${COMMENT_HEADER}${astToString(await openapiTS(schema, config))}`;
 }
 
 /** pretty-format error message but also throw */
@@ -230,6 +207,8 @@ async function main() {
     await Promise.all(
       Object.entries(redocly.apis).map(async ([name, api]) => {
         let configRoot = CWD;
+
+        const config = { ...flags, redocly };
         if (redocly.configFile) {
           // note: this will be absolute if --redoc is passed; otherwise, relative
           configRoot = path.isAbsolute(redocly.configFile)
@@ -241,7 +220,18 @@ async function main() {
             `API ${name} is missing an \`${REDOC_CONFIG_KEY}.output\` key. See https://openapi-ts.dev/cli/#multiple-schemas.`,
           );
         }
-        const result = await generateSchema(new URL(api.root, configRoot), { redocly });
+
+        if (api[REDOC_CONFIG_KEY]) {
+          for (const name of BOOLEAN_FLAGS) {
+            if (typeof api[REDOC_CONFIG_KEY][name] === "boolean") {
+              config[name] = api[REDOC_CONFIG_KEY][name];
+            } else if (typeof api[REDOC_CONFIG_KEY][kebabCase(name)] === "boolean") {
+              config[name] = api[REDOC_CONFIG_KEY][kebabCase(name)];
+            }
+          }
+        }
+        const result = await generateSchema(new URL(api.root, configRoot), config);
+
         const outFile = new URL(api[REDOC_CONFIG_KEY].output, configRoot);
         checkStaleOutput(result, outFile);
         fs.mkdirSync(new URL(".", outFile), { recursive: true });
@@ -254,6 +244,7 @@ async function main() {
   // handle stdin
   else if (!input) {
     const result = await generateSchema(process.stdin, {
+      ...flags,
       redocly,
       silent: outputType === OUTPUT_STDOUT,
     });
@@ -278,6 +269,7 @@ async function main() {
       );
     }
     const result = await generateSchema(new URL(input, CWD), {
+      ...flags,
       redocly,
       silent: outputType === OUTPUT_STDOUT,
     });

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -66,6 +66,7 @@
     "ansi-colors": "^4.1.3",
     "change-case": "^5.4.4",
     "parse-json": "^8.3.0",
+    "scule": "^1.3.0",
     "supports-color": "^10.2.2",
     "yargs-parser": "^21.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       parse-json:
         specifier: ^8.3.0
         version: 8.3.0
+      scule:
+        specifier: ^1.3.0
+        version: 1.3.0
       supports-color:
         specifier: ^10.2.2
         version: 10.2.2


### PR DESCRIPTION
## Changes

Allow declaration of CLI flags in `redocly.yaml`. 

In addition to being useful for most folks, this also patches a hole in our test setup where some schemas need to be generated with certain flags to work (#2615). We had a false positive where the test would always pass because the schema would never regenerate. This is our fault—a contributor wouldn’t have known to update this, and it got missed in review.



## How to Review

- Tests should pass.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
