### PR TITLE
feat(openapi-typescript): widen TypeScript peer dep to include v6

### DIFF
--- a/.changeset/widen-typescript-peer-dep.md
+++ b/.changeset/widen-typescript-peer-dep.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+feat(openapi-typescript): widen TypeScript peer dependency to include v6

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -59,7 +59,7 @@
     "version": "pnpm run build"
   },
   "peerDependencies": {
-    "typescript": "^5.x"
+    "typescript": "^5.x || ^6.x"
   },
   "dependencies": {
     "@redocly/openapi-core": "^1.34.6",


### PR DESCRIPTION
## Summary

TypeScript 6.0 was released on 2026-03-21. `openapi-typescript` works fine with TS6 — no code changes needed — but the peer dependency range `^5.x` prevents installation without `--legacy-peer-deps`.

This PR widens the peer dep to `^5.x || ^6.x` to support both major versions.

**Changes:**
- `packages/openapi-typescript/package.json`: `"typescript": "^5.x"` → `"typescript": "^5.x || ^6.x"`
- Added changeset for patch release

**Context:**
- Issue: #2723
- Related Renovate PR: #2711 (upgrades the entire monorepo's devDependency to TS6 — broader scope)
- This PR is intentionally minimal: only widens the peer dep range, doesn't upgrade the monorepo's own TS version

**Testing:**
Verified locally that `openapi-typescript@7.13.0` works correctly with TypeScript 6.0.2 — type generation produces identical output.

Closes #2723