### PR TITLE
packages/openapi-react-query: Update createClient documentation

### DIFF
--- a/packages/openapi-react-query/README.md
+++ b/packages/openapi-react-query/README.md
@@ -29,6 +29,8 @@ npx openapi-typescript ./path/to/api/v1.yaml -o ./src/lib/api/v1.d.ts
 
 Once your types have been generated from your schema, you can create a [fetch client](../openapi-fetch), a react-query client and start querying your API.
 
+Note that the returned `OpenapiQueryClient` is not a react-query client, you still need to construct a `QueryClient` and pass it to `<QueryClientProvider queryClient={...}>`. The returned `OpenapiQueryClient` only provides type-inferred wrappers over the actual `useQuery` / `useMutation` / etc. hooks.
+
 ```tsx
 import createFetchClient from "openapi-fetch";
 import createClient from "openapi-react-query";


### PR DESCRIPTION
Update createClient documentation in openapi-react-query to point out incompatibility between `@tanstack/react-query`'s `QueryClient` and the generated `OpenapiQueryClient`. 

The current documentation assumes that the user has constructed a `QueryClient`  already, the updated documentation explicitly brings forward the same assumption

## Changes

Documentation-only

## How to Review

Documentation change, explicitly notes the QueryClient assumption made for openapi-react-query's generated OpenpiQueryClient

## Checklist

- [x] Unit tests updated **NOT REQUIRED**
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript) **NOT REQUIRED**
