### PR TITLE
fix(openapi-typescript): guard Readable/Writable against branded primitive types

### DIFF
--- a/packages/openapi-fetch/test/read-write-visibility/read-write.test.ts
+++ b/packages/openapi-fetch/test/read-write-visibility/read-write.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
 import { createObservedClient } from "../helpers.js";
-import type { paths } from "./schemas/read-write.js";
+import type { paths, Readable, Writable } from "./schemas/read-write.js";
 
 describe("readOnly/writeOnly", () => {
   describe("deeply nested $Read unwrapping through $Read<Object>", () => {
@@ -108,6 +108,39 @@ describe("readOnly/writeOnly", () => {
       // No error - name (normal) is available everywhere
       const name: string | undefined = data?.name;
       expect(name).toBe("Alice");
+    });
+  });
+
+  describe("branded primitive types", () => {
+    test("Readable preserves branded string in object property", () => {
+      type BrandedString = string & { __brand: "BrandedString" };
+      type Schema = { id: BrandedString; name: string };
+      // Without fix: Readable maps branded primitives through the object branch,
+      // expanding ALL string prototype methods and producing a type that is NOT
+      // assignable back to BrandedString. The assignment below would be a type error.
+      const result = {} as Readable<Schema>;
+      const _id: BrandedString = result.id;
+    });
+
+    test("Writable preserves branded string in object property", () => {
+      type BrandedString = string & { __brand: "BrandedString" };
+      type Schema = { id: BrandedString; name: string };
+      const result = {} as Writable<Schema>;
+      const _id: BrandedString = result.id;
+    });
+
+    test("Readable preserves branded number in object property", () => {
+      type UserId = number & { __brand: "UserId" };
+      type Schema = { id: UserId; name: string };
+      const result = {} as Readable<Schema>;
+      const _id: UserId = result.id;
+    });
+
+    test("Writable preserves branded number in object property", () => {
+      type UserId = number & { __brand: "UserId" };
+      type Schema = { id: UserId; name: string };
+      const result = {} as Writable<Schema>;
+      const _id: UserId = result.id;
     });
   });
 });

--- a/packages/openapi-fetch/test/read-write-visibility/schemas/read-write.d.ts
+++ b/packages/openapi-fetch/test/read-write-visibility/schemas/read-write.d.ts
@@ -9,10 +9,10 @@ export type $Read<T> = {
 export type $Write<T> = {
     readonly $write: T;
 };
-export type Readable<T> = T extends $Write<any> ? never : T extends $Read<infer U> ? Readable<U> : T extends (infer E)[] ? Readable<E>[] : T extends object ? {
+export type Readable<T> = T extends $Write<any> ? never : T extends $Read<infer U> ? Readable<U> : T extends (infer E)[] ? Readable<E>[] : T extends string | number | boolean | bigint | symbol ? T : T extends object ? {
     [K in keyof T as NonNullable<T[K]> extends $Write<any> ? never : K]: Readable<T[K]>;
 } : T;
-export type Writable<T> = T extends $Read<any> ? never : T extends $Write<infer U> ? Writable<U> : T extends (infer E)[] ? Writable<E>[] : T extends object ? {
+export type Writable<T> = T extends $Read<any> ? never : T extends $Write<infer U> ? Writable<U> : T extends (infer E)[] ? Writable<E>[] : T extends string | number | boolean | bigint | symbol ? T : T extends object ? {
     [K in keyof T as NonNullable<T[K]> extends $Read<any> ? never : K]: Writable<T[K]>;
 } & {
     [K in keyof T as NonNullable<T[K]> extends $Read<any> ? K : never]?: never;

--- a/packages/openapi-typescript-helpers/src/index.ts
+++ b/packages/openapi-typescript-helpers/src/index.ts
@@ -223,9 +223,11 @@ export type Readable<T> =
       ? Readable<U>
       : T extends (infer E)[]
         ? Readable<E>[]
-        : T extends object
-          ? { [K in keyof T as NonNullable<T[K]> extends $Write<any> ? never : K]: Readable<T[K]> }
-          : T;
+        : T extends string | number | boolean | bigint | symbol
+          ? T
+          : T extends object
+            ? { [K in keyof T as NonNullable<T[K]> extends $Write<any> ? never : K]: Readable<T[K]> }
+            : T;
 
 /**
  * Resolve type for writing (requests): strips $Read properties, unwraps $Write
@@ -240,8 +242,10 @@ export type Writable<T> =
       ? Writable<U>
       : T extends (infer E)[]
         ? Writable<E>[]
-        : T extends object
-          ? { [K in keyof T as NonNullable<T[K]> extends $Read<any> ? never : K]: Writable<T[K]> } & {
-              [K in keyof T as NonNullable<T[K]> extends $Read<any> ? K : never]?: never;
-            }
-          : T;
+        : T extends string | number | boolean | bigint | symbol
+          ? T
+          : T extends object
+            ? { [K in keyof T as NonNullable<T[K]> extends $Read<any> ? never : K]: Writable<T[K]> } & {
+                [K in keyof T as NonNullable<T[K]> extends $Read<any> ? K : never]?: never;
+              }
+            : T;

--- a/packages/openapi-typescript/src/transform/index.ts
+++ b/packages/openapi-typescript/src/transform/index.ts
@@ -22,8 +22,8 @@ const transformers: Record<SchemaTransforms, (node: any, options: GlobalContext)
 const READ_WRITE_HELPER_TYPES = `
 export type $Read<T> = { readonly $read: T };
 export type $Write<T> = { readonly $write: T };
-export type Readable<T> = T extends $Write<any> ? never : T extends $Read<infer U> ? Readable<U> : T extends (infer E)[] ? Readable<E>[] : T extends object ? { [K in keyof T as NonNullable<T[K]> extends $Write<any> ? never : K]: Readable<T[K]> } : T;
-export type Writable<T> = T extends $Read<any> ? never : T extends $Write<infer U> ? Writable<U> : T extends (infer E)[] ? Writable<E>[] : T extends object ? { [K in keyof T as NonNullable<T[K]> extends $Read<any> ? never : K]: Writable<T[K]> } & { [K in keyof T as NonNullable<T[K]> extends $Read<any> ? K : never]?: never } : T;
+export type Readable<T> = T extends $Write<any> ? never : T extends $Read<infer U> ? Readable<U> : T extends (infer E)[] ? Readable<E>[] : T extends string | number | boolean | bigint | symbol ? T : T extends object ? { [K in keyof T as NonNullable<T[K]> extends $Write<any> ? never : K]: Readable<T[K]> } : T;
+export type Writable<T> = T extends $Read<any> ? never : T extends $Write<infer U> ? Writable<U> : T extends (infer E)[] ? Writable<E>[] : T extends string | number | boolean | bigint | symbol ? T : T extends object ? { [K in keyof T as NonNullable<T[K]> extends $Read<any> ? never : K]: Writable<T[K]> } & { [K in keyof T as NonNullable<T[K]> extends $Read<any> ? K : never]?: never } : T;
 `;
 
 export default function transformSchema(schema: OpenAPI3, ctx: GlobalContext) {


### PR DESCRIPTION
Fixes #2765

`string & { __brand: "UserId" }` satisfies `T extends object`, so `Readable<T>` and `Writable<T>` were mapping over all primitive prototype methods instead of returning the type as-is.

Adds `T extends string | number | boolean | bigint | symbol ? T :` before the `extends object` branch in both types. Applied to `openapi-typescript-helpers/src/index.ts` and `READ_WRITE_HELPER_TYPES` in `src/transform/index.ts`.